### PR TITLE
fix(feedback-forms): validate and serialize iframe form id (successor)

### DIFF
--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -263,7 +263,7 @@ embeddable widget calls from the customer's own site.
 > | Route | Rate / burst | Why |
 > |---|---|---|
 > | `POST /submit` | **20 rps / 40** | Each submission enqueues a record that drives Comprehend, Translate and a Bedrock invocation in the processor — a per-request model call against a shared quota |
-> | `GET /config`, `GET /iframe` | **100 rps / 200** | Fetched on every page load of every embed; cheap (one `get_item`, and a static HTML render, respectively) |
+> | `GET /config`, `GET /iframe` | **100 rps / 200** | Fetched on every page load of every embed; cheap (one `get_item` each — `iframe` reads the same record to confirm the form exists (#379) — plus a static HTML render for `iframe`) |
 >
 > The method-setting keys spell the variable `{form_id}` — the resource is created
 > as `addResource('{form_id}')`, so that is the path to look for in the template,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,29 +158,49 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   Run to completion neither is misleading, which is why cost carries the choice above.
 
   What the scan does **not** need to find, so that its silence means what it says: an id containing
-  a literal tab or newline, or a non-ASCII **symbol, punctuation mark, combining accent or space** —
-  `€`, `—`, `°`, `«`, an emoji, or a non-ASCII space such as U+00A0 (NBSP) or U+3000. None of those
-  can occur in an id any route ever resolved, because the route's own capture group admits only
+  a literal tab or newline, or a non-ASCII character that `\w` does not match. None of those can
+  occur in an id any route ever resolved, because the route's own capture group admits only
   `[-._~()'!*:@,;=+&$%<> \[\]{}|^\w]`, and `\w` — the one member of that class that reaches beyond
-  ASCII — matches any Unicode **letter or number** and nothing else. Read that as the `L*` and `N*`
-  CATEGORIES rather than as "a letter or a digit", because the difference is exactly the shapes an
-  operator is most likely to misfile: a modifier letter (`hawaiʼi-form`, whose `ʼ` is U+02BC — how
-  an ʻokina is correctly spelled, and visually an apostrophe), a fraction or superscript
-  (`half-½-price`, `surface-m²`) and a roman numeral (`section-Ⅷ`) are all `\w`, so all of them
-  resolved and are **in scope above**, however much they read as punctuation. That is the one edge
-  of this split with a real cost: over-reporting wastes a rename, but reading a printed row as out
-  of scope means skipping it, and the row then 404s in production. So `café`, `表単`, `hawaiʼi-form`
-  and `surface-m²` did resolve and are in scope above, while `form€a` and `form\xa0a` never matched
-  a route at all: those rows answered 404 before this change as well as after and are not
-  reachable-then-orphaned. The same `\w` fact is why a space is in scope but a tab is not — the
-  class lists a literal space and `\w` covers neither — and why a *decomposed* spelling of an
-  accented id was never routable while its composed form was: a combining accent is a mark, so NFD
-  `café` (`e` + U+0301) is unreachable where NFC `café` (U+00E9) resolved. The scan still *flags*
-  every one of these, which is the safe direction (it over-reports rather than misses), and it is
-  also why the tab example above is about the classifier disagreeing with the code rather than about
-  a form being missed. `test_the_scan_is_scoped_to_ids_a_route_could_actually_resolve` asserts this
-  split off the installed resolver, so a powertools upgrade that widened the class fails a test
-  rather than silently making this paragraph wrong.
+  ASCII — matches any Unicode **letter or number**, plus `_`. Take that as the `L*` and `N*`
+  CATEGORIES rather than as "a letter or a digit", and take the other side as the complement rather
+  than as a list of glyphs: what `\w` leaves out is **marks** (`M*`), **symbols** (`S*`),
+  **punctuation** (`P*`), **separators** (`Z*`) and **format characters** (`C*`). `€` and `°` are
+  symbols, `—` and `«` are punctuation, an emoji is a symbol, U+00A0 (NBSP) and U+3000 are
+  separators, a combining accent is a mark, and a zero-width joiner or a soft hyphen is a format
+  character. (`_` is inside the validator's *own* class, so an id holding one is accepted rather
+  than refused and appears in neither list. It really is the single exception to `L*`/`N*` — the
+  other connector punctuation, U+FF3F, U+2040 and U+203F, is outside `\w` like the rest of `P*`.)
+
+  Reading the categories rather than the gloss matters because the shapes an operator is most likely
+  to misfile fall on **both** sides of that line. In scope despite reading as punctuation: a
+  modifier letter (`hawaiʼi-form`, whose `ʼ` is U+02BC MODIFIER LETTER APOSTROPHE, visually an ASCII
+  `'`; the Hawaiian ʻokina, U+02BB, is the same category and equally in scope), a fraction or
+  superscript (`half-½-price`, `surface-m²`) and a roman numeral (`section-Ⅷ`) are all `\w`, so all
+  of them resolved. `Lm` even holds five characters whose Unicode *names* are accents — U+02C6
+  MODIFIER LETTER CIRCUMFLEX ACCENT and U+02CA–U+02CF — so `formˆa` is in scope although "combining
+  accent" describes it in every sense but the categorical one. Out of scope despite reading as
+  letters: an id in a script that spells a vowel with a combining mark — Hindi `फॉर्म`, Thai
+  `แบบฟอร์ม`, Arabic `نَموذج` with its fatha — never matched a route, because the mark is `Mc`/`Mn`
+  even where the base character is `Lo`. (Precomposed Korean `피드백` is all `Lo`, and did resolve.)
+
+  That is the one edge of this split with a real cost: over-reporting wastes a rename, but reading a
+  printed row as out of scope means skipping it, and the row then 404s in production. So `café`,
+  `表単`, `hawaiʼi-form`, `surface-m²` and `section-Ⅷ` did resolve and are in scope above, while
+  `form€a`, `form\xa0a` and `फॉर्म` never matched a route at all: those rows answered 404 before this
+  change as well as after and are not reachable-then-orphaned. The same `\w` fact is why a space is
+  in scope but a tab is not — the class lists a literal space and `\w` covers neither — and why a
+  *decomposed* spelling of an accented id was never routable while its composed form was: a
+  combining accent is a mark, so NFD `café` (`e` + U+0301) is unreachable where NFC `café` (U+00E9)
+  resolved. One look-alike pair is worth naming for the same reason: `hawai’i-form` spelled with
+  U+2019 RIGHT SINGLE QUOTATION MARK is punctuation and never resolved, while the U+02BC and U+02BB
+  spellings are letters and did — the apostrophe glyphs land on both sides, so a printed row cannot
+  be triaged by eye. The scan still *flags* every one of these, which is the safe direction (it
+  over-reports rather than misses), and it is also why the tab example above is about the classifier
+  disagreeing with the code rather than about a form being missed.
+  `test_the_scan_is_scoped_to_ids_a_route_could_actually_resolve` asserts this split off the
+  installed resolver, sampling each of the eight `\w` categories on the in-scope side and a mark, a
+  symbol, a separator, a format character and connector punctuation on the other, so a powertools
+  upgrade that moved the class fails a test rather than silently making this paragraph wrong.
 - **`POST /feedback-forms/{form_id}/submit` reports a malformed id ahead of an invalid body.** A
   request carrying both a bad id and an empty `text` now answers `404 Form not found` where it
   answered `400 Feedback text is required`; the id is wrong regardless of the body, and this route

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,21 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   `prfaq` before creating the job. The field steered the job type, the execution path and the
   generated document's DynamoDB sort key straight from the request body, and each attempt billed a
   model call.
+- The public embeddable feedback form page, `GET /feedback-forms/{form_id}/iframe`, no longer
+  reflects its form id into the page it returns. The id was interpolated into a `<script>` block
+  inside handwritten quotes, so a path the route's own pattern accepts —
+  `a');alert(document.domain);x=('` — came back as executable script on the API's own origin, to any
+  visitor who could be sent the link (#379). The id is now format-checked before the page is built,
+  every value the page inlines is serialized rather than quoted by hand, and the response carries a
+  Content-Security-Policy. The page also confirms the form exists first, so an attacker-chosen id no
+  longer produces a page at all. Embedding is unaffected: no `frame-ancestors` and no
+  `X-Frame-Options` are set, deliberately.
+- Every route that takes a form id out of the URL now checks its format before reading or writing,
+  so a probe or an unbounded path segment costs no DynamoDB call on the unauthenticated ones.
+- `PUT /feedback-forms/{form_id}` no longer creates a record. The write was an unconditional
+  `UpdateItem`, which is an upsert, so a request naming an id the table did not hold created a row
+  with no `form_id` of its own — one that read back with an empty id and could not afterwards be
+  addressed or deleted by id. It is now conditional on the form existing.
 
 ### Upgrade notes
 
@@ -75,6 +90,19 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   previously started a default `prd` generation. Unparseable JSON is a 400 too, where it was
   previously a 500. A body that is absent altogether, a literal JSON `null`, or zero-length
   (`Content-Length: 0`), still means "generate a PRD with the defaults" and is unchanged.
+- **A feedback form id that this service could not have issued now answers 404 on every route that
+  takes one out of the URL**, before any read. Ids are at most 64 characters of letters, digits, `_`
+  and `-`; surrounding whitespace is no longer trimmed, so ` abc123` is a 404 rather than another way
+  of writing `abc123`. Forms created through this platform are unaffected — the ids it mints are
+  8 hex characters — and a hand-seeded id like `website-form` still works.
+- **`POST /feedback-forms/{form_id}/submit` reports a malformed id ahead of an invalid body.** A
+  request carrying both a bad id and an empty `text` now answers `404 Form not found` where it
+  answered `400 Feedback text is required`; the id is wrong regardless of the body, and this route
+  had to refuse before enqueueing anything. A well-formed id with an empty `text` still answers 400.
+- **`PUT /feedback-forms/{form_id}` answers 404 for a form that does not exist**, instead of creating
+  one. Create through `POST /feedback-forms`, which mints the id. Any phantom rows an earlier version
+  created are visible in `GET /feedback-forms` as entries with an empty `form_id`; they have to be
+  removed directly from the aggregates table, since no route can address them by id.
 
 ## [0.2.0] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
 
   **Check before upgrading if you have hand-seeded or imported form ids.** An id containing anything
   outside that class — `:`, `+`, `@`, `%`, `~`, or any non-ASCII character, as in `a:b` or `café` —
-  *did* resolve on all five of its routes before this change and now answers `404 Form not found` on
+  *did* resolve on all eight of its routes before this change and now answers `404 Form not found` on
   all of them. Unlike the whitespace case those rows are genuinely reachable-then-orphaned, so scan
   the aggregates table for them first and rename any you find (write the record under a new `sk` and
   repoint the embed snippet; the old row's submissions stay under their original `source_channel`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,12 +129,14 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   ```
 
   `:`, `+`, `@`, `%`, `~` and a space *within* the id are the memorable ones, not the whole set.
-  Seven of the rest — `&`, `'`, `(`, `)`, `;`, `<`, `>` — are the characters the #379 payload itself
-  is built from, which is precisely why a list written by hand omits them: they read as attack
-  syntax rather than as something anyone would seed an id with. They resolved all the same, so
-  `form(1)` and `a;b` are as much in scope as `a:b`. Going the other way, `"`, `#`, `/`, `?`, `\`
-  and `` ` `` are the printable-ASCII characters the route does **not** admit, so they belong with
-  the tab and the newline below rather than in the scan.
+  Seven of the rest — `&`, `'`, `(`, `)`, `;`, `<`, `>` — are the characters the #379 fix turns on:
+  the quote, parentheses and semicolon the payload closes its handwritten string literal with, plus
+  the `<`, `>` and `&` that `_js_value` escapes for the HTML parser. That is precisely why a list
+  written by hand omits them — they read as attack syntax rather than as something anyone would seed
+  an id with — and they resolved all the same, so `form(1)` and `a;b` are as much in scope as `a:b`.
+  Going the other way, `"`, `#`, `/`, `?`, `\` and `` ` `` are the printable-ASCII characters the
+  route does **not** admit, so they belong with the tab and the newline below rather than in the
+  scan.
 
   This finds them — the classifier tests the class, so it flags all 24 without needing them named:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,17 +110,17 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   API base, so such an id addressed a different resource rather than a form.
 
   **Check before upgrading if you have hand-seeded or imported form ids.** An id containing anything
-  outside that class — `:`, `+`, `@`, `%`, `~`, any non-ASCII character, or a space *within* the
-  id, as in `a:b`, `café` or `my form` — *did* resolve on all eight of its routes before this change
-  and now answers `404 Form not found` on all of them. Unlike an id addressed with surrounding
+  outside that class — `:`, `+`, `@`, `%`, `~`, a non-ASCII **letter or digit**, or a space *within*
+  the id, as in `a:b`, `café` or `my form` — *did* resolve on all eight of its routes before this
+  change and now answers `404 Form not found` on all of them. Unlike an id addressed with surrounding
   whitespace, those rows are genuinely reachable-then-orphaned, so scan the aggregates table for them
   first and rename any you find (write the record under a new `sk` and repoint the embed snippet; the
   old row's submissions stay under their original `source_channel`, so also rewrite those if the
   form's stats matter):
 
   ```bash
-  aws dynamodb scan --table-name "$AGGREGATES_TABLE" \
-    --filter-expression 'pk = :pk' \
+  aws dynamodb query --table-name "$AGGREGATES_TABLE" \
+    --key-condition-expression 'pk = :pk' \
     --expression-attribute-values '{":pk":{"S":"FEEDBACK_FORM"}}' \
     --projection-expression 'sk' --output json --query 'Items[].sk.S' \
   | jq -r '.[]' | sed 's/^FORM#//' \
@@ -131,7 +131,16 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   (`jq` is the same tool `voc-datalake/frontend/scripts/deploy.sh` already needs, so a machine that
   can deploy this stack can run the scan.)
 
-  Three things about that command are deliberate. It asks for `--output json` and splits with `jq`
+  Four things about that command are deliberate. It is a `query` rather than a `scan`, because `pk` is
+  the table's partition key and `FEEDBACK_FORM` is one whole partition — the same read `list_forms`
+  makes in `lambda/api/feedback_form_handler.py`, for the same reason. This table is shared: it also
+  holds `METRIC#`, `LOGS#`, `PROJECT#`, `SOURCE#`, `SOURCE_RUN#`, `SCRAPER#`, `SCRAPER_RUN#`,
+  `MANUAL_IMPORT#`, `SETTINGS#` and `VOTING_SESSION` partitions, and the `METRIC#`/`LOGS#` rows are
+  per-day, so on a deployment with history the forms are a small minority and a filtered `scan` would
+  read — and bill for — overwhelmingly rows it then discards. It also removes a second way for the
+  silence below to be misleading: DynamoDB applies its 1 MB page limit *before* a filter expression,
+  so a filtered `scan` can return a page of zero matches with more pages left, where a `query` reads
+  only the partition that can contain a hit. Next, it asks for `--output json` and splits with `jq`
   rather than `--output text | tr '\t' '\n'`, because the classifier has to agree with the code's own
   check on every *stored* shape and `tr` cannot tell a separator tab from a tab inside an id:
   `--output text` separates values with tabs, so `FORM#abc<TAB>def` would arrive as the two lines
@@ -146,11 +155,20 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   first page.
 
   What the scan does **not** need to find, so that its silence means what it says: an id containing a
-  literal tab or newline. Those cannot occur in an id any route ever resolved, because the route's own
-  capture group excludes both characters (it admits a space, which is why `my form` is in scope
-  above), so such a row answered 404 before this change as well as after and is not
-  reachable-then-orphaned. That is also why the tab example above is about the classifier
+  literal tab or newline, or a non-ASCII character that is not a letter or digit — a symbol or
+  punctuation mark like `€`, `—`, `°` or an emoji, or a non-ASCII space such as U+00A0 (NBSP) or
+  U+3000. None of those can occur in an id any route ever resolved, because the route's own capture
+  group admits only `[-._~()'!*:@,;=+&$%<> \[\]{}|^\w]`, and `\w` — the one member of that class that
+  reaches beyond ASCII — is Unicode-aware for *letters and digits* only. So `café` and `表単` did
+  resolve and are in scope above, while `form€a` and `form\xa0a` never matched a route at all: those
+  rows answered 404 before this change as well as after and are not reachable-then-orphaned. The same
+  `\w` fact is why a space is in scope but a tab is not — the class lists a literal space and `\w`
+  covers neither. The scan still *flags* every one of these, which is the safe direction (it
+  over-reports rather than misses), and it is also why the tab example above is about the classifier
   disagreeing with the code rather than about a form being missed.
+  `test_the_scan_is_scoped_to_ids_a_route_could_actually_resolve` asserts this split off the installed
+  resolver, so a powertools upgrade that widened the class fails a test rather than silently making
+  this paragraph wrong.
 - **`POST /feedback-forms/{form_id}/submit` reports a malformed id ahead of an invalid body.** A
   request carrying both a bad id and an empty `text` now answers `404 Form not found` where it
   answered `400 Feedback text is required`; the id is wrong regardless of the body, and this route

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,13 +110,13 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   API base, so such an id addressed a different resource rather than a form.
 
   **Check before upgrading if you have hand-seeded or imported form ids.** An id containing anything
-  outside that class — `:`, `+`, `@`, `%`, `~`, a non-ASCII **letter or digit**, or a space *within*
-  the id, as in `a:b`, `café` or `my form` — *did* resolve on all eight of its routes before this
-  change and now answers `404 Form not found` on all of them. Unlike an id addressed with surrounding
-  whitespace, those rows are genuinely reachable-then-orphaned, so scan the aggregates table for them
-  first and rename any you find (write the record under a new `sk` and repoint the embed snippet; the
-  old row's submissions stay under their original `source_channel`, so also rewrite those if the
-  form's stats matter):
+  outside that class — `:`, `+`, `@`, `%`, `~`, a non-ASCII **letter or number**, or a space
+  *within* the id, as in `a:b`, `café`, `hawaiʼi-form`, `surface-m²` or `my form` — *did* resolve on
+  all eight of its routes before this change and now answers `404 Form not found` on all of them.
+  Unlike an id addressed with surrounding whitespace, those rows are genuinely
+  reachable-then-orphaned, so scan the aggregates table for them first and rename any you find
+  (write the record under a new `sk` and repoint the embed snippet; the old row's submissions stay
+  under their original `source_channel`, so also rewrite those if the form's stats matter):
 
   ```bash
   aws dynamodb query --table-name "$AGGREGATES_TABLE" \
@@ -131,44 +131,56 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   (`jq` is the same tool `voc-datalake/frontend/scripts/deploy.sh` already needs, so a machine that
   can deploy this stack can run the scan.)
 
-  Four things about that command are deliberate. It is a `query` rather than a `scan`, because `pk` is
-  the table's partition key and `FEEDBACK_FORM` is one whole partition — the same read `list_forms`
-  makes in `lambda/api/feedback_form_handler.py`, for the same reason. This table is shared: it also
-  holds `METRIC#`, `LOGS#`, `PROJECT#`, `SOURCE#`, `SOURCE_RUN#`, `SCRAPER#`, `SCRAPER_RUN#`,
-  `MANUAL_IMPORT#`, `SETTINGS#` and `VOTING_SESSION` partitions, and the `METRIC#`/`LOGS#` rows are
-  per-day, so on a deployment with history the forms are a small minority and a filtered `scan` would
-  read — and bill for — overwhelmingly rows it then discards. It also removes a second way for the
-  silence below to be misleading: DynamoDB applies its 1 MB page limit *before* a filter expression,
-  so a filtered `scan` can return a page of zero matches with more pages left, where a `query` reads
-  only the partition that can contain a hit. Next, it asks for `--output json` and splits with `jq`
-  rather than `--output text | tr '\t' '\n'`, because the classifier has to agree with the code's own
-  check on every *stored* shape and `tr` cannot tell a separator tab from a tab inside an id:
-  `--output text` separates values with tabs, so `FORM#abc<TAB>def` would arrive as the two lines
-  `abc` and `def` and be classified as two ids that are not the one stored. `length($0) &&` is there
-  for the whitespace-only id — `awk` splits fields on whitespace, so the more idiomatic `NF` is 0 for
-  an id of nothing but spaces, which the routes refuse and the scan therefore has to flag, while
-  `length($0)` skips only the genuinely empty string. (It also skips an `sk` of exactly `FORM#`, an
-  empty id, and that is correct to skip: an empty path segment does not match the route, so such a row
-  was never served by any of the eight and its status is unchanged.) And it relies on the AWS CLI's
-  default auto-pagination to walk a table larger than one page — if you disable that
-  (`--no-paginate`, `--max-items`, or `AWS_PAGER`/CLI config changes), the silence covers only the
-  first page.
+  Four things about that command are deliberate. It is a `query` rather than a `scan`, because `pk`
+  is the table's partition key and `FEEDBACK_FORM` is one whole partition — the same read
+  `list_forms` makes in `lambda/api/feedback_form_handler.py`, for the same reason. This table is
+  shared: it also holds `METRIC#`, `LOGS#`, `PROJECT#`, `SOURCE#`, `SOURCE_RUN#`, `SCRAPER#`,
+  `SCRAPER_RUN#`, `MANUAL_IMPORT#`, `SETTINGS#` and `VOTING_SESSION` partitions, and the
+  `METRIC#`/`LOGS#` rows are per-day, so on a deployment with history the forms are a small minority
+  and a filtered `scan` would read — and bill for — overwhelmingly rows it then discards. Cost is
+  the whole of that argument: walked to the end, which the auto-pagination noted below is what
+  ensures, a filtered `scan` prints exactly the same lines. Next, it asks for `--output json` and
+  splits with `jq` rather than `--output text | tr '\t' '\n'`, because the classifier has to agree
+  with the code's own check on every *stored* shape and `tr` cannot tell a separator tab from a tab
+  inside an id: `--output text` separates values with tabs, so `FORM#abc<TAB>def` would arrive as
+  the two lines `abc` and `def` and be classified as two ids that are not the one stored.
+  `length($0) &&` is there for the whitespace-only id — `awk` splits fields on whitespace, so the
+  more idiomatic `NF` is 0 for an id of nothing but spaces, which the routes refuse and the scan
+  therefore has to flag, while `length($0)` skips only the genuinely empty string. (It also skips an
+  `sk` of exactly `FORM#`, an empty id, and that is correct to skip: an empty path segment does not
+  match the route, so such a row was never served by any of the eight and its status is unchanged.)
+  And it relies on the AWS CLI's default auto-pagination to walk a table larger than one page — if
+  you disable that (`--no-paginate`, `--max-items`, or `AWS_PAGER`/CLI config changes), the silence
+  covers only the first page. That truncated case is the only one in which the `query` is safer
+  rather than merely cheaper, and it is worth knowing which way: DynamoDB applies its 1 MB page
+  limit *before* a filter expression, so a truncated filtered `scan` can report zero matches from
+  pages that held none, whereas a truncated `query` has at least read only rows that could match.
+  Run to completion neither is misleading, which is why cost carries the choice above.
 
-  What the scan does **not** need to find, so that its silence means what it says: an id containing a
-  literal tab or newline, or a non-ASCII character that is not a letter or digit — a symbol or
-  punctuation mark like `€`, `—`, `°` or an emoji, or a non-ASCII space such as U+00A0 (NBSP) or
-  U+3000. None of those can occur in an id any route ever resolved, because the route's own capture
-  group admits only `[-._~()'!*:@,;=+&$%<> \[\]{}|^\w]`, and `\w` — the one member of that class that
-  reaches beyond ASCII — is Unicode-aware for *letters and digits* only. So `café` and `表単` did
-  resolve and are in scope above, while `form€a` and `form\xa0a` never matched a route at all: those
-  rows answered 404 before this change as well as after and are not reachable-then-orphaned. The same
-  `\w` fact is why a space is in scope but a tab is not — the class lists a literal space and `\w`
-  covers neither. The scan still *flags* every one of these, which is the safe direction (it
-  over-reports rather than misses), and it is also why the tab example above is about the classifier
-  disagreeing with the code rather than about a form being missed.
-  `test_the_scan_is_scoped_to_ids_a_route_could_actually_resolve` asserts this split off the installed
-  resolver, so a powertools upgrade that widened the class fails a test rather than silently making
-  this paragraph wrong.
+  What the scan does **not** need to find, so that its silence means what it says: an id containing
+  a literal tab or newline, or a non-ASCII **symbol, punctuation mark, combining accent or space** —
+  `€`, `—`, `°`, `«`, an emoji, or a non-ASCII space such as U+00A0 (NBSP) or U+3000. None of those
+  can occur in an id any route ever resolved, because the route's own capture group admits only
+  `[-._~()'!*:@,;=+&$%<> \[\]{}|^\w]`, and `\w` — the one member of that class that reaches beyond
+  ASCII — matches any Unicode **letter or number** and nothing else. Read that as the `L*` and `N*`
+  CATEGORIES rather than as "a letter or a digit", because the difference is exactly the shapes an
+  operator is most likely to misfile: a modifier letter (`hawaiʼi-form`, whose `ʼ` is U+02BC — how
+  an ʻokina is correctly spelled, and visually an apostrophe), a fraction or superscript
+  (`half-½-price`, `surface-m²`) and a roman numeral (`section-Ⅷ`) are all `\w`, so all of them
+  resolved and are **in scope above**, however much they read as punctuation. That is the one edge
+  of this split with a real cost: over-reporting wastes a rename, but reading a printed row as out
+  of scope means skipping it, and the row then 404s in production. So `café`, `表単`, `hawaiʼi-form`
+  and `surface-m²` did resolve and are in scope above, while `form€a` and `form\xa0a` never matched
+  a route at all: those rows answered 404 before this change as well as after and are not
+  reachable-then-orphaned. The same `\w` fact is why a space is in scope but a tab is not — the
+  class lists a literal space and `\w` covers neither — and why a *decomposed* spelling of an
+  accented id was never routable while its composed form was: a combining accent is a mark, so NFD
+  `café` (`e` + U+0301) is unreachable where NFC `café` (U+00E9) resolved. The scan still *flags*
+  every one of these, which is the safe direction (it over-reports rather than misses), and it is
+  also why the tab example above is about the classifier disagreeing with the code rather than about
+  a form being missed. `test_the_scan_is_scoped_to_ids_a_route_could_actually_resolve` asserts this
+  split off the installed resolver, so a powertools upgrade that widened the class fails a test
+  rather than silently making this paragraph wrong.
 - **`POST /feedback-forms/{form_id}/submit` reports a malformed id ahead of an invalid body.** A
   request carrying both a bad id and an empty `text` now answers `404 Form not found` where it
   answered `400 Feedback text is required`; the id is wrong regardless of the body, and this route

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,13 +110,33 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   API base, so such an id addressed a different resource rather than a form.
 
   **Check before upgrading if you have hand-seeded or imported form ids.** An id containing anything
-  outside that class — `:`, `+`, `@`, `%`, `~`, a non-ASCII **letter or number**, or a space
-  *within* the id, as in `a:b`, `café`, `hawaiʼi-form`, `surface-m²` or `my form` — *did* resolve on
-  all eight of its routes before this change and now answers `404 Form not found` on all of them.
-  Unlike an id addressed with surrounding whitespace, those rows are genuinely
-  reachable-then-orphaned, so scan the aggregates table for them first and rename any you find
-  (write the record under a new `sk` and repoint the embed snippet; the old row's submissions stay
-  under their original `source_channel`, so also rewrite those if the form's stats matter):
+  outside that class *that the route itself admits* — `a:b`, `form(1)`, `a;b`, `café`,
+  `hawaiʼi-form`, `surface-m²` or `my form` — *did* resolve on all eight of its routes before this
+  change and now answers `404 Form not found` on all of them. Unlike an id addressed with
+  surrounding whitespace, those rows are genuinely reachable-then-orphaned, so scan the aggregates
+  table for them first and rename any you find (write the record under a new `sk` and repoint the
+  embed snippet; the old row's submissions stay under their original `source_channel`, so also
+  rewrite those if the form's stats matter).
+
+  **Read "anything outside that class" as a complement rather than as a list**, because for ASCII
+  the set is 24 characters and every hand-written list of it has been shorter. In scope is any
+  character outside the validator's `[0-9A-Za-z_.-]` that the route's own capture group
+  (`[-._~()'!*:@,;=+&$%<> \[\]{}|^\w]`) admits, which for ASCII means everything in
+  `[-._~()'!*:@,;=+&$%<> \[\]{}|^]` except `-`, `.` and `_`:
+
+  ```
+  space ! $ % & ' ( ) * + , : ; < = > @ [ ] ^ { | } ~
+  ```
+
+  `:`, `+`, `@`, `%`, `~` and a space *within* the id are the memorable ones, not the whole set.
+  Seven of the rest — `&`, `'`, `(`, `)`, `;`, `<`, `>` — are the characters the #379 payload itself
+  is built from, which is precisely why a list written by hand omits them: they read as attack
+  syntax rather than as something anyone would seed an id with. They resolved all the same, so
+  `form(1)` and `a;b` are as much in scope as `a:b`. Going the other way, `"`, `#`, `/`, `?`, `\`
+  and `` ` `` are the printable-ASCII characters the route does **not** admit, so they belong with
+  the tab and the newline below rather than in the scan.
+
+  This finds them — the classifier tests the class, so it flags all 24 without needing them named:
 
   ```bash
   aws dynamodb query --table-name "$AGGREGATES_TABLE" \
@@ -176,9 +196,13 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   modifier letter (`hawaiʼi-form`, whose `ʼ` is U+02BC MODIFIER LETTER APOSTROPHE, visually an ASCII
   `'`; the Hawaiian ʻokina, U+02BB, is the same category and equally in scope), a fraction or
   superscript (`half-½-price`, `surface-m²`) and a roman numeral (`section-Ⅷ`) are all `\w`, so all
-  of them resolved. `Lm` even holds five characters whose Unicode *names* are accents — U+02C6
-  MODIFIER LETTER CIRCUMFLEX ACCENT and U+02CA–U+02CF — so `formˆa` is in scope although "combining
-  accent" describes it in every sense but the categorical one. Out of scope despite reading as
+  of them resolved. `Lm` even holds characters whose Unicode *names* are accents — U+02C6 MODIFIER
+  LETTER CIRCUMFLEX ACCENT, U+02CA, U+02CB, U+02CE, U+02CF and U+A788 MODIFIER LETTER LOW CIRCUMFLEX
+  ACCENT — so `formˆa` is in scope although "combining accent" describes it in every sense but the
+  categorical one. Those six are spelled out rather than written as the range U+02CA–U+02CF, which
+  is not the same set: it also contains U+02CC MODIFIER LETTER LOW VERTICAL LINE and U+02CD MODIFIER
+  LETTER LOW MACRON, which are `Lm` and in scope like every other `Lm` character but are not
+  accents, and it misses U+A788, which is. Out of scope despite reading as
   letters: an id in a script that spells a vowel with a combining mark — Hindi `फॉर्म`, Thai
   `แบบฟอร์ม`, Arabic `نَموذج` with its fatha — never matched a route, because the mark is `Mc`/`Mn`
   even where the base character is `Lo`. (Precomposed Korean `피드백` is all `Lo`, and did resolve.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,12 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   `UpdateItem`, which is an upsert, so a request naming an id the table did not hold created a row
   with no `form_id` of its own — one that read back with an empty id and could not afterwards be
   addressed or deleted by id. It is now conditional on the form existing.
+- `POST /feedback-forms` can no longer overwrite an existing form. The write was an unconditional
+  `PutItem`, which replaces whatever is stored at the same key, so a minted id that collided with a
+  form already there would have replaced it — that form's `enabled` flag, theme and document link
+  gone, reported as a successful create. Unreachable by a caller, since the id is minted rather than
+  taken from the request, so it required a collision between two draws; the write is now conditional
+  on the id being free and a collision answers 500 instead of losing the form.
 
 ### Upgrade notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,9 +139,9 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   nothing at all rather than a blank line indistinguishable from a finding — `length` rather than the
   more idiomatic `NF` because `awk` splits fields on whitespace, so `NF` is also 0 for an id
   consisting *only* of spaces or a tab, which the routes refuse and the scan therefore has to flag.
-  And it relies on the AWS CLI's
-  default auto-pagination to walk a table larger than one page — if you disable that (`--no-paginate`,
-  `--max-items`, or `AWS_PAGER`/CLI config changes), the silence covers only the first page.
+  And it relies on the AWS CLI's default auto-pagination to walk a table larger than one page — if
+  you disable that (`--no-paginate`, `--max-items`, or `AWS_PAGER`/CLI config changes), the silence
+  covers only the first page.
   One residual gap, since no line-oriented pipeline can close it: an id containing a literal newline
   splits into two lines whatever the transport, so if you may have seeded such an id, find it with a
   scan that keeps the JSON intact (`--output json --query 'Items[].sk.S'` and inspect the array).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,9 +92,11 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   (`Content-Length: 0`), still means "generate a PRD with the defaults" and is unchanged.
 - **A feedback form id that this service could not have issued now answers 404 on every route that
   takes one out of the URL**, before any read. Ids are at most 64 characters of letters, digits, `_`
-  and `-`; surrounding whitespace is no longer trimmed, so ` abc123` is a 404 rather than another way
-  of writing `abc123`. Forms created through this platform are unaffected — the ids it mints are
-  8 hex characters — and a hand-seeded id like `website-form` still works.
+  and `-`, so an id containing anything else — a space, for instance — answers 404: ` abc123` is
+  refused on its format. Note that no route ever resolved ` abc123` to `abc123`; the space was always
+  part of the key, so there is no stored data to migrate. Forms created through this platform are
+  unaffected — the ids it mints are 8 hex characters — and a hand-seeded id like `website-form` still
+  works.
 - **`POST /feedback-forms/{form_id}/submit` reports a malformed id ahead of an invalid body.** A
   request carrying both a bad id and an empty `text` now answers `404 Form not found` where it
   answered `400 Feedback text is required`; the id is wrong regardless of the body, and this route

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,10 +203,10 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   categorical one. Those six are spelled out rather than written as the range U+02CA–U+02CF, which
   is not the same set: it also contains U+02CC MODIFIER LETTER LOW VERTICAL LINE and U+02CD MODIFIER
   LETTER LOW MACRON, which are `Lm` and in scope like every other `Lm` character but are not
-  accents, and it misses U+A788, which is. Out of scope despite reading as
-  letters: an id in a script that spells a vowel with a combining mark — Hindi `फॉर्म`, Thai
-  `แบบฟอร์ม`, Arabic `نَموذج` with its fatha — never matched a route, because the mark is `Mc`/`Mn`
-  even where the base character is `Lo`. (Precomposed Korean `피드백` is all `Lo`, and did resolve.)
+  accents, and it misses U+A788, which is. Out of scope despite reading as letters: an id in a
+  script that spells a vowel with a combining mark — Hindi `फॉर्म`, Thai `แบบฟอร์ม`, Arabic `نَموذج`
+  with its fatha — never matched a route, because the mark is `Mc`/`Mn` even where the base
+  character is `Lo`. (Precomposed Korean `피드백` is all `Lo`, and did resolve.)
 
   That is the one edge of this split with a real cost: over-reporting wastes a rename, but reading a
   printed row as out of scope means skipping it, and the row then 404s in production. So `café`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   API base, so such an id addressed a different resource rather than a form.
 
   **Check before upgrading if you have hand-seeded or imported form ids.** An id containing anything
-  outside that class — `:`, `+`, `@`, `%`, `~`, any non-ASCII character, or whitespace *within* the
+  outside that class — `:`, `+`, `@`, `%`, `~`, any non-ASCII character, or a space *within* the
   id, as in `a:b`, `café` or `my form` — *did* resolve on all eight of its routes before this change
   and now answers `404 Form not found` on all of them. Unlike an id addressed with surrounding
   whitespace, those rows are genuinely reachable-then-orphaned, so scan the aggregates table for them
@@ -132,19 +132,25 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   can deploy this stack can run the scan.)
 
   Three things about that command are deliberate. It asks for `--output json` and splits with `jq`
-  rather than `--output text | tr '\t' '\n'`, because `--output text` separates values with tabs and
-  `tr` cannot tell a separator tab from a tab *inside* an id — `FORM#abc<TAB>def` would arrive as the
-  two well-formed lines `abc` and `def`, and a form the routes will refuse would be reported as
-  absent. `length($0) &&` skips the empty record, so a table holding no `FEEDBACK_FORM` rows prints
-  nothing at all rather than a blank line indistinguishable from a finding — `length` rather than the
-  more idiomatic `NF` because `awk` splits fields on whitespace, so `NF` is also 0 for an id
-  consisting *only* of spaces or a tab, which the routes refuse and the scan therefore has to flag.
-  And it relies on the AWS CLI's default auto-pagination to walk a table larger than one page — if
-  you disable that (`--no-paginate`, `--max-items`, or `AWS_PAGER`/CLI config changes), the silence
-  covers only the first page.
-  One residual gap, since no line-oriented pipeline can close it: an id containing a literal newline
-  splits into two lines whatever the transport, so if you may have seeded such an id, find it with a
-  scan that keeps the JSON intact (`--output json --query 'Items[].sk.S'` and inspect the array).
+  rather than `--output text | tr '\t' '\n'`, because the classifier has to agree with the code's own
+  check on every *stored* shape and `tr` cannot tell a separator tab from a tab inside an id:
+  `--output text` separates values with tabs, so `FORM#abc<TAB>def` would arrive as the two lines
+  `abc` and `def` and be classified as two ids that are not the one stored. `length($0) &&` is there
+  for the whitespace-only id — `awk` splits fields on whitespace, so the more idiomatic `NF` is 0 for
+  an id of nothing but spaces, which the routes refuse and the scan therefore has to flag, while
+  `length($0)` skips only the genuinely empty string. (It also skips an `sk` of exactly `FORM#`, an
+  empty id, and that is correct to skip: an empty path segment does not match the route, so such a row
+  was never served by any of the eight and its status is unchanged.) And it relies on the AWS CLI's
+  default auto-pagination to walk a table larger than one page — if you disable that
+  (`--no-paginate`, `--max-items`, or `AWS_PAGER`/CLI config changes), the silence covers only the
+  first page.
+
+  What the scan does **not** need to find, so that its silence means what it says: an id containing a
+  literal tab or newline. Those cannot occur in an id any route ever resolved, because the route's own
+  capture group excludes both characters (it admits a space, which is why `my form` is in scope
+  above), so such a row answered 404 before this change as well as after and is not
+  reachable-then-orphaned. That is also why the tab example above is about the classifier
+  disagreeing with the code rather than about a form being missed.
 - **`POST /feedback-forms/{form_id}/submit` reports a malformed id ahead of an invalid body.** A
   request carrying both a bad id and an empty `text` now answers `404 Form not found` where it
   answered `400 Feedback text is required`; the id is wrong regardless of the body, and this route

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,13 +130,15 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
 
   `:`, `+`, `@`, `%`, `~` and a space *within* the id are the memorable ones, not the whole set.
   Seven of the rest — `&`, `'`, `(`, `)`, `;`, `<`, `>` — are the characters the #379 fix turns on:
-  the quote, parentheses and semicolon the payload closes its handwritten string literal with, plus
-  the `<`, `>` and `&` that `_js_value` escapes for the HTML parser. That is precisely why a list
-  written by hand omits them — they read as attack syntax rather than as something anyone would seed
-  an id with — and they resolved all the same, so `form(1)` and `a;b` are as much in scope as `a:b`.
-  Going the other way, `"`, `#`, `/`, `?`, `\` and `` ` `` are the printable-ASCII characters the
-  route does **not** admit, so they belong with the tab and the newline below rather than in the
-  scan.
+  the quote, parentheses and semicolon the payload breaks out with, plus the `<`, `>` and `&` that
+  `_js_value` escapes for the HTML parser. (In the payload itself, three of those four do the
+  breaking out — the `'` closes the string literal, the `)` closes the init call and the `;` starts
+  a second statement — while its `(` belongs to the `alert(` it calls and the `x=('` it re-opens
+  with.) That is precisely why a list written by hand omits them — they read as attack syntax rather
+  than as something anyone would seed an id with — and they resolved all the same, so `form(1)` and
+  `a;b` are as much in scope as `a:b`. Going the other way, `"`, `#`, `/`, `?`, `\` and `` ` `` are
+  the printable-ASCII characters the route does **not** admit, so they belong with the tab and the
+  newline below rather than in the scan.
 
   This finds them — the classifier tests the class, so it flags all 24 without needing them named:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,7 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
     --expression-attribute-values '{":pk":{"S":"FEEDBACK_FORM"}}' \
     --projection-expression 'sk' --output json --query 'Items[].sk.S' \
   | jq -r '.[]' | sed 's/^FORM#//' \
-  | awk 'NF && (length($0) > 64 || $0 !~ /^[0-9A-Za-z_.-]+$/ || $0 == "." || $0 == "..")'
+  | awk 'length($0) && (length($0) > 64 || $0 !~ /^[0-9A-Za-z_.-]+$/ || $0 == "." || $0 == "..")'
   ```
 
   No output means nothing to do. Any line printed is a form whose routes will start answering 404.
@@ -135,8 +135,11 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   rather than `--output text | tr '\t' '\n'`, because `--output text` separates values with tabs and
   `tr` cannot tell a separator tab from a tab *inside* an id — `FORM#abc<TAB>def` would arrive as the
   two well-formed lines `abc` and `def`, and a form the routes will refuse would be reported as
-  absent. `NF &&` skips the empty record, so a table holding no `FEEDBACK_FORM` rows prints nothing
-  at all rather than a blank line indistinguishable from a finding. And it relies on the AWS CLI's
+  absent. `length($0) &&` skips the empty record, so a table holding no `FEEDBACK_FORM` rows prints
+  nothing at all rather than a blank line indistinguishable from a finding — `length` rather than the
+  more idiomatic `NF` because `awk` splits fields on whitespace, so `NF` is also 0 for an id
+  consisting *only* of spaces or a tab, which the routes refuse and the scan therefore has to flag.
+  And it relies on the AWS CLI's
   default auto-pagination to walk a table larger than one page — if you disable that (`--no-paginate`,
   `--max-items`, or `AWS_PAGER`/CLI config changes), the silence covers only the first page.
   One residual gap, since no line-oriented pipeline can close it: an id containing a literal newline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,32 +99,49 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
 - **A feedback form id that this service could not have issued now answers 404 on every route that
   takes one out of the URL**, before any read. Ids are at most 64 characters of letters, digits, `_`,
   `-` and `.`, so an id containing anything else — a space, for instance — answers 404: ` abc123` is
-  refused on its format. **No migration is needed for the whitespace case**, and only for that case:
-  no route ever resolved ` abc123` to `abc123`, so the space was always part of the key and no stored
-  row has become unreachable. Forms created through this platform are unaffected — the ids it mints
-  are 8 hex characters — and hand-seeded ids like `website-form` and `acme.website` still work. The
-  two exceptions are `.` and `..` on their own, which are refused because they are relative-path
-  segments: a client resolves them away when it joins them onto the API base, so such an id addressed
-  a different resource rather than a form.
+  refused on its format. **No migration is needed for an id that was merely ADDRESSED with
+  surrounding whitespace**, and only for that case: no route ever resolved ` abc123` to `abc123`, so
+  the space was always part of the key and the record under `abc123` is reached exactly as it was.
+  That argument is about a caller's typo, and it does not extend to a form whose *stored* id contains
+  whitespace — see the scan below, which covers those. Forms created through this platform are
+  unaffected — the ids it mints are 8 hex characters — and hand-seeded ids like `website-form` and
+  `acme.website` still work. The two exceptions are `.` and `..` on their own, which are refused
+  because they are relative-path segments: a client resolves them away when it joins them onto the
+  API base, so such an id addressed a different resource rather than a form.
 
   **Check before upgrading if you have hand-seeded or imported form ids.** An id containing anything
-  outside that class — `:`, `+`, `@`, `%`, `~`, or any non-ASCII character, as in `a:b` or `café` —
-  *did* resolve on all eight of its routes before this change and now answers `404 Form not found` on
-  all of them. Unlike the whitespace case those rows are genuinely reachable-then-orphaned, so scan
-  the aggregates table for them first and rename any you find (write the record under a new `sk` and
-  repoint the embed snippet; the old row's submissions stay under their original `source_channel`,
-  so also rewrite those if the form's stats matter):
+  outside that class — `:`, `+`, `@`, `%`, `~`, any non-ASCII character, or whitespace *within* the
+  id, as in `a:b`, `café` or `my form` — *did* resolve on all eight of its routes before this change
+  and now answers `404 Form not found` on all of them. Unlike an id addressed with surrounding
+  whitespace, those rows are genuinely reachable-then-orphaned, so scan the aggregates table for them
+  first and rename any you find (write the record under a new `sk` and repoint the embed snippet; the
+  old row's submissions stay under their original `source_channel`, so also rewrite those if the
+  form's stats matter):
 
   ```bash
   aws dynamodb scan --table-name "$AGGREGATES_TABLE" \
     --filter-expression 'pk = :pk' \
     --expression-attribute-values '{":pk":{"S":"FEEDBACK_FORM"}}' \
-    --projection-expression 'sk' --output text --query 'Items[].sk.S' \
-  | tr '\t' '\n' | sed 's/^FORM#//' \
-  | awk 'length($0) > 64 || $0 !~ /^[0-9A-Za-z_.-]+$/ || $0 == "." || $0 == ".."'
+    --projection-expression 'sk' --output json --query 'Items[].sk.S' \
+  | jq -r '.[]' | sed 's/^FORM#//' \
+  | awk 'NF && (length($0) > 64 || $0 !~ /^[0-9A-Za-z_.-]+$/ || $0 == "." || $0 == "..")'
   ```
 
   No output means nothing to do. Any line printed is a form whose routes will start answering 404.
+  (`jq` is the same tool `voc-datalake/frontend/scripts/deploy.sh` already needs, so a machine that
+  can deploy this stack can run the scan.)
+
+  Three things about that command are deliberate. It asks for `--output json` and splits with `jq`
+  rather than `--output text | tr '\t' '\n'`, because `--output text` separates values with tabs and
+  `tr` cannot tell a separator tab from a tab *inside* an id — `FORM#abc<TAB>def` would arrive as the
+  two well-formed lines `abc` and `def`, and a form the routes will refuse would be reported as
+  absent. `NF &&` skips the empty record, so a table holding no `FEEDBACK_FORM` rows prints nothing
+  at all rather than a blank line indistinguishable from a finding. And it relies on the AWS CLI's
+  default auto-pagination to walk a table larger than one page — if you disable that (`--no-paginate`,
+  `--max-items`, or `AWS_PAGER`/CLI config changes), the silence covers only the first page.
+  One residual gap, since no line-oriented pipeline can close it: an id containing a literal newline
+  splits into two lines whatever the transport, so if you may have seeded such an id, find it with a
+  scan that keeps the JSON intact (`--output json --query 'Items[].sk.S'` and inspect the array).
 - **`POST /feedback-forms/{form_id}/submit` reports a malformed id ahead of an invalid body.** A
   request carrying both a bad id and an empty `text` now answers `404 Form not found` where it
   answered `400 Feedback text is required`; the id is wrong regardless of the body, and this route

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,10 +63,12 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   model call.
 - The public embeddable feedback form page, `GET /feedback-forms/{form_id}/iframe`, no longer
   reflects its form id into the page it returns. The id was interpolated into a `<script>` block
-  inside handwritten quotes, so a path the route's own pattern accepts —
-  `a');alert(document.domain);x=('` — came back as executable script on the API's own origin, to any
-  visitor who could be sent the link (#379). The id is now format-checked before the page is built,
-  every value the page inlines is serialized rather than quoted by hand, and the response carries a
+  inside handwritten quotes, so a path the route's own pattern accepts could close them and be
+  executed as script on the API's own origin, by any visitor who could be sent the link (#379). The
+  issue's own sample, `a');alert(document.domain);x=('`, was written for a bare-argument call and
+  leaves this template's object literal unparseable; `a',x:alert(1),y:'` is the same class through
+  the same hole and does run. The id is now format-checked before the page is built, every value the
+  page inlines is serialized rather than quoted by hand, and the response carries a
   Content-Security-Policy. The page also confirms the form exists first, so an attacker-chosen id no
   longer produces a page at all. Embedding is unaffected: no `frame-ancestors` and no
   `X-Frame-Options` are set, deliberately.
@@ -131,14 +133,18 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   `:`, `+`, `@`, `%`, `~` and a space *within* the id are the memorable ones, not the whole set.
   Seven of the rest — `&`, `'`, `(`, `)`, `;`, `<`, `>` — are the characters the #379 fix turns on:
   the quote, parentheses and semicolon the payload breaks out with, plus the `<`, `>` and `&` that
-  `_js_value` escapes for the HTML parser. (In the payload itself, three of those four do the
-  breaking out — the `'` closes the string literal, the `)` closes the init call and the `;` starts
-  a second statement — while its `(` belongs to the `alert(` it calls and the `x=('` it re-opens
-  with.) That is precisely why a list written by hand omits them — they read as attack syntax rather
-  than as something anyone would seed an id with — and they resolved all the same, so `form(1)` and
-  `a;b` are as much in scope as `a:b`. Going the other way, `"`, `#`, `/`, `?`, `\` and `` ` `` are
-  the printable-ASCII characters the route does **not** admit, so they belong with the tab and the
-  newline below rather than in the scan.
+  `_js_value` escapes for the HTML parser. (Only the `'` does the breaking out in the payload
+  itself: it closes the string literal the template wrote. Its `(` is the `alert(` it calls and the
+  `x=('` it re-opens with, and its `)` and `;` close a call and start a statement only in the
+  bare-argument shape `init('<id>')` the payload was written for — the merge-base template
+  interpolates the id inside an *object literal*, where they close nothing and leave the whole
+  `<script>` block unparseable instead. The class is exploitable regardless, just not by this
+  string: `a',x:alert(1),y:'` needs no `)` or `;` at all, parses, and runs.) That is precisely why a
+  list written by hand omits them — they read as attack syntax rather than as something anyone would
+  seed an id with — and they resolved all the same, so `form(1)` and `a;b` are as much in scope as
+  `a:b`. Going the other way, `"`, `#`, `/`, `?`, `\` and `` ` `` are the printable-ASCII characters
+  the route does **not** admit, so they belong with the tab and the newline below rather than in the
+  scan.
 
   This finds them — the classifier tests the class, so it flags all 24 without needing them named:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,7 +178,8 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   Run to completion neither is misleading, which is why cost carries the choice above.
 
   What the scan does **not** need to find, so that its silence means what it says: an id containing
-  a literal tab or newline, or a non-ASCII character that `\w` does not match. None of those can
+  a literal tab or newline, one of the six printable-ASCII characters the route's class omits (`"`,
+  `#`, `/`, `?`, `\`, `` ` ``), or a non-ASCII character that `\w` does not match. None of those can
   occur in an id any route ever resolved, because the route's own capture group admits only
   `[-._~()'!*:@,;=+&$%<> \[\]{}|^\w]`, and `\w` — the one member of that class that reaches beyond
   ASCII — matches any Unicode **letter or number**, plus `_`. Take that as the `L*` and `N*`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,12 +97,34 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   previously a 500. A body that is absent altogether, a literal JSON `null`, or zero-length
   (`Content-Length: 0`), still means "generate a PRD with the defaults" and is unchanged.
 - **A feedback form id that this service could not have issued now answers 404 on every route that
-  takes one out of the URL**, before any read. Ids are at most 64 characters of letters, digits, `_`
-  and `-`, so an id containing anything else — a space, for instance — answers 404: ` abc123` is
-  refused on its format. Note that no route ever resolved ` abc123` to `abc123`; the space was always
-  part of the key, so there is no stored data to migrate. Forms created through this platform are
-  unaffected — the ids it mints are 8 hex characters — and a hand-seeded id like `website-form` still
-  works.
+  takes one out of the URL**, before any read. Ids are at most 64 characters of letters, digits, `_`,
+  `-` and `.`, so an id containing anything else — a space, for instance — answers 404: ` abc123` is
+  refused on its format. **No migration is needed for the whitespace case**, and only for that case:
+  no route ever resolved ` abc123` to `abc123`, so the space was always part of the key and no stored
+  row has become unreachable. Forms created through this platform are unaffected — the ids it mints
+  are 8 hex characters — and hand-seeded ids like `website-form` and `acme.website` still work. The
+  two exceptions are `.` and `..` on their own, which are refused because they are relative-path
+  segments: a client resolves them away when it joins them onto the API base, so such an id addressed
+  a different resource rather than a form.
+
+  **Check before upgrading if you have hand-seeded or imported form ids.** An id containing anything
+  outside that class — `:`, `+`, `@`, `%`, `~`, or any non-ASCII character, as in `a:b` or `café` —
+  *did* resolve on all five of its routes before this change and now answers `404 Form not found` on
+  all of them. Unlike the whitespace case those rows are genuinely reachable-then-orphaned, so scan
+  the aggregates table for them first and rename any you find (write the record under a new `sk` and
+  repoint the embed snippet; the old row's submissions stay under their original `source_channel`,
+  so also rewrite those if the form's stats matter):
+
+  ```bash
+  aws dynamodb scan --table-name "$AGGREGATES_TABLE" \
+    --filter-expression 'pk = :pk' \
+    --expression-attribute-values '{":pk":{"S":"FEEDBACK_FORM"}}' \
+    --projection-expression 'sk' --output text --query 'Items[].sk.S' \
+  | tr '\t' '\n' | sed 's/^FORM#//' \
+  | awk 'length($0) > 64 || $0 !~ /^[0-9A-Za-z_.-]+$/ || $0 == "." || $0 == ".."'
+  ```
+
+  No output means nothing to do. Any line printed is a form whose routes will start answering 404.
 - **`POST /feedback-forms/{form_id}/submit` reports a malformed id ahead of an invalid body.** A
   request carrying both a bad id and an empty `text` now answers `404 Form not found` where it
   answered `400 Feedback text is required`; the id is wrong regardless of the body, and this route

--- a/docs/SYSTEM_DOCUMENTATION.md
+++ b/docs/SYSTEM_DOCUMENTATION.md
@@ -596,6 +596,22 @@ is no separate script to load:
 <iframe src="https://your-api/v1/feedback-forms/{form_id}/iframe" width="100%" height="500" frameborder="0"></iframe>
 ```
 
+Two things about that page to know before debugging a blank or error frame:
+
+- It answers **404 for a form id the table does not hold**, and for one this
+  service could not have issued — the route confirms the form exists before
+  rendering, where it previously served a page having read nothing. A deleted form
+  or a typo in `{form_id}` is therefore an error frame rather than an empty
+  widget. See
+  [how a form id is checked](feedback-forms.md#how-a-form-id-is-checked-on-every-one-of-those-routes).
+- It sets a **Content-Security-Policy**, and that one fails silently: the frame
+  goes blank with nothing to see but a violation in the browser console. It
+  deliberately sets no `frame-ancestors` and no `X-Frame-Options`, so a proxy or
+  CDN in front of the API that adds either will break every embed. See
+  [Embedding Forms](feedback-forms.md#embedding-forms), which is where both are
+  described — this page links rather than repeating them so there is one copy to
+  keep correct.
+
 The only public per-form routes are `config`, `submit` and `iframe`; there is no
 `widget.js` route, and requesting one returns `403 Missing Authentication Token`.
 See [Feedback Forms](feedback-forms.md#embedding-forms).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -791,6 +791,16 @@ inlines it into the HTML page returned by `/feedback-forms/{form_id}/iframe`
 embed path — see [Feedback Forms](feedback-forms.md) for the snippet to hand to
 customers.
 
+Operationally, that route now reads the aggregates table to confirm the form
+exists before rendering (#379), so it has a dependency it did not have: a
+DynamoDB failure answers `500`, which arrives as a raw API Gateway error page
+**inside the customer's frame** with no widget message and no retry, where the
+route previously served a working page having read nothing. It also answers 404
+for a form the table does not hold. Both are triaged from
+[Feedback Forms](feedback-forms.md#embedding-forms), which lists what makes an
+embed that used to work start showing an error frame; the read failure is
+counted by the `FeedbackFormReadFailed` metric.
+
 A second, stale copy used to be published to the CDN from
 `frontend/public/feedback-widget.js`. It called the retired `/feedback-form/*`
 (singular) routes and had no callers, so it was deleted. If an old integration

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -155,9 +155,20 @@ Customize the form appearance:
 Every route above that takes an id out of the URL checks its **format** before it
 reads or writes anything: an id that this service could not have issued answers
 `404 Form not found` without a lookup. Ids are up to 64 characters of letters,
-digits, `_` and `-`. Anything else is refused on its format, so ` abc123` is a 404
-— and it never addressed `abc123` in the first place: the space was always part of
-the key, so nothing that used to resolve has stopped resolving.
+digits, `_`, `-` and `.`. Anything else is refused on its format, so ` abc123` is a
+404 — and it never addressed `abc123` in the first place: the space was always part
+of the key, so no whitespace-bearing id has stopped resolving.
+
+`.` is inside that class so that a hand-seeded id written like a domain
+(`acme.website`) keeps working, but `.` and `..` **on their own** are refused: they
+are relative-path segments, so a client resolves them away when it joins them onto
+the API base and the request addresses a different resource than the one asked for.
+`...`, `.hidden-form` and `form.` are ordinary ids and are accepted.
+
+Ids containing anything else — `:`, `+`, `@`, `%`, `~` or a non-ASCII character —
+*did* resolve before the change that closed #379 and now answer 404 on all five of
+their routes. If you seeded or imported form ids by hand, the pre-upgrade scan in
+[CHANGELOG.md](../CHANGELOG.md) finds them; there is no compatibility shim.
 
 Two consequences are worth knowing if you integrate against these routes, both new
 in the change that closed #379:

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -168,11 +168,14 @@ are relative-path segments, so a client resolves them away when it joins them on
 the API base and the request addresses a different resource than the one asked for.
 `...`, `.hidden-form` and `form.` are ordinary ids and are accepted.
 
-Ids containing anything else — `:`, `+`, `@`, `%`, `~`, a non-ASCII character, or
-whitespace *within* the id — *did* resolve before the change that closed #379 and now
+Ids containing anything else — `:`, `+`, `@`, `%`, `~`, a non-ASCII character, or a
+space *within* the id — *did* resolve before the change that closed #379 and now
 answer 404 on all eight of their routes. If you seeded or imported form ids by hand,
 the pre-upgrade scan in [CHANGELOG.md](../CHANGELOG.md) finds them (it flags a space
-as readily as a colon); there is no compatibility shim.
+as readily as a colon); there is no compatibility shim. A *tab* or newline inside an
+id is the one shape that is not in scope, and not because the scan would miss it: the
+route's own capture group excludes both characters, so such an id never reached a
+handler and answered 404 before this change as well as after.
 
 Two consequences are worth knowing if you integrate against these routes, both new
 in the change that closed #379:

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -168,14 +168,21 @@ are relative-path segments, so a client resolves them away when it joins them on
 the API base and the request addresses a different resource than the one asked for.
 `...`, `.hidden-form` and `form.` are ordinary ids and are accepted.
 
-Ids containing anything else — `:`, `+`, `@`, `%`, `~`, a non-ASCII character, or a
-space *within* the id — *did* resolve before the change that closed #379 and now
-answer 404 on all eight of their routes. If you seeded or imported form ids by hand,
-the pre-upgrade scan in [CHANGELOG.md](../CHANGELOG.md) finds them (it flags a space
-as readily as a colon); there is no compatibility shim. A *tab* or newline inside an
-id is the one shape that is not in scope, and not because the scan would miss it: the
-route's own capture group excludes both characters, so such an id never reached a
-handler and answered 404 before this change as well as after.
+Ids containing anything else — `:`, `+`, `@`, `%`, `~`, a non-ASCII **letter or
+digit** such as `café` or `表単`, or a space *within* the id — *did* resolve before
+the change that closed #379 and now answer 404 on all eight of their routes. If you
+seeded or imported form ids by hand, the pre-upgrade scan in
+[CHANGELOG.md](../CHANGELOG.md) finds them (it flags a space as readily as a colon);
+there is no compatibility shim.
+
+Some shapes are **not** in scope, and not because the scan would miss them — it flags
+them too. They never reached a handler, so they answered 404 before this change as
+well as after: a *tab* or newline inside an id, and a non-ASCII character that is not
+a letter or digit (a symbol or punctuation mark like `€`, `—` or an emoji, or a
+non-ASCII space such as U+00A0 or U+3000). The route's own capture group is what
+excludes them: the only part of it that reaches beyond ASCII is `\w`, which is
+Unicode-aware for letters and digits alone. That is also why an ASCII space *is* in
+scope while a tab is not — the class lists a literal space, and `\w` covers neither.
 
 Two consequences are worth knowing if you integrate against these routes, both new
 in the change that closed #379:

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -168,12 +168,28 @@ are relative-path segments, so a client resolves them away when it joins them on
 the API base and the request addresses a different resource than the one asked for.
 `...`, `.hidden-form` and `form.` are ordinary ids and are accepted.
 
-Ids containing anything else — `:`, `+`, `@`, `%`, `~`, a non-ASCII **letter or
-number** such as `café`, `表単`, `hawaiʼi-form` or `surface-m²`, or a space *within* the
-id — *did* resolve before the change that closed #379 and now answer 404 on all eight
-of their routes. If you seeded or imported form ids by hand, the pre-upgrade scan in
-[CHANGELOG.md](../CHANGELOG.md) finds them (it flags a space as readily as a colon);
-there is no compatibility shim.
+Ids containing anything else *that the route admits* — `a:b`, `form(1)`, `a;b`, a
+non-ASCII **letter or number** such as `café`, `表単`, `hawaiʼi-form` or `surface-m²`,
+or a space *within* the id — *did* resolve before the change that closed #379 and now
+answer 404 on all eight of their routes. If you seeded or imported form ids by hand,
+the pre-upgrade scan in [CHANGELOG.md](../CHANGELOG.md) finds them (it flags a space
+as readily as a colon); there is no compatibility shim.
+
+Read "anything else" as a complement, not as a list of the memorable characters. For
+ASCII the in-scope set is the 24 characters the route's capture group admits and the
+validator does not — everything in `[-._~()'!*:@,;=+&$%<> \[\]{}|^]` except `-`, `.`
+and `_`:
+
+```
+space ! $ % & ' ( ) * + , : ; < = > @ [ ] ^ { | } ~
+```
+
+`:`, `+`, `@`, `%` and `~` are only the ones easy to remember. Seven of the others —
+`&`, `'`, `(`, `)`, `;`, `<`, `>` — are the characters the #379 payload is built from,
+so they read as attack syntax rather than as an id someone would seed; they resolved
+all the same, which makes `form(1)` and `a;b` as much in scope as `a:b`. Conversely
+`"`, `#`, `/`, `?`, `\` and `` ` `` are the printable-ASCII characters the route does
+**not** admit, so they belong with the tab and newline below.
 
 Some shapes are **not** in scope, and not because the scan would miss them — it flags
 them too. They never reached a handler, so they answered 404 before this change as
@@ -194,8 +210,12 @@ The categories matter because the ids an operator is most likely to misfile fall
 Hawaiian ʻokina U+02BB is the same category and equally in scope), a fraction or
 superscript (`half-½-price`, `surface-m²`) and a roman numeral (`section-Ⅷ`) are
 letters and numbers to `\w`, so those rows resolved and need renaming. `Lm` even holds
-five characters *named* as accents (U+02C6 MODIFIER LETTER CIRCUMFLEX ACCENT and
-U+02CA–U+02CF), so `formˆa` is in scope. **Out** of scope though they read as letters:
+characters *named* as accents — U+02C6 MODIFIER LETTER CIRCUMFLEX ACCENT, U+02CA,
+U+02CB, U+02CE, U+02CF and U+A788 MODIFIER LETTER LOW CIRCUMFLEX ACCENT — so `formˆa`
+is in scope. Those six rather than the range U+02CA–U+02CF, which sweeps in U+02CC
+MODIFIER LETTER LOW VERTICAL LINE and U+02CD MODIFIER LETTER LOW MACRON (also `Lm`,
+also in scope, but not accents) and misses U+A788. **Out** of scope though they read as
+letters:
 an id in a script that writes a vowel as a combining mark — Hindi `फॉर्म`, Thai
 `แบบฟอร์ม`, Arabic `نَموذج` — never matched a route, because the mark is `Mc`/`Mn` even
 where the base letter is `Lo`. (Precomposed Korean `피드백` is all `Lo` and did resolve.)

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -157,7 +157,10 @@ reads or writes anything: an id that this service could not have issued answers
 `404 Form not found` without a lookup. Ids are up to 64 characters of letters,
 digits, `_`, `-` and `.`. Anything else is refused on its format, so ` abc123` is a
 404 — and it never addressed `abc123` in the first place: the space was always part
-of the key, so no whitespace-bearing id has stopped resolving.
+of the key, so nothing that resolved through `abc123` has stopped resolving. That
+covers an id *addressed* with surrounding whitespace and nothing more: a form whose
+**stored** id contains a space, like `my form`, did resolve before and now answers
+404, so it is one of the ids the pre-upgrade scan below is for.
 
 `.` is inside that class so that a hand-seeded id written like a domain
 (`acme.website`) keeps working, but `.` and `..` **on their own** are refused: they
@@ -165,10 +168,11 @@ are relative-path segments, so a client resolves them away when it joins them on
 the API base and the request addresses a different resource than the one asked for.
 `...`, `.hidden-form` and `form.` are ordinary ids and are accepted.
 
-Ids containing anything else — `:`, `+`, `@`, `%`, `~` or a non-ASCII character —
-*did* resolve before the change that closed #379 and now answer 404 on all eight of
-their routes. If you seeded or imported form ids by hand, the pre-upgrade scan in
-[CHANGELOG.md](../CHANGELOG.md) finds them; there is no compatibility shim.
+Ids containing anything else — `:`, `+`, `@`, `%`, `~`, a non-ASCII character, or
+whitespace *within* the id — *did* resolve before the change that closed #379 and now
+answer 404 on all eight of their routes. If you seeded or imported form ids by hand,
+the pre-upgrade scan in [CHANGELOG.md](../CHANGELOG.md) finds them (it flags a space
+as readily as a colon); there is no compatibility shim.
 
 Two consequences are worth knowing if you integrate against these routes, both new
 in the change that closed #379:

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -177,20 +177,33 @@ there is no compatibility shim.
 
 Some shapes are **not** in scope, and not because the scan would miss them — it flags
 them too. They never reached a handler, so they answered 404 before this change as
-well as after: a *tab* or newline inside an id, and a non-ASCII **symbol, punctuation
-mark, combining accent or space** (`€`, `—`, `«`, an emoji, U+00A0, U+3000, or the
-`e` + U+0301 spelling of `é`). The route's own capture group is what excludes them:
-the only part of it that reaches beyond ASCII is `\w`, which matches any Unicode
-letter or number and nothing else. Read that as the `L*`/`N*` categories rather than
-as "letters and digits", because the surprising members are all **in** scope: a
-modifier letter (the `ʼ` of `hawaiʼi-form`, U+02BC, which is how an ʻokina is
-correctly spelled and looks like an apostrophe), a fraction or superscript
-(`half-½-price`, `surface-m²`) and a roman numeral (`section-Ⅷ`) are letters and
-numbers to `\w`, so those rows resolved and need renaming however much they read as
-punctuation. Misreading one of those as out of scope is the costly direction: the
-rename is skipped and the row 404s in production. That `\w` fact is also why an ASCII
-space *is* in scope while a tab is not — the class lists a literal space, and `\w`
-covers neither.
+well as after: a *tab* or newline inside an id, and any non-ASCII character that `\w`
+does not match. The route's own capture group is what excludes them: the only part of
+it that reaches beyond ASCII is `\w`, which matches any Unicode letter or number, plus
+`_`. Read both sides as Unicode CATEGORIES rather than as lists of glyphs — `\w` is
+`L*` and `N*`, and what it leaves out is marks (`M*`), symbols (`S*`), punctuation
+(`P*`), separators (`Z*`) and format characters (`C*`). So `€`, `°` and an emoji are
+symbols; `—` and `«` are punctuation; U+00A0 and U+3000 are separators; the `e` +
+U+0301 spelling of `é` is a mark; a zero-width joiner is a format character. (`_` is
+inside the validator's own class, so an id holding one is accepted and is in neither
+list; the other connector punctuation — U+FF3F, U+2040, U+203F — is outside `\w`.)
+
+The categories matter because the ids an operator is most likely to misfile fall on
+**both** sides. **In** scope though they read as punctuation: a modifier letter (the
+`ʼ` of `hawaiʼi-form`, U+02BC MODIFIER LETTER APOSTROPHE, visually an ASCII `'`; the
+Hawaiian ʻokina U+02BB is the same category and equally in scope), a fraction or
+superscript (`half-½-price`, `surface-m²`) and a roman numeral (`section-Ⅷ`) are
+letters and numbers to `\w`, so those rows resolved and need renaming. `Lm` even holds
+five characters *named* as accents (U+02C6 MODIFIER LETTER CIRCUMFLEX ACCENT and
+U+02CA–U+02CF), so `formˆa` is in scope. **Out** of scope though they read as letters:
+an id in a script that writes a vowel as a combining mark — Hindi `फॉर्म`, Thai
+`แบบฟอร์ม`, Arabic `نَموذج` — never matched a route, because the mark is `Mc`/`Mn` even
+where the base letter is `Lo`. (Precomposed Korean `피드백` is all `Lo` and did resolve.)
+Misreading an in-scope row as out of scope is the costly direction: the rename is
+skipped and the row 404s in production. Note too that the apostrophe glyphs straddle
+the line — `hawai’i-form` with U+2019 is punctuation and never resolved — so a printed
+row cannot be triaged by eye. That same `\w` fact is why an ASCII space *is* in scope
+while a tab is not: the class lists a literal space, and `\w` covers neither.
 
 Two consequences are worth knowing if you integrate against these routes, both new
 in the change that closed #379:

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -71,8 +71,10 @@ needs loading.
 
 It answers **404 both for a form id the service could not have issued and for one
 that is not in the table** — the same answer for either, so the response tells an
-anonymous caller nothing about which. All three public routes format-check the id
-before they read anything, so a malformed one is refused rather than looked up.
+anonymous caller nothing about which. Every route that takes a form id out of the
+URL format-checks it before reading anything, so a malformed one is refused rather
+than looked up; see
+[how a form id is checked](#how-a-form-id-is-checked-on-every-one-of-those-routes).
 
 The iframe route carries one extra concern, because it is the only route in the
 API that returns HTML, on the API's own origin, and its page is framed on
@@ -147,6 +149,30 @@ Customize the form appearance:
 | GET | `/feedback-forms/{id}/config` | Public config endpoint. **Unauthenticated** and fetched cross-origin by the embedded widget, so it returns only the widget-rendering fields, via a separate allowlist (`item_to_widget_config` in `lambda/api/feedback_form_handler.py`) rather than the projection the authenticated routes use. It never returns internal identifiers such as `project_id` / `document_id`. |
 | POST | `/feedback-forms/{id}/submit` | Submit feedback |
 | GET | `/feedback-forms/{id}/iframe` | Embeddable HTML page |
+
+### How a form id is checked, on every one of those routes
+
+Every route above that takes an id out of the URL checks its **format** before it
+reads or writes anything: an id that this service could not have issued answers
+`404 Form not found` without a lookup. Ids are up to 64 characters of letters,
+digits, `_` and `-`, with no surrounding whitespace — so ` abc123` is not a way of
+addressing `abc123`, it is a 404.
+
+Two consequences are worth knowing if you integrate against these routes, both new
+in the change that closed #379:
+
+- **`POST /{id}/submit` reports a bad id ahead of a bad body.** A request carrying
+  both a malformed id and an invalid body — an empty `text`, say — now answers
+  `404 Form not found` where it previously answered
+  `400 Feedback text is required`. This is deliberate: the id is wrong regardless
+  of what the body contains, and the check has to come first because this is the
+  one public route that enqueues work. A well-formed id with an empty `text` still
+  answers 400, unchanged.
+- **`PUT /{id}` no longer creates a form.** It updates an existing one and answers
+  `404 Form not found` for an id the table does not hold. Previously the underlying
+  write was an upsert, so a `PUT` to an unknown id silently created a record with
+  no `form_id` of its own — an unaddressable row in the list. Use
+  `POST /feedback-forms` to create a form; it mints the id.
 
 ### Rate limits on the three public routes
 

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -187,11 +187,14 @@ space ! $ % & ' ( ) * + , : ; < = > @ [ ] ^ { | } ~
 `:`, `+`, `@`, `%` and `~` are only the ones easy to remember. Seven of the others —
 `&`, `'`, `(`, `)`, `;`, `<`, `>` — are the characters the #379 fix turns on: the
 quote, parentheses and semicolon the payload breaks out with, plus the `<`, `>` and
-`&` that `_js_value` escapes for the HTML parser. (Three of those four do the
-breaking out in the payload itself — its `'` closes the string literal, its `)`
-closes the init call and its `;` starts a second statement — while its `(` belongs to
-the `alert(` it calls and the `x=('` it re-opens with.) So they read as attack syntax
-rather than as an id someone would seed; they resolved all the same, which makes
+`&` that `_js_value` escapes for the HTML parser. (Only the `'` does the breaking out
+in the payload itself, closing the string literal the template wrote. Its `(` is the
+`alert(` it calls and the `x=('` it re-opens with, and its `)` and `;` close a call
+and start a statement only in the bare-argument shape `init('<id>')` it was written
+for — this template puts the id inside an *object literal*, where they close nothing
+and leave the `<script>` block unparseable. The hole is real either way: the tailored
+`a',x:alert(1),y:'` uses no `)` or `;`, parses, and runs.) So they read as attack
+syntax rather than as an id someone would seed; they resolved all the same, which makes
 `form(1)` and `a;b` as much in scope as `a:b`. Conversely `"`, `#`, `/`, `?`, `\` and
 `` ` `` are the printable-ASCII characters the route does **not** admit, so they
 belong with the tab and newline below.

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -166,7 +166,7 @@ the API base and the request addresses a different resource than the one asked f
 `...`, `.hidden-form` and `form.` are ordinary ids and are accepted.
 
 Ids containing anything else — `:`, `+`, `@`, `%`, `~` or a non-ASCII character —
-*did* resolve before the change that closed #379 and now answer 404 on all five of
+*did* resolve before the change that closed #379 and now answer 404 on all eight of
 their routes. If you seeded or imported form ids by hand, the pre-upgrade scan in
 [CHANGELOG.md](../CHANGELOG.md) finds them; there is no compatibility shim.
 

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -155,8 +155,9 @@ Customize the form appearance:
 Every route above that takes an id out of the URL checks its **format** before it
 reads or writes anything: an id that this service could not have issued answers
 `404 Form not found` without a lookup. Ids are up to 64 characters of letters,
-digits, `_` and `-`, with no surrounding whitespace — so ` abc123` is not a way of
-addressing `abc123`, it is a 404.
+digits, `_` and `-`. Anything else is refused on its format, so ` abc123` is a 404
+— and it never addressed `abc123` in the first place: the space was always part of
+the key, so nothing that used to resolve has stopped resolving.
 
 Two consequences are worth knowing if you integrate against these routes, both new
 in the change that closed #379:

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -193,8 +193,10 @@ all the same, which makes `form(1)` and `a;b` as much in scope as `a:b`. Convers
 
 Some shapes are **not** in scope, and not because the scan would miss them — it flags
 them too. They never reached a handler, so they answered 404 before this change as
-well as after: a *tab* or newline inside an id, and any non-ASCII character that `\w`
-does not match. The route's own capture group is what excludes them: the only part of
+well as after: a *tab* or newline inside an id, one of the six printable-ASCII
+characters the route's class omits (`"`, `#`, `/`, `?`, `\`, `` ` ``), and any non-ASCII
+character that `\w` does not match. The route's own capture group is what excludes
+them: the only part of
 it that reaches beyond ASCII is `\w`, which matches any Unicode letter or number, plus
 `_`. Read both sides as Unicode CATEGORIES rather than as lists of glyphs — `\w` is
 `L*` and `N*`, and what it leaves out is marks (`M*`), symbols (`S*`), punctuation

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -191,20 +191,21 @@ all the same, which makes `form(1)` and `a;b` as much in scope as `a:b`. Convers
 `"`, `#`, `/`, `?`, `\` and `` ` `` are the printable-ASCII characters the route does
 **not** admit, so they belong with the tab and newline below.
 
-Some shapes are **not** in scope, and not because the scan would miss them — it flags
-them too. They never reached a handler, so they answered 404 before this change as
-well as after: a *tab* or newline inside an id, one of the six printable-ASCII
-characters the route's class omits (`"`, `#`, `/`, `?`, `\`, `` ` ``), and any non-ASCII
-character that `\w` does not match. The route's own capture group is what excludes
-them: the only part of
-it that reaches beyond ASCII is `\w`, which matches any Unicode letter or number, plus
-`_`. Read both sides as Unicode CATEGORIES rather than as lists of glyphs — `\w` is
-`L*` and `N*`, and what it leaves out is marks (`M*`), symbols (`S*`), punctuation
-(`P*`), separators (`Z*`) and format characters (`C*`). So `€`, `°` and an emoji are
-symbols; `—` and `«` are punctuation; U+00A0 and U+3000 are separators; the `e` +
-U+0301 spelling of `é` is a mark; a zero-width joiner is a format character. (`_` is
-inside the validator's own class, so an id holding one is accepted and is in neither
-list; the other connector punctuation — U+FF3F, U+2040, U+203F — is outside `\w`.)
+Some shapes are **not** in scope, and not because the scan would miss them — it
+flags them too. They never reached a handler, so they answered 404 before this
+change as well as after: a *tab* or newline inside an id, one of the six
+printable-ASCII characters the route's class omits (`"`, `#`, `/`, `?`, a
+backslash or a backtick), and any non-ASCII character that `\w` does not match.
+The route's own capture group is what excludes them: the only part of it that
+reaches beyond ASCII is `\w`, which matches any Unicode letter or number, plus
+`_`. Read both sides as Unicode CATEGORIES rather than as lists of glyphs — `\w`
+is `L*` and `N*`, and what it leaves out is marks (`M*`), symbols (`S*`),
+punctuation (`P*`), separators (`Z*`) and format characters (`C*`). So `€`, `°`
+and an emoji are symbols; `—` and `«` are punctuation; U+00A0 and U+3000 are
+separators; the `e` + U+0301 spelling of `é` is a mark; a zero-width joiner is a
+format character. (`_` is inside the validator's own class, so an id holding one
+is accepted and is in neither list; the other connector punctuation — U+FF3F,
+U+2040, U+203F — is outside `\w`.)
 
 The categories matter because the ids an operator is most likely to misfile fall on
 **both** sides. **In** scope though they read as punctuation: a modifier letter (the

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -69,6 +69,16 @@ The iframe route returns a self-contained HTML page: the Lambda inlines
 with the form's `config` and `submit` endpoints already wired, so nothing else
 needs loading.
 
+It answers **404 both for a form id the service could not have issued and for one
+that is not in the table** — the same answer for either, so the response tells an
+anonymous caller nothing about which. This is the only route in the API that
+returns HTML, on the API's own origin, and its page is framed on third-party
+sites, so the id is format-checked before any read and every value written into
+the page's script is serialized with `json.dumps` rather than quoted by hand
+(issue #379). If an embed that used to work starts showing an error frame, check
+that the form still exists before suspecting the
+[rate limits](#rate-limits-on-the-three-public-routes).
+
 There is no standalone `widget.js` script to load. That path is registered
 nowhere — not by the handler and not by the API — so a
 `<script src=".../widget.js">` tag never reaches the application at all and gets
@@ -143,8 +153,9 @@ knowing before you embed the widget, because they are observable from your page:
 
 `submit` is the tighter one because each submission enqueues a record that drives
 Comprehend, Translate and a Bedrock model invocation downstream. The two reads are
-cheap — one `get_item`, and a static HTML render — so they are held at the higher
-pair, sized for widget page-view traffic rather than for submissions.
+cheap — one `get_item` each, and for `iframe` a static HTML render on top of it —
+so they are held at the higher pair, sized for widget page-view traffic rather
+than for submissions.
 
 These figures are **pinned against the synthesized template** by a lockstep case in
 `voc-datalake/lib/stacks/api-stack.test.ts`, so tuning the numbers in `api-stack.ts`

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -71,13 +71,36 @@ needs loading.
 
 It answers **404 both for a form id the service could not have issued and for one
 that is not in the table** — the same answer for either, so the response tells an
-anonymous caller nothing about which. This is the only route in the API that
-returns HTML, on the API's own origin, and its page is framed on third-party
-sites, so the id is format-checked before any read and every value written into
-the page's script is serialized with `json.dumps` rather than quoted by hand
-(issue #379). If an embed that used to work starts showing an error frame, check
-that the form still exists before suspecting the
-[rate limits](#rate-limits-on-the-three-public-routes).
+anonymous caller nothing about which. All three public routes format-check the id
+before they read anything, so a malformed one is refused rather than looked up.
+
+The iframe route carries one extra concern, because it is the only route in the
+API that returns HTML, on the API's own origin, and its page is framed on
+third-party sites: every value written into that page's script is serialized with
+`json.dumps` rather than quoted by hand, **and** the characters the HTML parser
+acts on (`<`, `>`, `&`) are escaped on top of that — a `</script>` sequence ends
+the script element even inside a JavaScript string, which serializing alone does
+not prevent (issue #379). If you are extending the page, reaching for
+`json.dumps` is half the mechanism; `_js_value` in
+`voc-datalake/lambda/api/feedback_form_handler.py` is the one place to emit a
+value from, and its docstring says why.
+
+If an embed that used to work starts showing an error frame, check that the form
+still exists before suspecting the
+[rate limits](#rate-limits-on-the-three-public-routes). Two other causes to know
+about:
+
+- **The page now depends on a table read.** It confirms the form exists before
+  rendering, so a DynamoDB failure answers `500` — a raw API Gateway error page
+  inside the frame — where the route previously served a working page having read
+  nothing.
+- **The page sets a Content-Security-Policy.** It permits inline script and
+  style, and network access to the API's own origin, which is everything the
+  widget uses; it names no `img-src`, `font-src` or `frame-src`, so an asset added
+  to the widget later would be blocked until the policy names it. It deliberately
+  sets **no `frame-ancestors` and no `X-Frame-Options`**, because either would
+  refuse the embed this route exists for — if a proxy or CDN in front of the API
+  adds one, the frame will be blank on every customer site.
 
 There is no standalone `widget.js` script to load. That path is registered
 nowhere — not by the handler and not by the API — so a

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -169,20 +169,28 @@ the API base and the request addresses a different resource than the one asked f
 `...`, `.hidden-form` and `form.` are ordinary ids and are accepted.
 
 Ids containing anything else — `:`, `+`, `@`, `%`, `~`, a non-ASCII **letter or
-digit** such as `café` or `表単`, or a space *within* the id — *did* resolve before
-the change that closed #379 and now answer 404 on all eight of their routes. If you
-seeded or imported form ids by hand, the pre-upgrade scan in
+number** such as `café`, `表単`, `hawaiʼi-form` or `surface-m²`, or a space *within* the
+id — *did* resolve before the change that closed #379 and now answer 404 on all eight
+of their routes. If you seeded or imported form ids by hand, the pre-upgrade scan in
 [CHANGELOG.md](../CHANGELOG.md) finds them (it flags a space as readily as a colon);
 there is no compatibility shim.
 
 Some shapes are **not** in scope, and not because the scan would miss them — it flags
 them too. They never reached a handler, so they answered 404 before this change as
-well as after: a *tab* or newline inside an id, and a non-ASCII character that is not
-a letter or digit (a symbol or punctuation mark like `€`, `—` or an emoji, or a
-non-ASCII space such as U+00A0 or U+3000). The route's own capture group is what
-excludes them: the only part of it that reaches beyond ASCII is `\w`, which is
-Unicode-aware for letters and digits alone. That is also why an ASCII space *is* in
-scope while a tab is not — the class lists a literal space, and `\w` covers neither.
+well as after: a *tab* or newline inside an id, and a non-ASCII **symbol, punctuation
+mark, combining accent or space** (`€`, `—`, `«`, an emoji, U+00A0, U+3000, or the
+`e` + U+0301 spelling of `é`). The route's own capture group is what excludes them:
+the only part of it that reaches beyond ASCII is `\w`, which matches any Unicode
+letter or number and nothing else. Read that as the `L*`/`N*` categories rather than
+as "letters and digits", because the surprising members are all **in** scope: a
+modifier letter (the `ʼ` of `hawaiʼi-form`, U+02BC, which is how an ʻokina is
+correctly spelled and looks like an apostrophe), a fraction or superscript
+(`half-½-price`, `surface-m²`) and a roman numeral (`section-Ⅷ`) are letters and
+numbers to `\w`, so those rows resolved and need renaming however much they read as
+punctuation. Misreading one of those as out of scope is the costly direction: the
+rename is skipped and the row 404s in production. That `\w` fact is also why an ASCII
+space *is* in scope while a tab is not — the class lists a literal space, and `\w`
+covers neither.
 
 Two consequences are worth knowing if you integrate against these routes, both new
 in the change that closed #379:

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -185,9 +185,11 @@ space ! $ % & ' ( ) * + , : ; < = > @ [ ] ^ { | } ~
 ```
 
 `:`, `+`, `@`, `%` and `~` are only the ones easy to remember. Seven of the others —
-`&`, `'`, `(`, `)`, `;`, `<`, `>` — are the characters the #379 payload is built from,
-so they read as attack syntax rather than as an id someone would seed; they resolved
-all the same, which makes `form(1)` and `a;b` as much in scope as `a:b`. Conversely
+`&`, `'`, `(`, `)`, `;`, `<`, `>` — are the characters the #379 fix turns on: the
+quote, parentheses and semicolon the payload closes its handwritten string literal
+with, plus the `<`, `>` and `&` that `_js_value` escapes for the HTML parser. So they
+read as attack syntax rather than as an id someone would seed; they resolved all the
+same, which makes `form(1)` and `a;b` as much in scope as `a:b`. Conversely
 `"`, `#`, `/`, `?`, `\` and `` ` `` are the printable-ASCII characters the route does
 **not** admit, so they belong with the tab and newline below.
 

--- a/docs/feedback-forms.md
+++ b/docs/feedback-forms.md
@@ -186,12 +186,15 @@ space ! $ % & ' ( ) * + , : ; < = > @ [ ] ^ { | } ~
 
 `:`, `+`, `@`, `%` and `~` are only the ones easy to remember. Seven of the others —
 `&`, `'`, `(`, `)`, `;`, `<`, `>` — are the characters the #379 fix turns on: the
-quote, parentheses and semicolon the payload closes its handwritten string literal
-with, plus the `<`, `>` and `&` that `_js_value` escapes for the HTML parser. So they
-read as attack syntax rather than as an id someone would seed; they resolved all the
-same, which makes `form(1)` and `a;b` as much in scope as `a:b`. Conversely
-`"`, `#`, `/`, `?`, `\` and `` ` `` are the printable-ASCII characters the route does
-**not** admit, so they belong with the tab and newline below.
+quote, parentheses and semicolon the payload breaks out with, plus the `<`, `>` and
+`&` that `_js_value` escapes for the HTML parser. (Three of those four do the
+breaking out in the payload itself — its `'` closes the string literal, its `)`
+closes the init call and its `;` starts a second statement — while its `(` belongs to
+the `alert(` it calls and the `x=('` it re-opens with.) So they read as attack syntax
+rather than as an id someone would seed; they resolved all the same, which makes
+`form(1)` and `a;b` as much in scope as `a:b`. Conversely `"`, `#`, `/`, `?`, `\` and
+`` ` `` are the printable-ASCII characters the route does **not** admit, so they
+belong with the tab and newline below.
 
 Some shapes are **not** in scope, and not because the scan would miss them — it
 flags them too. They never reached a handler, so they answered 404 before this

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -171,12 +171,16 @@ FORM_ID_LENGTH = 8
 # what fails if it is dropped again, and the remaining exclusions that a route
 # COULD resolve (`:`, `+`, `@`, `%`, a non-ASCII letter or NUMBER, and a space
 # inside an id) are named to an operator with a pre-upgrade scan in CHANGELOG.md's
-# upgrade notes, since for those the 404 is real. A non-ASCII SYMBOL, punctuation
-# mark, combining accent or space is not on that list and is not the scan's to
-# find: the route's capture group reaches past ASCII only through `\w`, which
-# matches any Unicode letter or number — every `L*` and `N*` category, so a modifier
-# letter (`hawaiʼi-form`) and a fraction (`surface-m²`) are in scope despite reading
-# as punctuation — so `café` resolved while `form€a` never matched a route at all.
+# upgrade notes, since for those the 404 is real. A non-ASCII character that `\w`
+# does NOT match is not on that list and is not the scan's to find: the route's
+# capture group reaches past ASCII only through `\w`, which matches any Unicode
+# letter or number — every `L*` and `N*` category, plus `_` — so what it leaves out
+# is marks, symbols, punctuation, separators and format characters. Read both sides
+# as CATEGORIES, because the misfiling risk runs both ways: a modifier letter
+# (`hawaiʼi-form`, and the accent-NAMED U+02C6/U+02CA-U+02CF are `Lm` too) and a
+# fraction (`surface-m²`) are in scope despite reading as punctuation, while a script
+# writing a vowel as a combining mark (Hindi `फॉर्म`) is out of scope despite reading
+# as letters. So `café` resolved while `form€a` never matched a route at all.
 #
 # The `(?!\.{1,2}\Z)` in front of the class is what makes admitting `.` safe, and
 # it is about URL RESOLUTION rather than about DynamoDB: '.' and '..' are the
@@ -276,26 +280,34 @@ def _validated_form_id(raw: Any) -> str | None:
     That list is narrower than "everything non-ASCII" and than "whitespace", and
     both narrowings come from ONE fact about the route rather than about this
     pattern: powertools' capture group reaches past ASCII only through `\\w`, which
-    matches any Unicode letter or number, and it lists a literal space but no other
-    whitespace. So `'café'` and `'my form'` matched a route and are the scan's to
-    find, while a tab, a newline, and a non-ASCII SYMBOL, PUNCTUATION MARK,
-    COMBINING ACCENT or space (`'form€a'`, `'form\\xa0a'`, `'form«a'`, an NFD
-    `'cafe\\u0301'`) never matched one at all — those rows answered 404 before this
-    change as well as after, so they are unreachable rather than
-    reachable-then-orphaned. Telling an operator to rename one would be renaming a
-    row that was never served.
+    matches any Unicode letter or number plus `_`, and it lists a literal space but
+    no other whitespace. So `'café'` and `'my form'` matched a route and are the
+    scan's to find, while a tab, a newline, and any non-ASCII character `\\w` does
+    NOT match (`'form€a'`, `'form\\xa0a'`, `'form«a'`, an NFD `'cafe\\u0301'`) never
+    matched one at all — those rows answered 404 before this change as well as after,
+    so they are unreachable rather than reachable-then-orphaned. Telling an operator
+    to rename one would be renaming a row that was never served.
     `test_the_scan_is_scoped_to_ids_a_route_could_actually_resolve` pins the whole
     split off the live resolver, since it is what bounds the operator scan's reach.
 
-    Read `\\w` as the `L*` and `N*` CATEGORIES rather than as "letters and digits",
-    because the difference falls on the shapes an operator is most likely to
-    misfile: a modifier letter (`'hawaiʼi-form'`, whose `ʼ` is U+02BC — how an
-    ʻokina is correctly spelled, and visually an apostrophe), a fraction or
-    superscript (`'half-½-price'`, `'surface-m²'`) and a roman numeral
-    (`'section-Ⅷ'`) are all `\\w`, hence routable, hence the scan's to find, however
-    much they read as punctuation. That is the ONE direction of this split with a
-    real cost: over-reporting wastes a rename, but under-reporting means an operator
-    reads a printed row as out of scope, skips it, and it 404s in production.
+    Read BOTH sides as Unicode CATEGORIES rather than as "letters and digits" versus
+    a list of glyphs: `\\w` is `L*` and `N*` (plus `_`), and what it excludes is
+    marks (`M*`), symbols (`S*`), punctuation (`P*`), separators (`Z*`) and format
+    characters (`C*`). The difference falls on the shapes an operator is most likely
+    to misfile, and it runs in BOTH directions. Routable, hence the scan's to find,
+    however much they read as punctuation: a modifier letter (`'hawaiʼi-form'`, whose
+    `ʼ` is U+02BC MODIFIER LETTER APOSTROPHE, visually an ASCII quote — as is the
+    Hawaiian ʻokina, U+02BB, which is the same category; and note `Lm` holds five
+    characters NAMED as accents, U+02C6 and U+02CA-U+02CF, so `'formˆa'` is in scope
+    too), a fraction or superscript (`'half-½-price'`, `'surface-m²'`) and a roman
+    numeral (`'section-Ⅷ'`). Unroutable, hence NOT the scan's, however much they read
+    as letters: a script that writes a vowel as a combining mark, so Hindi
+    `'फॉर्म'`, Thai `'แบบฟอร์ม'` and Arabic `'نَموذج'` never matched a route because the
+    mark is `Mc`/`Mn` even where the base character is `Lo` (precomposed Korean
+    `'피드백'` is all `Lo`, and did resolve). That is the ONE direction of this split
+    with a real cost: over-reporting wastes a rename, but under-reporting means an
+    operator reads a printed row as out of scope, skips it, and it 404s in
+    production.
 
     Interior whitespace belongs in that list rather than under the `.strip()`
     argument below, and the two are easy to conflate: that argument is about an id

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -515,16 +515,53 @@ def list_forms():
 @app.post("/feedback-forms")
 @tracer.capture_method
 def create_form():
-    """Create a new feedback form."""
+    """Create a new feedback form.
+
+    The other half of `update_form`'s condition, and here for the mirror-image
+    reason: PutItem OVERWRITES an item at the same key as silently as UpdateItem
+    creates one. `attribute_not_exists(sk)` makes this write a create only, so a
+    minted id that collides with a form already stored is refused instead of
+    replacing it — a customer's live form, its `enabled` flag, its theme and its
+    link to a prioritization document, gone with a 200 and a response echoing the
+    NEW record. The idiom is `projects_handler`'s, at its own two creates.
+
+    Reachable only through a collision, which is why this is a guard rather than a
+    fix for something observed: the id is never taken from the caller
+    (`build_form_item` mints it), so two `_minted_form_id()` draws would have to
+    agree — a birthday problem over `FORM_ID_LENGTH` hex characters, 32 bits at
+    the current 8. Small at a few thousand forms, and not zero. The constant's
+    comment says it is safe to RAISE, and this condition is what keeps that a free
+    choice rather than something eventually forced: it makes the collision a
+    refused request instead of a silent loss, whatever the width.
+
+    A collision is the SERVER's fault, not the caller's, so it answers 500 with
+    the generic message rather than a 4xx — the client did nothing wrong and
+    retrying is the right move, since the retry mints a different id.
+    `test_a_create_that_would_overwrite_a_stored_form_is_refused` pins it.
+    """
     body = app.current_event.json_body or {}
     # Link fields are validated inside build_form_item, structurally.
     item = build_form_item(body)
-    
+
     try:
-        aggregates_table.put_item(Item=item)
+        aggregates_table.put_item(
+            Item=item,
+            # See the docstring: this is what makes the route a create rather than
+            # a blind overwrite of whatever the minted id happens to name.
+            ConditionExpression='attribute_not_exists(sk)',
+        )
         logger.info(f"Created feedback form: {item['form_id']}")
         return {'success': True, 'form': item_to_form(item)}
     except Exception as e:
+        if _is_conditional_check_failure(e):
+            # A minted id that is already taken. Logged distinctly because it is
+            # the one failure here that says something about FORM_ID_LENGTH rather
+            # than about DynamoDB, and it would otherwise be invisible.
+            logger.error(
+                f"Refused to overwrite existing form {item['form_id']}: "
+                'the minted id collided with a stored one'
+            )
+            raise ServiceError('Failed to create form') from e
         logger.error(f"Error creating form: {e}")
         raise ServiceError('Failed to create form')
 

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -129,9 +129,16 @@ LINK_FIELDS = ('project_id', 'document_id')
 # Form identifier
 # ============================================
 #
-# A form id is MINTED by this module and never taken from a request body — see
-# `_minted_form_id`, the one place the format is decided. Everything below is
-# derived from that one place so the two cannot drift.
+# Two SEPARATE decisions, and they are deliberately not derived from each other:
+# `_minted_form_id` is the one place the format this service ISSUES is decided,
+# and `_FORM_ID_PATTERN` is a deliberately WIDER bound on what a caller may hand
+# back. Narrowing the mint therefore does not tighten the validator, and is not
+# meant to — the width is argued below and pinned in both directions by tests
+# (`test_a_hand_seeded_form_id_is_still_embeddable` for the width,
+# `test_an_over_long_id_is_refused_without_a_read` for the bound). The ONE
+# coupling that must hold — the service can always serve a page for an id it
+# issued — is checked by `test_a_minted_id_always_satisfies_the_validator`
+# rather than assumed here.
 FORM_ID_LENGTH = 8
 
 # The shape a caller-supplied form id has to have before it reaches a read or a
@@ -147,6 +154,9 @@ FORM_ID_LENGTH = 8
 # the parenthesis, the semicolon, '<', '>', '&', the backslash — is outside it.
 # Powertools' dynamic-route capture group admits all of those (issue #379), so
 # this pattern, not the route, is what bounds them.
+#
+# No whitespace either, and that is a choice rather than an oversight: see
+# `_validated_form_id`.
 FORM_ID_MAX_LENGTH = 64
 _FORM_ID_PATTERN = re.compile(rf'^[0-9A-Za-z_-]{{1,{FORM_ID_MAX_LENGTH}}}$')
 
@@ -154,22 +164,34 @@ _FORM_ID_PATTERN = re.compile(rf'^[0-9A-Za-z_-]{{1,{FORM_ID_MAX_LENGTH}}}$')
 def _minted_form_id() -> str:
     """A new form's id: the first `FORM_ID_LENGTH` hex characters of a uuid4.
 
-    The only place a form id is created. Named so the validator below can be
-    described against one definition rather than against a literal repeated at
-    the two sites that used to spell it out.
+    The only place a form id is created — it is never taken from a request body.
+
+    `.hex` rather than `str(uuid4())[:n]`, so the constant above is safe to
+    RAISE: the dashed form puts a '-' at offset 8, so slicing 9 characters of it
+    would mint an id ending in a separator, and slicing 14 would mint one holding
+    a '-' that the reader has no reason to expect. `.hex` is 32 hex characters
+    with no separators, so every length from 1 to 32 yields the format this
+    docstring claims.
     """
-    return str(uuid.uuid4())[:FORM_ID_LENGTH]
+    return uuid.uuid4().hex[:FORM_ID_LENGTH]
 
 
 def _validated_form_id(raw: Any) -> str | None:
     """The form id from the URL, or None if it cannot be one of ours.
+
+    THE authoritative statement of why this exists; the call sites point here
+    rather than restating it.
 
     Modelled on `ballots_handler._validated_session_id`, for the same two
     reasons: a format check before any read means a probe for
     `/feedback-forms/admin` or a 1 MB path segment costs no DynamoDB call, and
     None rather than a raise because every caller answers the same 404 — telling
     an anonymous caller "malformed" apart from "absent" only helps someone
-    probing.
+    probing. Like that sibling, it is applied at EVERY route that takes a form id
+    out of the URL and turns it into a key: `/config`, `/submit`, `/iframe`,
+    `/submissions` and `/stats` (the last two through `_load_form_for_query`), so
+    the cost argument above holds everywhere it is stated rather than on one route
+    only.
 
     The defect this closes (#379) is narrower than "unvalidated input", and worth
     stating so nobody relaxes the pattern on the grounds that the render escapes
@@ -177,13 +199,25 @@ def _validated_form_id(raw: Any) -> str | None:
     pattern Powertools compiles accepts `'`, `)` and `;`, so
     `a');alert(document.domain);x=('` matched the route and used to be rendered
     into a `<script>` block verbatim. Validation bounds what reaches the handler;
-    the structural serialization at the render site bounds what a value can do
-    once there. Both, because either alone leaves the other's failure fatal.
+    the structural serialization at the render site (`_js_value`) bounds what a
+    value can do once there. Both, because either alone leaves the other's
+    failure fatal.
+
+    NOT `.strip()`ed, which is where this parts company with the sibling it is
+    modelled on. There a session id is a 128-bit token and the leniency is
+    inconsequential; here it would make `' deadbeef'` an alias for `'deadbeef'`,
+    so every whitespace variant of an id would be a distinct URL serving
+    byte-identical HTML. That is a cache-key multiplier for the `Cache-Control`
+    follow-up recorded in `lib/stacks/api-stack.ts`, whose whole premise is that
+    the response is a pure function of the id and the host — with a strip it
+    would be a pure function of the STRIPPED id while the cache keys on the raw
+    path. An exact id keeps the URL-to-content mapping one-to-one, and no id this
+    service mints has whitespace to forgive
+    (`test_an_id_padded_with_whitespace_is_not_an_alias_for_the_id`).
     """
     if not isinstance(raw, str):
         return None
-    form_id = raw.strip()
-    return form_id if _FORM_ID_PATTERN.match(form_id) else None
+    return raw if _FORM_ID_PATTERN.match(raw) else None
 
 
 def validate_link_fields(body: dict) -> None:
@@ -554,10 +588,20 @@ def delete_form(form_id: str):
 @app.get("/feedback-forms/<form_id>/config")
 @tracer.capture_method
 def get_form_config_by_id(form_id: str):
-    """Get form config for widget (public endpoint)."""
+    """Get form config for widget (public endpoint).
+
+    The id is format-checked before the read, for the reason `_validated_form_id`
+    gives: this route is unauthenticated and its path segment is unbounded, so a
+    probe for `/feedback-forms/admin` or a megabyte of path must not buy a
+    DynamoDB call. Same 404 either way, so the refusal says no more than "no such
+    form" does.
+    """
+    validated = _validated_form_id(form_id)
+    if not validated:
+        raise NotFoundError('Form not found')
     try:
         response = aggregates_table.get_item(
-            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
         )
         item = response.get('Item')
         
@@ -576,17 +620,28 @@ def get_form_config_by_id(form_id: str):
 @app.post("/feedback-forms/<form_id>/submit")
 @tracer.capture_method
 def submit_form_feedback(form_id: str):
-    """Submit feedback to a specific form."""
+    """Submit feedback to a specific form.
+
+    The id is format-checked before the read (`_validated_form_id`), and BEFORE
+    the body is looked at: the write side of the public trio is the one route here
+    that also enqueues, so a form id that cannot be one of ours must not reach
+    either the table or the queue. The validated value is used everywhere below —
+    the key, `source_channel`, the metadata and `_anchor_form_brand` — so what is
+    stored is what was checked.
+    """
+    validated = _validated_form_id(form_id)
+    if not validated:
+        raise NotFoundError('Form not found')
     body = app.current_event.json_body or {}
-    
+
     text = body.get('text', '').strip()
     if not text:
         raise ValidationError('Feedback text is required')
-    
+
     # Get form config
     try:
         response = aggregates_table.get_item(
-            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
         )
         form = response.get('Item')
         
@@ -618,14 +673,14 @@ def submit_form_feedback(form_id: str):
     if not form.get('brand_name') and effective_brand:
         # Store it, so this form stops depending on the environment variable —
         # see _anchor_form_brand.
-        _anchor_form_brand(form_id, effective_brand)
+        _anchor_form_brand(validated, effective_brand)
 
     now = datetime.now(timezone.utc)
     feedback_id = str(uuid.uuid4())
 
     # Build normalized record with category routing
     metadata = {
-        'form_id': form_id,
+        'form_id': validated,
         'form_name': form.get('name', ''),
         'form_version': '2.0',
     }
@@ -639,7 +694,7 @@ def submit_form_feedback(form_id: str):
     normalized_record = {
         'id': feedback_id,
         'source_platform': 'feedback_form',
-        'source_channel': f'form_{form_id}',
+        'source_channel': f'form_{validated}',
         'text': text,
         'rating': body.get('rating'),
         'created_at': now.isoformat(),
@@ -659,7 +714,7 @@ def submit_form_feedback(form_id: str):
             QueueUrl=PROCESSING_QUEUE_URL,
             MessageBody=json.dumps(normalized_record, default=str)
         )
-        logger.info(f"Submitted feedback to form {form_id}: {feedback_id}")
+        logger.info(f"Submitted feedback to form {validated}: {feedback_id}")
         return {
             'success': True,
             'feedback_id': feedback_id,
@@ -693,11 +748,16 @@ def _js_value(value: Any) -> str:
     while making it inert to the parser above it.
 
     U+2028 and U+2029 need the same treatment (they terminate a JavaScript line
-    but not a JSON string) and get it for free: `json.dumps` defaults to
-    `ensure_ascii=True`, which escapes every non-ASCII character.
+    but not a JSON string) and get it from `ensure_ascii=True`, which escapes
+    every non-ASCII character. That is `json.dumps`'s default and is passed
+    EXPLICITLY anyway: it is load-bearing here rather than cosmetic, and
+    `ensure_ascii=False` is an inviting edit (it makes a non-ASCII value readable
+    in a debug dump) that would put those two characters back into the script
+    raw. `test_a_line_separator_cannot_end_the_statement` is what fails if it is
+    removed.
     """
     return (
-        json.dumps(value)
+        json.dumps(value, ensure_ascii=True)
         .replace('<', '\\u003c')
         .replace('>', '\\u003e')
         .replace('&', '\\u0026')
@@ -716,9 +776,26 @@ def _js_value(value: Any) -> str:
 # serializer above has nowhere to send anything.
 #
 # `style-src 'unsafe-inline'` is required by the page's own <style> block and by
-# the widget's `style="..."` attributes; `connect-src 'self'` is the widget's
+# the widget's `style.cssText` assignments; `connect-src 'self'` is the widget's
 # fetch of /config and /submit, which are on this origin by construction
 # (api_endpoint is built from this request's own host).
+#
+# Those three are what makes the page WORK, and `default-src 'none'` is the
+# fallback for everything not named — so deleting any one of them is a total,
+# silent failure of the product on a customer's site rather than a degraded page.
+# That is why the whole policy is pinned as a directive-to-sources mapping by
+# `test_the_policy_names_every_directive_the_page_needs_and_no_wildcard`, which
+# fails on a removal AND on a widening.
+#
+# There is deliberately NO `img-src`, `font-src` or `frame-src`: the widget
+# builds its UI from DOM elements, text and CSS only — no <img>, no `url(...)`,
+# no `data:` URI, no webfont — so `default-src 'none'` blocks nothing it asks
+# for. `form-action 'none'` is correct for the same kind of reason: the widget
+# submits through `fetch`, never through a <form>. Those are claims about
+# feedback-widget.js rather than about this dict, so they are derived from that
+# file by `test_the_widget_asks_for_no_asset_the_policy_would_block` instead of
+# being trusted here — the day the widget grows an icon, that test fails and
+# names the directive to add.
 #
 # `frame-ancestors` is deliberately absent, and that is the decision this route
 # turns on: it EXISTS to be framed on customers' sites (docs/feedback-forms.md),
@@ -745,23 +822,33 @@ def get_form_iframe(form_id: str):
     """Serve the HTML page a customer's site frames for one form.
 
     The only route in this API that answers with a document rather than JSON, on
-    the API's own origin, unauthenticated — which is why the two gates below come
-    before a single character of HTML is produced (#379):
+    the API's own origin, unauthenticated — which is why two gates come before a
+    single character of HTML is produced. `_validated_form_id` carries the
+    argument for the FORMAT gate and is not restated here; what is specific to
+    this route is the EXISTENCE gate below and the availability consequence of
+    having one (#379).
 
-    - The id must have the SHAPE of one of ours (`_validated_form_id`). Powertools'
-      dynamic-route capture group accepts `'`, `)` and `;`, so the route pattern
-      is no bound at all; without this, `a');alert(document.domain);x=('` matched
-      and was rendered into the script block below.
-    - The form must EXIST. This route used to read nothing, so any string matching
-      the capture group got a 200 and a page — unlike /config and /submit, which
-      404 an id the table does not have. Existence is checked through
-      `_load_form_for_query`, the same one-get_item lookup those routes' siblings
-      use, so a caller cannot mint an attacker-chosen page on this origin at all,
-      and a deleted form stops serving an embed that can only fail.
+    The form must EXIST. This route used to read nothing, so any string matching
+    the capture group got a 200 and a page — unlike /config and /submit, which
+    404 an id the table does not have. That is what let a caller mint an
+    attacker-chosen page on this origin without even needing a malformed id, and
+    it is why the check is here rather than left to the widget's own /config
+    fetch. `_load_form_for_query` is the same one-get_item lookup /stats and
+    /submissions make, so both gates answer the same 404 as every sibling.
 
-    Both answer the same 404, deliberately: a malformed id and an absent one are
-    indistinguishable to an anonymous caller, which is `_validated_form_id`'s
-    reasoning and `ballots_handler._validated_session_id`'s before it.
+    THE TRADE, because it is a new coupling and a reader hunting "why did every
+    embed go blank" needs to find it: reading anything means the route can now
+    fail. `_load_form_for_query` raises `ServiceError` if the get_item raises, so
+    an aggregates-table blip answers 500 here where this route previously served
+    a working page having read nothing — and a 500 on this route is a raw API
+    Gateway error page inside the customer's iframe, with no widget string and no
+    retry (the throttle comment in `lib/stacks/api-stack.ts` traces the same
+    symptom for a 429). Accepted rather than overlooked: a page served for a form
+    that may not exist is the defect being closed, and a page whose /config fetch
+    is about to fail against the same table has nothing to render anyway, so
+    failing at the frame is more honest than failing inside it. It is also
+    observable — `_load_form_for_query` emits `FeedbackFormReadFailed` — which is
+    what makes it a trade rather than a silent regression.
 
     Neither gate is trusted alone. Every value that reaches the script is built by
     `_js_value`, so the render is safe even if the pattern is later widened or the
@@ -865,7 +952,18 @@ def _load_form_for_query(form_id: str, read_failure_message: str) -> dict:
 
     Both failure modes previously produced HTTP 200 with total_submissions: 0 on
     the stats route, which is the exact defect issue #312 is about.
+
+    The FORMAT check is here rather than at each caller because this function is
+    the one read those routes make, so one call covers `/stats`, `/submissions`
+    and the iframe page's existence gate — `_validated_form_id`'s cost argument
+    then holds at every route that states it rather than at one. Callers keep
+    using their own `form_id` for anything else they build (`source_channel`,
+    the response's echo) with no risk of a split-brain, because the validator is
+    EXACT: it returns the string it was given or None, never a normalized
+    variant of it.
     """
+    if not _validated_form_id(form_id):
+        raise NotFoundError('Form not found')
     try:
         response = aggregates_table.get_item(
             Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -169,16 +169,25 @@ FORM_ID_LENGTH = 8
 # a tag or start a statement, so admitting it moves no character the #379
 # serializer depends on. `test_a_dotted_hand_seeded_form_id_still_resolves` is
 # what fails if it is dropped again, and the remaining exclusions that a route
-# COULD resolve (`:`, `+`, `@`, `%`, a non-ASCII letter or NUMBER, and a space
-# inside an id) are named to an operator with a pre-upgrade scan in CHANGELOG.md's
-# upgrade notes, since for those the 404 is real. A non-ASCII character that `\w`
-# does NOT match is not on that list and is not the scan's to find: the route's
-# capture group reaches past ASCII only through `\w`, which matches any Unicode
-# letter or number — every `L*` and `N*` category, plus `_` — so what it leaves out
-# is marks, symbols, punctuation, separators and format characters. Read both sides
-# as CATEGORIES, because the misfiling risk runs both ways: a modifier letter
-# (`hawaiʼi-form`, and the accent-NAMED U+02C6/U+02CA-U+02CF are `Lm` too) and a
-# fraction (`surface-m²`) are in scope despite reading as punctuation, while a script
+# COULD resolve are named to an operator with a pre-upgrade scan in CHANGELOG.md's
+# upgrade notes, since for those the 404 is real. Those exclusions are a SET rather
+# than a short list, and stating it as a complement is the only way to state it
+# without being short: in scope is any character outside this pattern's own
+# `[0-9A-Za-z_.-]` that the ROUTE admits, which for ASCII is everything in
+# `[-._~()'!*:@,;=+&$%<> \[\]{}|^]` except `-`, `.` and `_` — 24 characters, of
+# which `:`, `+`, `@`, `%`, `~` and a space inside an id are only the illustrations.
+# Seven of the other eighteen (`&`, `'`, `(`, `)`, `;`, `<`, `>`) are the #379
+# payload's own characters, which is exactly why a hand-written list omits them.
+# `"`, `#`, `/`, `?`, `\` and a backtick are the printable-ASCII exceptions: the
+# route admits none of them, so they belong with the tab and the newline below.
+# A non-ASCII character that `\w` does NOT match is likewise not the scan's to
+# find: the route's capture group reaches past ASCII only through `\w`, which
+# matches any Unicode letter or number — every `L*` and `N*` category, plus `_` —
+# so what it leaves out is marks, symbols, punctuation, separators and format
+# characters. Read both sides as CATEGORIES, because the misfiling risk runs both
+# ways: a modifier letter (`hawaiʼi-form`, and characters NAMED as accents are `Lm`
+# too — U+02C6, U+02CA, U+02CB, U+02CE, U+02CF and U+A788) and a fraction
+# (`surface-m²`) are in scope despite reading as punctuation, while a script
 # writing a vowel as a combining mark (Hindi `फॉर्म`) is out of scope despite reading
 # as letters. So `café` resolved while `form€a` never matched a route at all.
 #
@@ -271,13 +280,24 @@ def _validated_form_id(raw: Any) -> str | None:
     routes, and for a hand-seeded row whose id resolved before, that is a reachable
     record becoming unreachable rather than a probe being refused. `.` is admitted
     for exactly that reason (see the pattern above). The characters still outside
-    the class — `:`, `+`, `@`, `%`, `~`, a non-ASCII LETTER OR NUMBER such as
-    `'café'`, and a SPACE within an id such as `'my form'` — are a deliberate
-    narrowing rather than an oversight, and the upgrade path is an operator scan of
-    the aggregates table for `FORM#` ids outside the class, written down in
-    CHANGELOG.md's upgrade notes rather than left for whoever reads the 404.
+    the class are a deliberate narrowing rather than an oversight, and the upgrade
+    path is an operator scan of the aggregates table for `FORM#` ids outside the
+    class, written down in CHANGELOG.md's upgrade notes rather than left for whoever
+    reads the 404.
 
-    That list is narrower than "everything non-ASCII" and than "whitespace", and
+    That set is stated as a COMPLEMENT rather than as a list, because a list of it
+    has been short every time it was written by hand: in scope is any character
+    outside this pattern's `[0-9A-Za-z_.-]` that the ROUTE admits, which for ASCII
+    is every character of `[-._~()'!*:@,;=+&$%<> \\[\\]{}|^]` except `-`, `.` and `_`
+    — 24 of them, where `:`, `+`, `@`, `%`, `~` and a SPACE within an id such as
+    `'my form'` are illustrations and not the set. Seven of the eighteen unnamed
+    ones (`&`, `'`, `(`, `)`, `;`, `<`, `>`) are the #379 payload's own characters,
+    which is why they are the ones a hand-written list drops. On the other side,
+    `"`, `#`, `/`, `?`, a backslash and a backtick are the printable-ASCII
+    characters the route does NOT admit, so they sit with the tab and the newline
+    below rather than in the scan.
+
+    That set is narrower than "everything non-ASCII" and than "whitespace", and
     both narrowings come from ONE fact about the route rather than about this
     pattern: powertools' capture group reaches past ASCII only through `\\w`, which
     matches any Unicode letter or number plus `_`, and it lists a literal space but
@@ -297,9 +317,13 @@ def _validated_form_id(raw: Any) -> str | None:
     to misfile, and it runs in BOTH directions. Routable, hence the scan's to find,
     however much they read as punctuation: a modifier letter (`'hawaiʼi-form'`, whose
     `ʼ` is U+02BC MODIFIER LETTER APOSTROPHE, visually an ASCII quote — as is the
-    Hawaiian ʻokina, U+02BB, which is the same category; and note `Lm` holds five
-    characters NAMED as accents, U+02C6 and U+02CA-U+02CF, so `'formˆa'` is in scope
-    too), a fraction or superscript (`'half-½-price'`, `'surface-m²'`) and a roman
+    Hawaiian ʻokina, U+02BB, which is the same category; and note that characters
+    NAMED as accents are `Lm` too, so `'formˆa'` is in scope. Those are U+02C6,
+    U+02CA, U+02CB, U+02CE, U+02CF and U+A788, spelled out rather than written as
+    the range U+02CA-U+02CF, which also holds U+02CC MODIFIER LETTER LOW VERTICAL
+    LINE and U+02CD MODIFIER LETTER LOW MACRON — `Lm` and in scope like the rest,
+    but not accents), a fraction or superscript (`'half-½-price'`, `'surface-m²'`)
+    and a roman
     numeral (`'section-Ⅷ'`). Unroutable, hence NOT the scan's, however much they read
     as letters: a script that writes a vowel as a combining mark, so Hindi
     `'फॉर्म'`, Thai `'แบบฟอร์ม'` and Arabic `'نَموذج'` never matched a route because the

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -158,8 +158,10 @@ FORM_ID_LENGTH = 8
 # `.` IS INSIDE the class, and it is here for a compatibility reason rather than
 # an aesthetic one. This pattern is a NEW refusal on records that already exist:
 # the character class is the only bound in this change that can turn a row which
-# used to resolve into a 404 on all eight of its routes, and unlike the whitespace
-# case there is no argument that such a row was already unreachable. `acme.website`
+# used to resolve into a 404 on all eight of its routes, and unlike an id merely
+# ADDRESSED with surrounding whitespace there is no argument that such a row was
+# already unreachable (a row STORED with a space in its id has no such argument
+# either, which is why the scan covers it). `acme.website`
 # resolved correctly before — the dot was part of the key and the key was found —
 # so narrowing it out is data loss dressed as hardening. A dotted id is also the
 # most plausible hand-seeded spelling after `website-form`, since it is how a
@@ -167,8 +169,9 @@ FORM_ID_LENGTH = 8
 # string, open a tag or start a statement, so admitting it moves no character the
 # #379 serializer depends on. `test_a_dotted_hand_seeded_form_id_still_resolves`
 # is what fails if it is dropped again, and the remaining exclusions (`:`, `+`,
-# `@`, `%` and everything non-ASCII) are named to an operator with a pre-upgrade
-# scan in CHANGELOG.md's upgrade notes, since for those the 404 is real.
+# `@`, `%`, everything non-ASCII, and whitespace inside an id) are named to an
+# operator with a pre-upgrade scan in CHANGELOG.md's upgrade notes, since for those
+# the 404 is real.
 #
 # The `(?!\.{1,2}\Z)` in front of the class is what makes admitting `.` safe, and
 # it is about URL RESOLUTION rather than about DynamoDB: '.' and '..' are the
@@ -259,10 +262,18 @@ def _validated_form_id(raw: Any) -> str | None:
     routes, and for a hand-seeded row whose id resolved before, that is a reachable
     record becoming unreachable rather than a probe being refused. `.` is admitted
     for exactly that reason (see the pattern above). The characters still outside
-    the class — `:`, `+`, `@`, `%`, `~` and everything non-ASCII — are a deliberate
-    narrowing rather than an oversight, and the upgrade path is an operator scan of
-    the aggregates table for `FORM#` ids outside the class, written down in
-    CHANGELOG.md's upgrade notes rather than left for whoever reads the 404.
+    the class — `:`, `+`, `@`, `%`, `~`, everything non-ASCII, and whitespace
+    WITHIN an id such as `'my form'` — are a deliberate narrowing rather than an
+    oversight, and the upgrade path is an operator scan of the aggregates table for
+    `FORM#` ids outside the class, written down in CHANGELOG.md's upgrade notes
+    rather than left for whoever reads the 404.
+
+    Interior whitespace belongs in that list rather than under the `.strip()`
+    argument below, and the two are easy to conflate: that argument is about an id
+    ADDRESSED with surrounding space, where nothing becomes unreachable because
+    `' deadbeef'` never resolved to `'deadbeef'` to begin with. A row STORED as
+    `'my form'` is the `acme.website` case instead — it resolved, and now it does
+    not — so it is scanned for rather than argued away.
 
     NOT `.strip()`ed, which is where this parts company with the sibling it is
     modelled on. There a session id is a 128-bit token and the leniency is

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -4,6 +4,7 @@ Handles: /feedback-forms/* - multiple forms management
 """
 import json
 import os
+import re
 import uuid
 from datetime import datetime, timezone
 from typing import Any
@@ -124,6 +125,67 @@ LINK_FIELD_MAX_LENGTH = 128
 LINK_FIELDS = ('project_id', 'document_id')
 
 
+# ============================================
+# Form identifier
+# ============================================
+#
+# A form id is MINTED by this module and never taken from a request body — see
+# `_minted_form_id`, the one place the format is decided. Everything below is
+# derived from that one place so the two cannot drift.
+FORM_ID_LENGTH = 8
+
+# The shape a caller-supplied form id has to have before it reaches a read or a
+# rendered page (`_validated_form_id`).
+#
+# WIDER than the mint on purpose, and that width is the whole decision worth
+# arguing: the mint is `[0-9a-f]{8}`, but records seeded by hand or by an import
+# carry ids like 'website-form', and their embeddable page must keep working — a
+# validator narrowed to the mint would 404 the iframe for a form whose /config
+# and /submit still answer, which reads as "the product broke" rather than as a
+# refusal. So the bound is on the CHARACTER SET and the LENGTH instead, and every
+# character that could end a JavaScript string or open an HTML tag — the quote,
+# the parenthesis, the semicolon, '<', '>', '&', the backslash — is outside it.
+# Powertools' dynamic-route capture group admits all of those (issue #379), so
+# this pattern, not the route, is what bounds them.
+FORM_ID_MAX_LENGTH = 64
+_FORM_ID_PATTERN = re.compile(rf'^[0-9A-Za-z_-]{{1,{FORM_ID_MAX_LENGTH}}}$')
+
+
+def _minted_form_id() -> str:
+    """A new form's id: the first `FORM_ID_LENGTH` hex characters of a uuid4.
+
+    The only place a form id is created. Named so the validator below can be
+    described against one definition rather than against a literal repeated at
+    the two sites that used to spell it out.
+    """
+    return str(uuid.uuid4())[:FORM_ID_LENGTH]
+
+
+def _validated_form_id(raw: Any) -> str | None:
+    """The form id from the URL, or None if it cannot be one of ours.
+
+    Modelled on `ballots_handler._validated_session_id`, for the same two
+    reasons: a format check before any read means a probe for
+    `/feedback-forms/admin` or a 1 MB path segment costs no DynamoDB call, and
+    None rather than a raise because every caller answers the same 404 — telling
+    an anonymous caller "malformed" apart from "absent" only helps someone
+    probing.
+
+    The defect this closes (#379) is narrower than "unvalidated input", and worth
+    stating so nobody relaxes the pattern on the grounds that the render escapes
+    anyway: `get_form_iframe` returns HTML on the API's own origin, and the route
+    pattern Powertools compiles accepts `'`, `)` and `;`, so
+    `a');alert(document.domain);x=('` matched the route and used to be rendered
+    into a `<script>` block verbatim. Validation bounds what reaches the handler;
+    the structural serialization at the render site bounds what a value can do
+    once there. Both, because either alone leaves the other's failure fatal.
+    """
+    if not isinstance(raw, str):
+        return None
+    form_id = raw.strip()
+    return form_id if _FORM_ID_PATTERN.match(form_id) else None
+
+
 def validate_link_fields(body: dict) -> None:
     """Reject a malformed project_id / document_id before it is persisted.
 
@@ -241,7 +303,7 @@ def build_form_item(body: dict, form_id: str | None = None) -> dict:
     """
     validate_link_fields(body)
     now = datetime.now(timezone.utc).isoformat()
-    fid = form_id or str(uuid.uuid4())[:8]
+    fid = form_id or _minted_form_id()
     
     item = {
         'pk': 'FEEDBACK_FORM',
@@ -608,14 +670,134 @@ def submit_form_feedback(form_id: str):
         raise ServiceError('Failed to submit feedback. Please try again.')
 
 
+def _js_value(value: Any) -> str:
+    """A trusted Python value as a JavaScript expression to inline in a script.
+
+    `json.dumps` and nothing hand-written: JSON is a subset of JavaScript
+    expression syntax, so the serializer — not the template — decides where the
+    quotes go and how a quote inside the value is escaped. The spelling this
+    replaced was `'{value}'`, a handwritten quote pair around raw text, and every
+    reflected-XSS variant on this route came from a value that closed it (#379).
+    Wrapping `json.dumps(...)` in quotes of our own would reintroduce exactly
+    that: the result already carries its own, and a second pair round it makes the
+    inner ones data again.
+
+    The three replacements are for the HTML parser, which sees this text before
+    any JavaScript engine does: inside a `<script>` element `</script>` ends the
+    element wherever it appears — string literal or not — so `<` and `>` cannot be
+    left as themselves. `&` goes with them because it is the other character an
+    HTML parser gives meaning to. `html.escape` is deliberately NOT used here and
+    could not be: it produces `&#x27;` and `&lt;`, which are entities the script
+    context does not decode, so it would corrupt the value rather than protect it.
+    Escaping to `\\uXXXX` keeps the string byte-identical to the JavaScript engine
+    while making it inert to the parser above it.
+
+    U+2028 and U+2029 need the same treatment (they terminate a JavaScript line
+    but not a JSON string) and get it for free: `json.dumps` defaults to
+    `ensure_ascii=True`, which escapes every non-ASCII character.
+    """
+    return (
+        json.dumps(value)
+        .replace('<', '\\u003c')
+        .replace('>', '\\u003e')
+        .replace('&', '\\u0026')
+    )
+
+
+# Sent with the one response in this API that is HTML rather than JSON, so it is
+# the one response a browser will parse as a document on the API's own origin.
+#
+# `script-src 'unsafe-inline'` is there because the widget is INLINED into the
+# page (get_widget_js) and this is the deployment's only script host; removing it
+# means a nonce and a widget that loads from a URL, which is a bigger change than
+# this one. What the policy still buys with that in place is worth having: no
+# EXTERNAL script can load, no image, font or frame can be fetched, and the only
+# network destination is this same origin — so a value that did escape the
+# serializer above has nowhere to send anything.
+#
+# `style-src 'unsafe-inline'` is required by the page's own <style> block and by
+# the widget's `style="..."` attributes; `connect-src 'self'` is the widget's
+# fetch of /config and /submit, which are on this origin by construction
+# (api_endpoint is built from this request's own host).
+#
+# `frame-ancestors` is deliberately absent, and that is the decision this route
+# turns on: it EXISTS to be framed on customers' sites (docs/feedback-forms.md),
+# and the directive has no fallback to `default-src`, so leaving it out is how
+# "any site may embed this" is spelled. Adding it, or an X-Frame-Options header,
+# would break every embed.
+_IFRAME_SECURITY_HEADERS = {
+    'Content-Security-Policy': (
+        "default-src 'none'; "
+        "script-src 'unsafe-inline'; "
+        "style-src 'unsafe-inline'; "
+        "connect-src 'self'; "
+        "base-uri 'none'; "
+        "form-action 'none'"
+    ),
+    'X-Content-Type-Options': 'nosniff',
+    'Referrer-Policy': 'no-referrer',
+}
+
+
 @app.get("/feedback-forms/<form_id>/iframe")
 @tracer.capture_method
 def get_form_iframe(form_id: str):
-    """Serve HTML page for form-specific iframe embedding."""
+    """Serve the HTML page a customer's site frames for one form.
+
+    The only route in this API that answers with a document rather than JSON, on
+    the API's own origin, unauthenticated — which is why the two gates below come
+    before a single character of HTML is produced (#379):
+
+    - The id must have the SHAPE of one of ours (`_validated_form_id`). Powertools'
+      dynamic-route capture group accepts `'`, `)` and `;`, so the route pattern
+      is no bound at all; without this, `a');alert(document.domain);x=('` matched
+      and was rendered into the script block below.
+    - The form must EXIST. This route used to read nothing, so any string matching
+      the capture group got a 200 and a page — unlike /config and /submit, which
+      404 an id the table does not have. Existence is checked through
+      `_load_form_for_query`, the same one-get_item lookup those routes' siblings
+      use, so a caller cannot mint an attacker-chosen page on this origin at all,
+      and a deleted form stops serving an embed that can only fail.
+
+    Both answer the same 404, deliberately: a malformed id and an absent one are
+    indistinguishable to an anonymous caller, which is `_validated_form_id`'s
+    reasoning and `ballots_handler._validated_session_id`'s before it.
+
+    Neither gate is trusted alone. Every value that reaches the script is built by
+    `_js_value`, so the render is safe even if the pattern is later widened or the
+    route's own regex changes underneath it.
+    """
+    validated = _validated_form_id(form_id)
+    if not validated:
+        raise NotFoundError('Form not found')
+    # Return value unused: this is the existence gate, not a projection. The
+    # page's content is a function of the id and the host, nothing stored.
+    _load_form_for_query(validated, 'Failed to load form')
+
     host = app.current_event.request_context.get('domainName', '')
     stage = app.current_event.request_context.get('stage', 'v1')
     api_endpoint = f"https://{host}/{stage}" if host else ''
-    
+
+    # ONE serialized object rather than five interpolated fields: the options
+    # object is a JSON object literal, so json.dumps writes every quote, brace and
+    # comma in it and the template writes none. `api_endpoint` goes through it too
+    # — it is derived from a request header (domainName), so it is not ours either.
+    #
+    # This is the page's ONLY reflected value, and it is in SCRIPT context, which
+    # is why `html.escape` appears nowhere below: the <title>, the container id and
+    # the <style> block are fixed text, so no request value reaches an HTML
+    # context. `html.escape(..., quote=True)` is the right tool for a value
+    # rendered as MARKUP and the wrong one inside a script, where its entities are
+    # never decoded — so if a later change puts the form id in the title or an
+    # attribute, that value needs it and NOT this function.
+    init_options = _js_value({
+        'container': '#voc-feedback-form',
+        'apiEndpoint': api_endpoint,
+        'formId': validated,
+        'configEndpoint': f'/feedback-forms/{validated}/config',
+        'submitEndpoint': f'/feedback-forms/{validated}/submit',
+    })
+
     html = f'''<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -632,18 +814,17 @@ def get_form_iframe(form_id: str):
   <div id="voc-feedback-form"></div>
   <script>
   {get_widget_js()}
-  VoCFeedbackForm.init({{
-    container: '#voc-feedback-form',
-    apiEndpoint: '{api_endpoint}',
-    formId: '{form_id}',
-    configEndpoint: '/feedback-forms/{form_id}/config',
-    submitEndpoint: '/feedback-forms/{form_id}/submit'
-  }});
+  VoCFeedbackForm.init({init_options});
   </script>
 </body>
 </html>'''
-    
-    return Response(status_code=200, content_type="text/html", body=html)
+
+    return Response(
+        status_code=200,
+        content_type="text/html",
+        body=html,
+        headers=dict(_IFRAME_SECURITY_HEADERS),
+    )
 
 
 # ============================================

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -938,6 +938,16 @@ def get_form_iframe(form_id: str):
         raise NotFoundError('Form not found')
     # Return value unused: this is the existence gate, not a projection. The
     # page's content is a function of the id and the host, nothing stored.
+    #
+    # EXISTENCE ONLY — `enabled` is deliberately NOT consulted, which the unused
+    # return value makes look like an oversight rather than a decision. A disabled
+    # form still gets its page, matching `GET /config`, which publishes `enabled`
+    # in its projection and leaves the decision to the widget; `submit_form_feedback`
+    # is where it is enforced. The reason to keep the asymmetry is that the widget
+    # has to RUN in order to show its own disabled state — gate the page on
+    # `enabled` and the visitor gets a raw API Gateway 404 frame instead, which is
+    # a worse answer for the customer who turned the form off on purpose.
+    # `test_a_disabled_form_still_serves_its_page_so_the_widget_can_say_so` pins it.
     _load_form_for_query(validated, 'Failed to load form')
 
     host = app.current_event.request_context.get('domainName', '')

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -179,11 +179,14 @@ FORM_ID_LENGTH = 8
 # Seven of the other eighteen (`&`, `'`, `(`, `)`, `;`, `<`, `>`) are the characters
 # the #379 fix turns on — the quote, parens and semicolon the payload breaks out
 # with, plus the `<`, `>` and `&` `_js_value` escapes for the HTML parser — which is
-# exactly why a hand-written list omits them. (Three of those four do the breaking
-# out in the payload: its `'` closes the string literal, its `)` closes the init call
-# and its `;` starts a second statement, while its `(` is the `alert(` it calls and
-# the `x=('` it re-opens with. `_INJECTION_PAYLOAD`'s comment in the test file is
-# where that decomposition is stated as the module's own.)
+# exactly why a hand-written list omits them. (Only the `'` does the breaking out in
+# the payload itself, closing the string literal the template wrote; its `(` is the
+# `alert(` it calls and the `x=('` it re-opens with, and its `)` and `;` close a call
+# and start a statement only in the bare-argument shape `init('<id>')` it was written
+# for — the template interpolated the id inside an OBJECT LITERAL, where they close
+# nothing and the block does not parse. `a',x:alert(1),y:'` is the same class through
+# the same hole and does run, which is why the fix is the serializer and not a
+# blocklist. `_INJECTION_PAYLOAD`'s comment in the test file states the same.)
 # `"`, `#`, `/`, `?`, `\` and a backtick are the printable-ASCII exceptions: the
 # route admits none of them, so they belong with the tab and the newline below.
 # A non-ASCII character that `\w` does NOT match is likewise not the scan's to
@@ -300,10 +303,13 @@ def _validated_form_id(raw: Any) -> str | None:
     ones (`&`, `'`, `(`, `)`, `;`, `<`, `>`) are the characters the #379 fix turns
     on — the quote, parens and semicolon the payload breaks out with, plus the `<`,
     `>` and `&` `_js_value` escapes for the HTML parser — which is why they are the
-    ones a hand-written list drops. Three of those four do the breaking out in the
-    payload itself (its `'` closes the string literal, its `)` closes the init call
-    and its `;` starts a second statement; its `(` is the `alert(` it calls and the
-    `x=('` it re-opens with). On the other side, `"`, `#`, `/`, `?`, a backslash and
+    ones a hand-written list drops. Only the `'` does the breaking out in the payload
+    itself, closing the string literal the template wrote; its `(` is the `alert(` it
+    calls and the `x=('` it re-opens with, and its `)` and `;` close a call and start
+    a statement only in the bare-argument shape `init('<id>')` it was written for —
+    the template put the id inside an OBJECT LITERAL, where they close nothing and
+    the block does not parse. The hole is real either way: `a',x:alert(1),y:'` needs
+    neither, and runs. On the other side, `"`, `#`, `/`, `?`, a backslash and
     a backtick are the printable-ASCII characters the route does NOT admit, so they
     sit with the tab and the newline below rather than in the scan.
 

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -168,10 +168,13 @@ FORM_ID_LENGTH = 8
 # written. It costs the fix nothing: `.` cannot close a JavaScript string, open
 # a tag or start a statement, so admitting it moves no character the #379
 # serializer depends on. `test_a_dotted_hand_seeded_form_id_still_resolves` is
-# what fails if it is dropped again, and the remaining exclusions (`:`, `+`,
-# `@`, `%`, everything non-ASCII, and a space inside an id) are named to an
-# operator with a pre-upgrade scan in CHANGELOG.md's upgrade notes, since for
-# those the 404 is real.
+# what fails if it is dropped again, and the remaining exclusions that a route
+# COULD resolve (`:`, `+`, `@`, `%`, a non-ASCII letter or digit, and a space
+# inside an id) are named to an operator with a pre-upgrade scan in CHANGELOG.md's
+# upgrade notes, since for those the 404 is real. A non-ASCII SYMBOL or space is
+# not on that list and is not the scan's to find: the route's capture group reaches
+# past ASCII only through `\w`, which covers letters and digits, so `café`
+# resolved while `form€a` never matched a route at all.
 #
 # The `(?!\.{1,2}\Z)` in front of the class is what makes admitting `.` safe, and
 # it is about URL RESOLUTION rather than about DynamoDB: '.' and '..' are the
@@ -262,17 +265,23 @@ def _validated_form_id(raw: Any) -> str | None:
     routes, and for a hand-seeded row whose id resolved before, that is a reachable
     record becoming unreachable rather than a probe being refused. `.` is admitted
     for exactly that reason (see the pattern above). The characters still outside
-    the class — `:`, `+`, `@`, `%`, `~`, everything non-ASCII, and a SPACE within
-    an id such as `'my form'` — are a deliberate narrowing rather than an
-    oversight, and the upgrade path is an operator scan of the aggregates table for
-    `FORM#` ids outside the class, written down in CHANGELOG.md's upgrade notes
-    rather than left for whoever reads the 404.
+    the class — `:`, `+`, `@`, `%`, `~`, a non-ASCII LETTER OR DIGIT such as
+    `'café'`, and a SPACE within an id such as `'my form'` — are a deliberate
+    narrowing rather than an oversight, and the upgrade path is an operator scan of
+    the aggregates table for `FORM#` ids outside the class, written down in
+    CHANGELOG.md's upgrade notes rather than left for whoever reads the 404.
 
-    A space rather than "whitespace" in that list, because the two are not the same
-    category and only one of them is this change's to answer for: the route's own
-    capture group admits a space but excludes a tab and a newline, so an id holding
-    either never matched a route and answered 404 before this change as well as
-    after. `test_the_scan_is_scoped_to_ids_a_route_could_actually_resolve` pins that
+    That list is narrower than "everything non-ASCII" and than "whitespace", and
+    both narrowings come from ONE fact about the route rather than about this
+    pattern: powertools' capture group reaches past ASCII only through `\\w`, which
+    is Unicode-aware for letters and digits alone, and it lists a literal space but
+    no other whitespace. So `'café'` and `'my form'` matched a route and are the
+    scan's to find, while a tab, a newline, and a non-ASCII SYMBOL or space
+    (`'form€a'`, `'form\\xa0a'`) never matched one at all — those rows answered 404
+    before this change as well as after, so they are unreachable rather than
+    reachable-then-orphaned. Telling an operator to rename one would be renaming a
+    row that was never served.
+    `test_the_scan_is_scoped_to_ids_a_route_could_actually_resolve` pins the whole
     split off the live resolver, since it is what bounds the operator scan's reach.
 
     Interior whitespace belongs in that list rather than under the `.strip()`

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -161,17 +161,17 @@ FORM_ID_LENGTH = 8
 # used to resolve into a 404 on all eight of its routes, and unlike an id merely
 # ADDRESSED with surrounding whitespace there is no argument that such a row was
 # already unreachable (a row STORED with a space in its id has no such argument
-# either, which is why the scan covers it). `acme.website`
-# resolved correctly before — the dot was part of the key and the key was found —
-# so narrowing it out is data loss dressed as hardening. A dotted id is also the
-# most plausible hand-seeded spelling after `website-form`, since it is how a
-# domain is written. It costs the fix nothing: `.` cannot close a JavaScript
-# string, open a tag or start a statement, so admitting it moves no character the
-# #379 serializer depends on. `test_a_dotted_hand_seeded_form_id_still_resolves`
-# is what fails if it is dropped again, and the remaining exclusions (`:`, `+`,
-# `@`, `%`, everything non-ASCII, and whitespace inside an id) are named to an
-# operator with a pre-upgrade scan in CHANGELOG.md's upgrade notes, since for those
-# the 404 is real.
+# either, which is why the scan covers it). `acme.website` resolved correctly
+# before — the dot was part of the key and the key was found — so narrowing it
+# out is data loss dressed as hardening. A dotted id is also the most plausible
+# hand-seeded spelling after `website-form`, since it is how a domain is
+# written. It costs the fix nothing: `.` cannot close a JavaScript string, open
+# a tag or start a statement, so admitting it moves no character the #379
+# serializer depends on. `test_a_dotted_hand_seeded_form_id_still_resolves` is
+# what fails if it is dropped again, and the remaining exclusions (`:`, `+`,
+# `@`, `%`, everything non-ASCII, and a space inside an id) are named to an
+# operator with a pre-upgrade scan in CHANGELOG.md's upgrade notes, since for
+# those the 404 is real.
 #
 # The `(?!\.{1,2}\Z)` in front of the class is what makes admitting `.` safe, and
 # it is about URL RESOLUTION rather than about DynamoDB: '.' and '..' are the
@@ -262,11 +262,18 @@ def _validated_form_id(raw: Any) -> str | None:
     routes, and for a hand-seeded row whose id resolved before, that is a reachable
     record becoming unreachable rather than a probe being refused. `.` is admitted
     for exactly that reason (see the pattern above). The characters still outside
-    the class — `:`, `+`, `@`, `%`, `~`, everything non-ASCII, and whitespace
-    WITHIN an id such as `'my form'` — are a deliberate narrowing rather than an
+    the class — `:`, `+`, `@`, `%`, `~`, everything non-ASCII, and a SPACE within
+    an id such as `'my form'` — are a deliberate narrowing rather than an
     oversight, and the upgrade path is an operator scan of the aggregates table for
     `FORM#` ids outside the class, written down in CHANGELOG.md's upgrade notes
     rather than left for whoever reads the 404.
+
+    A space rather than "whitespace" in that list, because the two are not the same
+    category and only one of them is this change's to answer for: the route's own
+    capture group admits a space but excludes a tab and a newline, so an id holding
+    either never matched a route and answered 404 before this change as well as
+    after. `test_the_scan_is_scoped_to_ids_a_route_could_actually_resolve` pins that
+    split off the live resolver, since it is what bounds the operator scan's reach.
 
     Interior whitespace belongs in that list rather than under the `.strip()`
     argument below, and the two are easy to conflate: that argument is about an id

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -1223,7 +1223,12 @@ def get_form_submissions(form_id: str):
         
         return {
             'success': True,
-            'form_id': form_id,
+            # The VALIDATED id, like the key and the filter above: this response
+            # names the record those two addressed, so a normalizing validator
+            # cannot make it describe one row set while naming another id. See
+            # _load_form_for_query, and `submit_form_feedback` which already
+            # stores `'form_id': validated`.
+            'form_id': validated,
             'stats': {
                 'total_submissions': len(items),
                 'avg_rating': avg_rating,
@@ -1312,7 +1317,11 @@ def get_form_stats(form_id: str):
         
         return {
             'success': True,
-            'form_id': form_id,
+            # The VALIDATED id, for the same reason as get_form_submissions: the
+            # count reported here is of the rows the key and the filter above
+            # selected, so the id naming it has to be the one they were built
+            # from.
+            'form_id': validated,
             'stats': {
                 'total_submissions': submission_count,
                 'avg_rating': avg_rating,

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -169,12 +169,14 @@ FORM_ID_LENGTH = 8
 # a tag or start a statement, so admitting it moves no character the #379
 # serializer depends on. `test_a_dotted_hand_seeded_form_id_still_resolves` is
 # what fails if it is dropped again, and the remaining exclusions that a route
-# COULD resolve (`:`, `+`, `@`, `%`, a non-ASCII letter or digit, and a space
+# COULD resolve (`:`, `+`, `@`, `%`, a non-ASCII letter or NUMBER, and a space
 # inside an id) are named to an operator with a pre-upgrade scan in CHANGELOG.md's
-# upgrade notes, since for those the 404 is real. A non-ASCII SYMBOL or space is
-# not on that list and is not the scan's to find: the route's capture group reaches
-# past ASCII only through `\w`, which covers letters and digits, so `café`
-# resolved while `form€a` never matched a route at all.
+# upgrade notes, since for those the 404 is real. A non-ASCII SYMBOL, punctuation
+# mark, combining accent or space is not on that list and is not the scan's to
+# find: the route's capture group reaches past ASCII only through `\w`, which
+# matches any Unicode letter or number — every `L*` and `N*` category, so a modifier
+# letter (`hawaiʼi-form`) and a fraction (`surface-m²`) are in scope despite reading
+# as punctuation — so `café` resolved while `form€a` never matched a route at all.
 #
 # The `(?!\.{1,2}\Z)` in front of the class is what makes admitting `.` safe, and
 # it is about URL RESOLUTION rather than about DynamoDB: '.' and '..' are the
@@ -265,7 +267,7 @@ def _validated_form_id(raw: Any) -> str | None:
     routes, and for a hand-seeded row whose id resolved before, that is a reachable
     record becoming unreachable rather than a probe being refused. `.` is admitted
     for exactly that reason (see the pattern above). The characters still outside
-    the class — `:`, `+`, `@`, `%`, `~`, a non-ASCII LETTER OR DIGIT such as
+    the class — `:`, `+`, `@`, `%`, `~`, a non-ASCII LETTER OR NUMBER such as
     `'café'`, and a SPACE within an id such as `'my form'` — are a deliberate
     narrowing rather than an oversight, and the upgrade path is an operator scan of
     the aggregates table for `FORM#` ids outside the class, written down in
@@ -274,15 +276,26 @@ def _validated_form_id(raw: Any) -> str | None:
     That list is narrower than "everything non-ASCII" and than "whitespace", and
     both narrowings come from ONE fact about the route rather than about this
     pattern: powertools' capture group reaches past ASCII only through `\\w`, which
-    is Unicode-aware for letters and digits alone, and it lists a literal space but
-    no other whitespace. So `'café'` and `'my form'` matched a route and are the
-    scan's to find, while a tab, a newline, and a non-ASCII SYMBOL or space
-    (`'form€a'`, `'form\\xa0a'`) never matched one at all — those rows answered 404
-    before this change as well as after, so they are unreachable rather than
+    matches any Unicode letter or number, and it lists a literal space but no other
+    whitespace. So `'café'` and `'my form'` matched a route and are the scan's to
+    find, while a tab, a newline, and a non-ASCII SYMBOL, PUNCTUATION MARK,
+    COMBINING ACCENT or space (`'form€a'`, `'form\\xa0a'`, `'form«a'`, an NFD
+    `'cafe\\u0301'`) never matched one at all — those rows answered 404 before this
+    change as well as after, so they are unreachable rather than
     reachable-then-orphaned. Telling an operator to rename one would be renaming a
     row that was never served.
     `test_the_scan_is_scoped_to_ids_a_route_could_actually_resolve` pins the whole
     split off the live resolver, since it is what bounds the operator scan's reach.
+
+    Read `\\w` as the `L*` and `N*` CATEGORIES rather than as "letters and digits",
+    because the difference falls on the shapes an operator is most likely to
+    misfile: a modifier letter (`'hawaiʼi-form'`, whose `ʼ` is U+02BC — how an
+    ʻokina is correctly spelled, and visually an apostrophe), a fraction or
+    superscript (`'half-½-price'`, `'surface-m²'`) and a roman numeral
+    (`'section-Ⅷ'`) are all `\\w`, hence routable, hence the scan's to find, however
+    much they read as punctuation. That is the ONE direction of this split with a
+    real cost: over-reporting wastes a rename, but under-reporting means an operator
+    reads a printed row as out of scope, skips it, and it 404s in production.
 
     Interior whitespace belongs in that list rather than under the `.strip()`
     argument below, and the two are easy to conflate: that argument is about an id

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -177,9 +177,13 @@ FORM_ID_LENGTH = 8
 # `[-._~()'!*:@,;=+&$%<> \[\]{}|^]` except `-`, `.` and `_` — 24 characters, of
 # which `:`, `+`, `@`, `%`, `~` and a space inside an id are only the illustrations.
 # Seven of the other eighteen (`&`, `'`, `(`, `)`, `;`, `<`, `>`) are the characters
-# the #379 fix turns on — the quote, parens and semicolon the payload closes its
-# handwritten string literal with, plus the `<`, `>` and `&` `_js_value` escapes for
-# the HTML parser — which is exactly why a hand-written list omits them.
+# the #379 fix turns on — the quote, parens and semicolon the payload breaks out
+# with, plus the `<`, `>` and `&` `_js_value` escapes for the HTML parser — which is
+# exactly why a hand-written list omits them. (Three of those four do the breaking
+# out in the payload: its `'` closes the string literal, its `)` closes the init call
+# and its `;` starts a second statement, while its `(` is the `alert(` it calls and
+# the `x=('` it re-opens with. `_INJECTION_PAYLOAD`'s comment in the test file is
+# where that decomposition is stated as the module's own.)
 # `"`, `#`, `/`, `?`, `\` and a backtick are the printable-ASCII exceptions: the
 # route admits none of them, so they belong with the tab and the newline below.
 # A non-ASCII character that `\w` does NOT match is likewise not the scan's to
@@ -294,12 +298,14 @@ def _validated_form_id(raw: Any) -> str | None:
     `_` — 24 of them, where `:`, `+`, `@`, `%`, `~` and a SPACE within an id such as
     `'my form'` are illustrations and not the set. Seven of the eighteen unnamed
     ones (`&`, `'`, `(`, `)`, `;`, `<`, `>`) are the characters the #379 fix turns
-    on — the quote, parens and semicolon the payload closes its handwritten string
-    literal with, plus the `<`, `>` and `&` `_js_value` escapes for the HTML parser
-    — which is why they are the ones a hand-written list drops. On the other side,
-    `"`, `#`, `/`, `?`, a backslash and a backtick are the printable-ASCII
-    characters the route does NOT admit, so they sit with the tab and the newline
-    below rather than in the scan.
+    on — the quote, parens and semicolon the payload breaks out with, plus the `<`,
+    `>` and `&` `_js_value` escapes for the HTML parser — which is why they are the
+    ones a hand-written list drops. Three of those four do the breaking out in the
+    payload itself (its `'` closes the string literal, its `)` closes the init call
+    and its `;` starts a second statement; its `(` is the `alert(` it calls and the
+    `x=('` it re-opens with). On the other side, `"`, `#`, `/`, `?`, a backslash and
+    a backtick are the printable-ASCII characters the route does NOT admit, so they
+    sit with the tab and the newline below rather than in the scan.
 
     The non-ASCII half of that is narrower than "everything non-ASCII" and the
     whitespace half narrower than "whitespace", and both narrowings come from ONE

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -187,11 +187,24 @@ def _validated_form_id(raw: Any) -> str | None:
     `/feedback-forms/admin` or a 1 MB path segment costs no DynamoDB call, and
     None rather than a raise because every caller answers the same 404 — telling
     an anonymous caller "malformed" apart from "absent" only helps someone
-    probing. Like that sibling, it is applied at EVERY route that takes a form id
-    out of the URL and turns it into a key: `/config`, `/submit`, `/iframe`,
-    `/submissions` and `/stats` (the last two through `_load_form_for_query`), so
-    the cost argument above holds everywhere it is stated rather than on one route
-    only.
+    probing.
+
+    Like that sibling, it is applied at EVERY route that takes a form id out of
+    the URL and turns it into a key. All eight, so the claim can be read as
+    written and a reader does not have to hold a list of exceptions:
+
+    - unauthenticated: `/config`, `/submit`, `/iframe`
+    - authenticated reads: `/submissions`, `/stats` (both through
+      `_load_form_for_query`, the single read they make)
+    - authenticated CRUD: `GET`, `PUT` and `DELETE /feedback-forms/<form_id>`
+
+    The cost argument only earns its keep on the first three — the others are
+    behind Cognito, so nobody is probing them for free. They are covered anyway
+    because a universal claim is worth more than the three lines it saves: the
+    next reader of this function should not have to check which routes meant it.
+    `test_no_route_keys_on_a_form_id_without_validating_it_first` derives the list
+    from the module's own routing table rather than from this docstring, so a
+    route added later is a failure here instead of a quiet omission.
 
     The defect this closes (#379) is narrower than "unvalidated input", and worth
     stating so nobody relaxes the pattern on the grounds that the render escapes
@@ -509,10 +522,19 @@ def create_form():
 @app.get("/feedback-forms/<form_id>")
 @tracer.capture_method
 def get_form(form_id: str):
-    """Get a specific feedback form."""
+    """Get a specific feedback form.
+
+    Authenticated, so `_validated_form_id` is not buying a bound against an
+    anonymous prober here — it is buying the SAME bound at every route that turns
+    this URL segment into a key, so the claim in that function's docstring is true
+    of the module rather than of the public trio only.
+    """
+    validated = _validated_form_id(form_id)
+    if not validated:
+        raise NotFoundError('Form not found')
     try:
         response = aggregates_table.get_item(
-            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
         )
         item = response.get('Item')
         
@@ -530,7 +552,28 @@ def get_form(form_id: str):
 @app.put("/feedback-forms/<form_id>")
 @tracer.capture_method
 def update_form(form_id: str):
-    """Update a feedback form."""
+    """Update a feedback form.
+
+    UpdateItem is an UPSERT, which is the whole reason the two guards below are
+    here rather than only on the public routes:
+
+    - The id is format-checked first (`_validated_form_id`), so a segment that
+      could not be one of ours never becomes a key.
+    - `attribute_exists(sk)` makes this an UPDATE rather than a create. Without it
+      a PUT to an id the table does not hold WROTE one: a bare
+      {pk, sk, <updated fields>} row with no `form_id` attribute, which
+      `item_to_form` reads back as `form_id: ''` — a nameless entry in
+      `list_forms` that nothing can address or delete by id. That is the same
+      phantom-stub shape `_anchor_form_brand` already refuses for the same reason;
+      this route simply had no condition at all.
+
+    Creation is `POST /feedback-forms`, which mints the id, so nothing legitimate
+    reaches this route with an id that does not exist yet — a PUT to an absent id
+    is a client bug or a probe, and 404 is the answer both want.
+    """
+    validated = _validated_form_id(form_id)
+    if not validated:
+        raise NotFoundError('Form not found')
     body = app.current_event.json_body or {}
     validate_link_fields(body)
     now = datetime.now(timezone.utc).isoformat()
@@ -553,15 +596,24 @@ def update_form(form_id: str):
     
     try:
         response = aggregates_table.update_item(
-            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'},
+            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'},
             UpdateExpression='SET ' + ', '.join(update_parts),
             ExpressionAttributeNames=expr_names,
             ExpressionAttributeValues=expr_values,
+            # See the docstring: this is what makes the route an update instead of
+            # a create. One round trip, and no read-then-write race — a form
+            # deleted between a check and this write would still be refused.
+            ConditionExpression='attribute_exists(sk)',
             ReturnValues='ALL_NEW'
         )
-        
+
         return {'success': True, 'form': item_to_form(response.get('Attributes', {}))}
     except Exception as e:
+        # The condition failing is not a server error: it means the form is not
+        # there, which is the same 404 `get_form` gives for the same id. Reported
+        # before the generic branch so it cannot be logged as a failure to update.
+        if _is_conditional_check_failure(e):
+            raise NotFoundError('Form not found') from e
         logger.error(f"Error updating form: {e}")
         raise ServiceError('Failed to update form')
 
@@ -569,12 +621,21 @@ def update_form(form_id: str):
 @app.delete("/feedback-forms/<form_id>")
 @tracer.capture_method
 def delete_form(form_id: str):
-    """Delete a feedback form."""
+    """Delete a feedback form.
+
+    Format-checked for the same module-wide reason as `get_form`. No
+    `attribute_exists` condition, unlike `update_form`: DeleteItem on a key that
+    is not there is a no-op rather than a write, so the idempotent 200 this
+    already returns is the honest answer and there is no phantom row to prevent.
+    """
+    validated = _validated_form_id(form_id)
+    if not validated:
+        raise NotFoundError('Form not found')
     try:
         aggregates_table.delete_item(
-            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
         )
-        logger.info(f"Deleted feedback form: {form_id}")
+        logger.info(f"Deleted feedback form: {validated}")
         return {'success': True}
     except Exception as e:
         logger.error(f"Error deleting form: {e}")
@@ -780,6 +841,24 @@ def _js_value(value: Any) -> str:
 # fetch of /config and /submit, which are on this origin by construction
 # (api_endpoint is built from this request's own host).
 #
+# That construction is what `'self'` depends on, and it holds for the ONE
+# deployment topology this stack builds: API Gateway invoked directly, so
+# `requestContext.domainName` — the host the document was served from — is also
+# the host the widget fetches. `lib/stacks/api-stack.ts` takes a
+# `frontendDistribution`, but that CloudFront distribution fronts the website
+# bucket only; no behaviour points at the API, and no custom domain or base-path
+# mapping is declared for it.
+#
+# If a deployment ever puts this API behind a distribution or a custom domain that
+# rewrites Host, `'self'` and `api_endpoint` stop agreeing — `domainName` would be
+# the ORIGIN's host while the document came from the EDGE's — and the widget's own
+# fetch is refused, with nothing to see but a CSP violation in a console nobody is
+# watching. The fix then is to derive both from the same forwarded host rather
+# than to widen the directive: `connect-src` naming an explicit API host is still
+# a bound, `'self' *` is not. Out of scope here because the topology does not
+# exist yet, and recorded because this comment is where the reader of that
+# deployment's blank frame will end up.
+#
 # Those three are what makes the page WORK, and `default-src 'none'` is the
 # fallback for everything not named — so deleting any one of them is a total,
 # silent failure of the product on a customer's site rather than a degraded page.
@@ -956,17 +1035,26 @@ def _load_form_for_query(form_id: str, read_failure_message: str) -> dict:
     The FORMAT check is here rather than at each caller because this function is
     the one read those routes make, so one call covers `/stats`, `/submissions`
     and the iframe page's existence gate — `_validated_form_id`'s cost argument
-    then holds at every route that states it rather than at one. Callers keep
-    using their own `form_id` for anything else they build (`source_channel`,
-    the response's echo) with no risk of a split-brain, because the validator is
-    EXACT: it returns the string it was given or None, never a normalized
-    variant of it.
+    then holds at every route that states it rather than at one.
+
+    The key is built from the VALIDATED value, like every other call site, rather
+    than from the parameter. Those are the same string today, and relying on that
+    was a latent split rather than a saving: a validator that normalized — a
+    plausible "form ids are case-insensitive" change — would have this function
+    read `FORM#DEADBEEF` while `/config` read `FORM#deadbeef` for the same URL,
+    and `/submissions` would then filter on a `source_channel` built by its caller
+    from the raw id, which no write ever used. A silent zero, which is the exact
+    defect class this function exists to prevent (#312). Keying on the validated
+    value removes the dependency instead of documenting it;
+    `test_the_validator_returns_its_input_unchanged` pins the exactness the
+    callers' own use of `form_id` still relies on.
     """
-    if not _validated_form_id(form_id):
+    validated = _validated_form_id(form_id)
+    if not validated:
         raise NotFoundError('Form not found')
     try:
         response = aggregates_table.get_item(
-            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+            Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
         )
     except Exception as e:
         # Surfaced as a metric because this failure used to be invisible: it was

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -288,8 +288,8 @@ def _validated_form_id(raw: Any) -> str | None:
     That set is stated as a COMPLEMENT rather than as a list, because a list of it
     has been short every time it was written by hand: in scope is any character
     outside this pattern's `[0-9A-Za-z_.-]` that the ROUTE admits, which for ASCII
-    is every character of `[-._~()'!*:@,;=+&$%<> \\[\\]{}|^]` except `-`, `.` and `_`
-    — 24 of them, where `:`, `+`, `@`, `%`, `~` and a SPACE within an id such as
+    is every character of `[-._~()'!*:@,;=+&$%<> \\[\\]{}|^]` except `-`, `.` and
+    `_` — 24 of them, where `:`, `+`, `@`, `%`, `~` and a SPACE within an id such as
     `'my form'` are illustrations and not the set. Seven of the eighteen unnamed
     ones (`&`, `'`, `(`, `)`, `;`, `<`, `>`) are the #379 payload's own characters,
     which is why they are the ones a hand-written list drops. On the other side,
@@ -297,16 +297,17 @@ def _validated_form_id(raw: Any) -> str | None:
     characters the route does NOT admit, so they sit with the tab and the newline
     below rather than in the scan.
 
-    That set is narrower than "everything non-ASCII" and than "whitespace", and
-    both narrowings come from ONE fact about the route rather than about this
-    pattern: powertools' capture group reaches past ASCII only through `\\w`, which
-    matches any Unicode letter or number plus `_`, and it lists a literal space but
-    no other whitespace. So `'café'` and `'my form'` matched a route and are the
-    scan's to find, while a tab, a newline, and any non-ASCII character `\\w` does
-    NOT match (`'form€a'`, `'form\\xa0a'`, `'form«a'`, an NFD `'cafe\\u0301'`) never
-    matched one at all — those rows answered 404 before this change as well as after,
-    so they are unreachable rather than reachable-then-orphaned. Telling an operator
-    to rename one would be renaming a row that was never served.
+    The non-ASCII half of that is narrower than "everything non-ASCII" and the
+    whitespace half narrower than "whitespace", and both narrowings come from ONE
+    fact about the route rather than about this pattern: powertools' capture group
+    reaches past ASCII only through `\\w`, which matches any Unicode letter or
+    number plus `_`, and it lists a literal space but no other whitespace. So
+    `'café'` and `'my form'` matched a route and are the scan's to find, while a
+    tab, a newline, and any non-ASCII character `\\w` does NOT match (`'form€a'`,
+    `'form\\xa0a'`, `'form«a'`, an NFD `'cafe\\u0301'`) never matched one at all —
+    those rows answered 404 before this change as well as after, so they are
+    unreachable rather than reachable-then-orphaned. Telling an operator to rename
+    one would be renaming a row that was never served.
     `test_the_scan_is_scoped_to_ids_a_route_could_actually_resolve` pins the whole
     split off the live resolver, since it is what bounds the operator scan's reach.
 
@@ -315,19 +316,18 @@ def _validated_form_id(raw: Any) -> str | None:
     marks (`M*`), symbols (`S*`), punctuation (`P*`), separators (`Z*`) and format
     characters (`C*`). The difference falls on the shapes an operator is most likely
     to misfile, and it runs in BOTH directions. Routable, hence the scan's to find,
-    however much they read as punctuation: a modifier letter (`'hawaiʼi-form'`, whose
-    `ʼ` is U+02BC MODIFIER LETTER APOSTROPHE, visually an ASCII quote — as is the
-    Hawaiian ʻokina, U+02BB, which is the same category; and note that characters
-    NAMED as accents are `Lm` too, so `'formˆa'` is in scope. Those are U+02C6,
-    U+02CA, U+02CB, U+02CE, U+02CF and U+A788, spelled out rather than written as
-    the range U+02CA-U+02CF, which also holds U+02CC MODIFIER LETTER LOW VERTICAL
-    LINE and U+02CD MODIFIER LETTER LOW MACRON — `Lm` and in scope like the rest,
-    but not accents), a fraction or superscript (`'half-½-price'`, `'surface-m²'`)
-    and a roman
-    numeral (`'section-Ⅷ'`). Unroutable, hence NOT the scan's, however much they read
-    as letters: a script that writes a vowel as a combining mark, so Hindi
-    `'फॉर्म'`, Thai `'แบบฟอร์ม'` and Arabic `'نَموذج'` never matched a route because the
-    mark is `Mc`/`Mn` even where the base character is `Lo` (precomposed Korean
+    however much they read as punctuation: a modifier letter (`'hawaiʼi-form'`,
+    whose `ʼ` is U+02BC MODIFIER LETTER APOSTROPHE, visually an ASCII quote — as is
+    the Hawaiian ʻokina, U+02BB, which is the same category; and note that
+    characters NAMED as accents are `Lm` too, so `'formˆa'` is in scope — those
+    being U+02C6, U+02CA, U+02CB, U+02CE, U+02CF and U+A788, spelled out rather than
+    as the range U+02CA-U+02CF, which also holds U+02CC MODIFIER LETTER LOW VERTICAL
+    LINE and U+02CD MODIFIER LETTER LOW MACRON, `Lm` and in scope like the rest but
+    not accents), a fraction or superscript (`'half-½-price'`, `'surface-m²'`) and a
+    roman numeral (`'section-Ⅷ'`). Unroutable, hence NOT the scan's, however much
+    they read as letters: a script that writes a vowel as a combining mark, so Hindi
+    `'फॉर्म'`, Thai `'แบบฟอร์ม'` and Arabic `'نَموذج'` never matched a route because
+    the mark is `Mc`/`Mn` even where the base character is `Lo` (precomposed Korean
     `'피드백'` is all `Lo`, and did resolve). That is the ONE direction of this split
     with a real cost: over-reporting wastes a rename, but under-reporting means an
     operator reads a printed row as out of scope, skips it, and it 404s in

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -158,7 +158,7 @@ FORM_ID_LENGTH = 8
 # `.` IS INSIDE the class, and it is here for a compatibility reason rather than
 # an aesthetic one. This pattern is a NEW refusal on records that already exist:
 # the character class is the only bound in this change that can turn a row which
-# used to resolve into a 404 on all five of its routes, and unlike the whitespace
+# used to resolve into a 404 on all eight of its routes, and unlike the whitespace
 # case there is no argument that such a row was already unreachable. `acme.website`
 # resolved correctly before — the dot was part of the key and the key was found —
 # so narrowing it out is data loss dressed as hardening. A dotted id is also the
@@ -255,7 +255,7 @@ def _validated_form_id(raw: Any) -> str | None:
     failure fatal.
 
     A NEW refusal on data that already exists, which is the one respect in which
-    this is not purely additive: an id outside the pattern 404s on all five of its
+    this is not purely additive: an id outside the pattern 404s on all eight of its
     routes, and for a hand-seeded row whose id resolved before, that is a reachable
     record becoming unreachable rather than a probe being refused. `.` is admitted
     for exactly that reason (see the pattern above). The characters still outside

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -176,8 +176,10 @@ FORM_ID_LENGTH = 8
 # `[0-9A-Za-z_.-]` that the ROUTE admits, which for ASCII is everything in
 # `[-._~()'!*:@,;=+&$%<> \[\]{}|^]` except `-`, `.` and `_` — 24 characters, of
 # which `:`, `+`, `@`, `%`, `~` and a space inside an id are only the illustrations.
-# Seven of the other eighteen (`&`, `'`, `(`, `)`, `;`, `<`, `>`) are the #379
-# payload's own characters, which is exactly why a hand-written list omits them.
+# Seven of the other eighteen (`&`, `'`, `(`, `)`, `;`, `<`, `>`) are the characters
+# the #379 fix turns on — the quote, parens and semicolon the payload closes its
+# handwritten string literal with, plus the `<`, `>` and `&` `_js_value` escapes for
+# the HTML parser — which is exactly why a hand-written list omits them.
 # `"`, `#`, `/`, `?`, `\` and a backtick are the printable-ASCII exceptions: the
 # route admits none of them, so they belong with the tab and the newline below.
 # A non-ASCII character that `\w` does NOT match is likewise not the scan's to
@@ -291,8 +293,10 @@ def _validated_form_id(raw: Any) -> str | None:
     is every character of `[-._~()'!*:@,;=+&$%<> \\[\\]{}|^]` except `-`, `.` and
     `_` — 24 of them, where `:`, `+`, `@`, `%`, `~` and a SPACE within an id such as
     `'my form'` are illustrations and not the set. Seven of the eighteen unnamed
-    ones (`&`, `'`, `(`, `)`, `;`, `<`, `>`) are the #379 payload's own characters,
-    which is why they are the ones a hand-written list drops. On the other side,
+    ones (`&`, `'`, `(`, `)`, `;`, `<`, `>`) are the characters the #379 fix turns
+    on — the quote, parens and semicolon the payload closes its handwritten string
+    literal with, plus the `<`, `>` and `&` `_js_value` escapes for the HTML parser
+    — which is why they are the ones a hand-written list drops. On the other side,
     `"`, `#`, `/`, `?`, a backslash and a backtick are the printable-ASCII
     characters the route does NOT admit, so they sit with the tab and the newline
     below rather than in the scan.

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -980,6 +980,10 @@ def get_form_iframe(form_id: str):
     # `enabled` and the visitor gets a raw API Gateway 404 frame instead, which is
     # a worse answer for the customer who turned the form off on purpose.
     # `test_a_disabled_form_still_serves_its_page_so_the_widget_can_say_so` pins it.
+    #
+    # Both halves of the pair are discarded, including the validated id it hands
+    # back for `/stats` and `/submissions` to build their filter from: this route
+    # already holds that string, having passed it in.
     _load_form_for_query(validated, 'Failed to load form')
 
     host = app.current_event.request_context.get('domainName', '')
@@ -1058,7 +1062,9 @@ def _form_source_pk(form: dict) -> str:
     return f"SOURCE#{effective_brand}" if effective_brand else 'SOURCE#feedback_form'
 
 
-def _load_form_for_query(form_id: str, read_failure_message: str) -> dict:
+def _load_form_for_query(
+    form_id: str, read_failure_message: str
+) -> tuple[str, dict]:
     """Load a form record for a stats/submissions query, failing loudly.
 
     One get_item answers both questions those routes need, so neither has to be
@@ -1079,17 +1085,24 @@ def _load_form_for_query(form_id: str, read_failure_message: str) -> dict:
     and the iframe page's existence gate — `_validated_form_id`'s cost argument
     then holds at every route that states it rather than at one.
 
-    The key is built from the VALIDATED value, like every other call site, rather
-    than from the parameter. Those are the same string today, and relying on that
-    was a latent split rather than a saving: a validator that normalized — a
-    plausible "form ids are case-insensitive" change — would have this function
-    read `FORM#DEADBEEF` while `/config` read `FORM#deadbeef` for the same URL,
-    and `/submissions` would then filter on a `source_channel` built by its caller
-    from the raw id, which no write ever used. A silent zero, which is the exact
-    defect class this function exists to prevent (#312). Keying on the validated
-    value removes the dependency instead of documenting it;
-    `test_the_validator_returns_its_input_unchanged` pins the exactness the
-    callers' own use of `form_id` still relies on.
+    Returns the VALIDATED id alongside the record, and that is the whole reason
+    this signature is a pair rather than a dict. The key here is built from the
+    validated value, but a caller's `source_channel` — the filter that selects
+    which submissions belong to this form — used to be built from the raw
+    parameter, so the read and the filter came from two different strings. They
+    are the same string today, and relying on that was a latent split rather than
+    a saving: a validator that normalized (a plausible "form ids are
+    case-insensitive" change) would have this function read `FORM#DEADBEEF` while
+    `/config` read `FORM#deadbeef` for the same URL, and the caller would filter
+    on `form_DEADBEEF` while every write used `form_deadbeef` — zero submissions
+    for a form that has them, reported as a 200. That is the exact defect class
+    this function exists to prevent (#312), arriving through the door the format
+    check installed. Handing the validated id back removes the dependency instead
+    of documenting it, so `submit_form_feedback`'s write (`f'form_{validated}'`)
+    and both read routes' filter are built from one string.
+    `test_the_validator_returns_its_input_unchanged` still pins the exactness, and
+    `test_the_key_a_query_route_reads_is_the_id_in_its_url` pins the pair
+    end to end.
     """
     validated = _validated_form_id(form_id)
     if not validated:
@@ -1108,7 +1121,7 @@ def _load_form_for_query(form_id: str, read_failure_message: str) -> dict:
     form = response.get('Item')
     if not form:
         raise NotFoundError('Form not found')
-    return form
+    return validated, form
 
 
 @app.get("/feedback-forms/<form_id>/submissions")
@@ -1124,9 +1137,14 @@ def get_form_submissions(form_id: str):
     # One read answers both the 404 and the partition, where this route used to
     # do its own existence check and then have _get_form_source_pk re-read the
     # same record (and swallow a failure of it).
-    form = _load_form_for_query(form_id, 'Failed to fetch form')
+    validated, form = _load_form_for_query(form_id, 'Failed to fetch form')
 
-    source_channel = f'form_{form_id}'
+    # From the VALIDATED id, so this filter and the write that produced the rows
+    # it selects (`submit_form_feedback`, `'source_channel': f'form_{validated}'`)
+    # are built from one string. See _load_form_for_query: a validator that
+    # normalized would otherwise have this route filter on a channel no write ever
+    # used, and the symptom is zero rows rather than an error.
+    source_channel = f'form_{validated}'
     source_pk = _form_source_pk(form)
 
     try:
@@ -1220,9 +1238,12 @@ def get_form_stats(form_id: str):
 
     # 404 for a deleted form, and the partition its submissions are in, from the
     # one read — never a partition guessed from a read that failed.
-    form = _load_form_for_query(form_id, 'Failed to fetch form stats')
+    validated, form = _load_form_for_query(form_id, 'Failed to fetch form stats')
 
-    source_channel = f'form_{form_id}'
+    # From the VALIDATED id, for the same reason as get_form_submissions above:
+    # this filter has to be the string `submit_form_feedback` wrote
+    # (`'source_channel': f'form_{validated}'`), or the count is a false zero.
+    source_channel = f'form_{validated}'
     source_pk = _form_source_pk(form)
 
     try:

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -155,6 +155,32 @@ FORM_ID_LENGTH = 8
 # Powertools' dynamic-route capture group admits all of those (issue #379), so
 # this pattern, not the route, is what bounds them.
 #
+# `.` IS INSIDE the class, and it is here for a compatibility reason rather than
+# an aesthetic one. This pattern is a NEW refusal on records that already exist:
+# the character class is the only bound in this change that can turn a row which
+# used to resolve into a 404 on all five of its routes, and unlike the whitespace
+# case there is no argument that such a row was already unreachable. `acme.website`
+# resolved correctly before — the dot was part of the key and the key was found —
+# so narrowing it out is data loss dressed as hardening. A dotted id is also the
+# most plausible hand-seeded spelling after `website-form`, since it is how a
+# domain is written. It costs the fix nothing: `.` cannot close a JavaScript
+# string, open a tag or start a statement, so admitting it moves no character the
+# #379 serializer depends on. `test_a_dotted_hand_seeded_form_id_still_resolves`
+# is what fails if it is dropped again, and the remaining exclusions (`:`, `+`,
+# `@`, `%` and everything non-ASCII) are named to an operator with a pre-upgrade
+# scan in CHANGELOG.md's upgrade notes, since for those the 404 is real.
+#
+# The `(?!\.{1,2}\Z)` in front of the class is what makes admitting `.` safe, and
+# it is about URL RESOLUTION rather than about DynamoDB: '.' and '..' are the
+# relative-path segments, so a snippet built by joining a base to
+# `feedback-forms/../config` addresses a DIFFERENT resource — the id is removed
+# from the path by the client before a request is ever sent, and the caller sees a
+# working page for a form it did not ask for rather than a refusal. Only those two
+# exact strings are affected ('...' is an ordinary segment), so the exclusion is
+# an exact-match negative lookahead rather than a ban on leading dots, which would
+# refuse `.hidden-form` for no reason. `test_the_two_relative_path_segments_are_not_form_ids`
+# pins both directions.
+#
 # No whitespace either, and that is a choice rather than an oversight: see
 # `_validated_form_id`.
 #
@@ -168,7 +194,9 @@ FORM_ID_LENGTH = 8
 # what they say. `test_a_trailing_newline_is_not_a_valid_form_id` is what fails if
 # it goes back.
 FORM_ID_MAX_LENGTH = 64
-_FORM_ID_PATTERN = re.compile(rf'^[0-9A-Za-z_-]{{1,{FORM_ID_MAX_LENGTH}}}\Z')
+_FORM_ID_PATTERN = re.compile(
+    rf'^(?!\.{{1,2}}\Z)[0-9A-Za-z_.-]{{1,{FORM_ID_MAX_LENGTH}}}\Z'
+)
 
 
 def _minted_form_id() -> str:
@@ -225,6 +253,16 @@ def _validated_form_id(raw: Any) -> str | None:
     the structural serialization at the render site (`_js_value`) bounds what a
     value can do once there. Both, because either alone leaves the other's
     failure fatal.
+
+    A NEW refusal on data that already exists, which is the one respect in which
+    this is not purely additive: an id outside the pattern 404s on all five of its
+    routes, and for a hand-seeded row whose id resolved before, that is a reachable
+    record becoming unreachable rather than a probe being refused. `.` is admitted
+    for exactly that reason (see the pattern above). The characters still outside
+    the class — `:`, `+`, `@`, `%`, `~` and everything non-ASCII — are a deliberate
+    narrowing rather than an oversight, and the upgrade path is an operator scan of
+    the aggregates table for `FORM#` ids outside the class, written down in
+    CHANGELOG.md's upgrade notes rather than left for whoever reads the 404.
 
     NOT `.strip()`ed, which is where this parts company with the sibling it is
     modelled on. There a session id is a 128-bit token and the leniency is
@@ -563,7 +601,15 @@ def create_form():
             )
             raise ServiceError('Failed to create form') from e
         logger.error(f"Error creating form: {e}")
-        raise ServiceError('Failed to create form')
+        # `from e` on both branches, and this is the one that needed it more: the
+        # branch above already names its cause in prose, while here the underlying
+        # ClientError is all the diagnosis there is and `logger.error` stringifies
+        # it without a traceback. Matches `_load_form_for_query`,
+        # `get_form_submissions` and `get_form_stats`, which is the module's
+        # prevailing spelling. No response changes — both branches answer the same
+        # generic message on purpose, so a client cannot tell a collision from a
+        # table failure.
+        raise ServiceError('Failed to create form') from e
 
 
 @app.get("/feedback-forms/<form_id>")

--- a/voc-datalake/lambda/api/feedback_form_handler.py
+++ b/voc-datalake/lambda/api/feedback_form_handler.py
@@ -157,8 +157,18 @@ FORM_ID_LENGTH = 8
 #
 # No whitespace either, and that is a choice rather than an oversight: see
 # `_validated_form_id`.
+#
+# `\Z` rather than `$`, and that ONE character is load-bearing: Python's `$` also
+# matches immediately before a trailing newline, so `$` with `.match` accepted
+# `'deadbeef\n'` — the single whitespace character this pattern is supposed to
+# exclude, arriving by the one route the character class does not police. It also
+# made the length cap bound the MATCHED PREFIX rather than the id, so
+# `'a' * FORM_ID_MAX_LENGTH + '\n'` was admitted at 65 characters. `\Z` matches
+# only at the very end of the string, so the cap and the character class both mean
+# what they say. `test_a_trailing_newline_is_not_a_valid_form_id` is what fails if
+# it goes back.
 FORM_ID_MAX_LENGTH = 64
-_FORM_ID_PATTERN = re.compile(rf'^[0-9A-Za-z_-]{{1,{FORM_ID_MAX_LENGTH}}}$')
+_FORM_ID_PATTERN = re.compile(rf'^[0-9A-Za-z_-]{{1,{FORM_ID_MAX_LENGTH}}}\Z')
 
 
 def _minted_form_id() -> str:
@@ -881,6 +891,28 @@ def _js_value(value: Any) -> str:
 # and the directive has no fallback to `default-src`, so leaving it out is how
 # "any site may embed this" is spelled. Adding it, or an X-Frame-Options header,
 # would break every embed.
+#
+# The other two headers are conventional, but each is here for a reason specific to
+# THIS response rather than as boilerplate:
+#
+# `nosniff` matters more here than it would anywhere else in this API, because this
+# is the only `text/html` it serves. Everything else is JSON, so this is the one
+# response whose whole purpose is to be parsed as a document on the API's own
+# origin — exactly the case where letting a browser decide the type for itself has
+# something to get wrong.
+#
+# `no-referrer` is the one with a PRODUCT consequence, and it is the one worth
+# recording so a future reader does not read it as data the product wanted and lost.
+# The page is framed on a customer's site, so without it the `Referer` on the
+# widget's own two fetches would carry the customer's page URL into this API's
+# access logs. Note the widget already sends `page_url: window.location.href` in
+# the submit body ON PURPOSE — so this is not withholding the URL from the product,
+# which receives it as a field it chose. It keeps it out of a log nobody asked to
+# collect it in.
+#
+# Both are pinned by `test_the_response_carries_the_two_headers_the_csp_does_not`:
+# `test_the_policy_names_every_directive_the_page_needs_and_no_wildcard` reads the
+# policy BY KEY and so would not notice either being removed or renamed.
 _IFRAME_SECURITY_HEADERS = {
     'Content-Security-Policy': (
         "default-src 'none'; "

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -3582,12 +3582,24 @@ def _sink_bearing_helpers(tree: ast.Module) -> frozenset[str]:
     Two exclusions, both in the false-positive direction, because this set only
     ever ADDS sinks to a caller:
 
-    - A function that calls `_validated_form_id` itself. That is what keeps
-      `_load_form_for_query` — which reads, and which three routes delegate to —
-      a refusal rather than an unguarded sink: it bounds the id it was handed
-      before its own read, which `_validates_its_form_id` already accepts as the
-      delegating spelling. Counting it would report `/iframe`, `/stats` and
-      `/submissions` as unbounded.
+    - A function that BOUNDS for itself — `_bounds_its_id`, the same
+      refusal-plus-order-plus-linkage decision the route check applies, asked of
+      the helper. That is what keeps `_load_form_for_query` — which reads, and
+      which three routes delegate to — a refusal rather than an unguarded sink:
+      it refuses the id it was handed before its own read, and keys that read on
+      the value the refusal vouched for. Counting it would report `/iframe`,
+      `/stats` and `/submissions` as unbounded.
+
+      Deliberately NOT "the body mentions `_validated_form_id` somewhere", which
+      is what this used to ask. A mention is not a bound, and the three shapes it
+      wrongly excluded are the ones a hardening edit produces: a validator call
+      under `if False:`, a call about a DIFFERENT value than the one written, and
+      a call whose result is never refused. Each dropped the helper out of this
+      set, so its write went back to being invisible and a route handing it a raw
+      id reported bounded. The last of those is `_anchor_form_brand` plus a
+      defensive-looking line, i.e. the plausible next edit to the one helper this
+      set names — see
+      `test_the_helper_set_is_not_escaped_by_mentioning_the_validator`.
     - A ROUTE handler, since a route is entered by the resolver rather than called
       by another function here. Without this the set names `list_forms`,
       `create_form`, `get_form_stats` and `get_form_submissions` — true of them
@@ -3595,37 +3607,51 @@ def _sink_bearing_helpers(tree: ast.Module) -> frozenset[str]:
       did, the caller would be accused for a read the route bounds for itself.
 
     A fixpoint rather than one level, because a helper calling a helper is the same
-    hole one step further out and the loop costs four lines. It resolves NAMES in
-    this module only: a sink reached through an imported function is still invisible,
-    which is the remaining ceiling — worth stating rather than implying, since the
-    failure mode is the vacuous pass this whole helper exists to close.
+    hole one step further out and the loop costs four lines. Both questions are
+    re-asked on every pass, since a helper joining the set can give another one a
+    sink it did not have before — the set only ever grows, so this terminates.
+
+    Three ceilings, all in the same direction — a write this set cannot see is one
+    no question is asked about, so the verdict is the vacuous pass the helper
+    exists to close. Named rather than implied, so the next reader knows they are
+    accepted rather than overlooked:
+
+    - it resolves NAMES defined in THIS module, so a sink reached through an
+      imported function is invisible;
+    - candidates are the module's TOP-LEVEL definitions, so a `def` nested one
+      level (inside `if TYPE_CHECKING:`, a `try:`/`except ImportError:` shim, a
+      feature flag) is not one;
+    - a call reaches a helper by its own NAME, so `fn = _writer` then `fn(id)` is
+      not matched — the alias class `_collect_aliases` handles for table handles,
+      unhandled for functions.
+
+    `async def` is NOT among them: it is a candidate like any other
+    (`test_the_helper_set_sees_an_async_writer`), because a different node type is
+    the weakest possible reason for a write to escape.
     """
-    def _eligible(node: ast.FunctionDef) -> bool:
-        validates = any(
-            isinstance(call, ast.Call)
-            and isinstance(call.func, ast.Name)
-            and call.func.id == '_validated_form_id'
-            for call in ast.walk(node)
-        )
-        routed = any(
+    def _routed(node) -> bool:
+        return any(
             isinstance(decorator, ast.Call)
             and isinstance(decorator.func, ast.Attribute)
             and isinstance(decorator.func.value, ast.Name)
             and decorator.func.value.id == 'app'
             for decorator in node.decorator_list
         )
-        return not validates and not routed
 
     candidates = {
         node.name: node for node in tree.body
-        if isinstance(node, ast.FunctionDef) and _eligible(node)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and not _routed(node)
     }
     helpers: set[str] = set()
     growing = True
     while growing:
         growing = False
         for name, node in candidates.items():
-            if name not in helpers and _sink_calls(node, frozenset(helpers)):
+            if name in helpers:
+                continue
+            known = frozenset(helpers)
+            if _sink_calls(node, known) and not _bounds_its_id(node, known):
                 helpers.add(name)
                 growing = True
     return frozenset(helpers)
@@ -3837,9 +3863,20 @@ def _refused_names(function: ast.FunctionDef) -> dict[str, tuple[int, int]]:
     return refused
 
 
-def _validates_its_form_id(source: str, function_name: str) -> bool:
-    """Does `function_name` reach the validator, and REFUSE, before keying on
-    anything?
+def _bounds_its_id(
+    function, helpers: frozenset[str] = frozenset()
+) -> bool:
+    """Does `function` reach the validator, and REFUSE, before keying on anything?
+
+    THE decision, asked of any `FunctionDef` — a route (`_validates_its_form_id`,
+    which is this with the module parsed for it) or a module-level helper
+    (`_sink_bearing_helpers`, which excludes one that bounds for itself). One
+    function rather than two, because the two callers were asking the same
+    question and only one of them was asking it properly: the helper exclusion
+    used to test whether `_validated_form_id` was MENTIONED anywhere in the body,
+    which a dead call, a call about another value and an unenforced call all
+    satisfy. Sharing this makes "bounds its id" mean the same thing on both sides
+    by construction.
 
     Positional and result-aware, because the order and the refusal are the whole
     claim. An earlier version of this helper was an order-insensitive set-membership
@@ -3905,17 +3942,13 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     rather than an unremarkable string. The ceiling: propagation follows `Assign`
     and `AnnAssign` only, so an id smuggled through a `for` target or a mutated
     container is not traced — a deliberate stopping point, since the shapes that
-    exist here build keys and filters by assignment.
+    exist here build keys and filters by assignment. For the same reason the taint
+    SOURCE is the parameter list, so an id taken from `app.current_event` rather
+    than from the capture group is outside this instrument by construction:
+    Powertools always hands the capture in as a parameter, and an id out of the
+    request BODY is a different validation question. "Universal over the values
+    Powertools binds as parameters" is the accurate reading of the claim.
     """
-    tree = ast.parse(source)
-    functions = [
-        node for node in ast.walk(tree)
-        if isinstance(node, ast.FunctionDef) and node.name == function_name
-    ]
-    assert len(functions) == 1, (
-        f'expected exactly one def {function_name}, found {len(functions)}'
-    )
-    function = functions[0]
     refused = _refused_names(function)
 
     def _calls(statement) -> list[ast.Call]:
@@ -3927,6 +3960,31 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     def _mentioned(node: ast.AST) -> set[str]:
         return {
             child.id for child in ast.walk(node) if isinstance(child, ast.Name)
+        }
+
+    def _bare_arguments(call: ast.Call) -> set[str]:
+        """The call's arguments that are a NAME and nothing else.
+
+        What the refusal of `_validated_form_id(form_id)` vouches for is `form_id`
+        — the value that was handed in. It vouches for nothing about a value that
+        was TRANSFORMED on the way in: `_validated_form_id(form_id.lower())`
+        establishes that the lowercased string is well formed, and a key built from
+        raw `form_id` afterwards is built from a value nothing checked.
+
+        That distinction is not academic here. `_load_form_for_query`'s docstring
+        reasons about "a plausible 'form ids are case-insensitive' change",
+        `_validated_form_id`'s argues at length against `.strip()`ing, and
+        `test_a_query_route_filters_on_the_id_it_read_even_if_the_validator_normalizes`
+        monkeypatches a normalizing validator for that exact reason — so a
+        normalizing spelling is the change this module has already anticipated
+        twice, and walking the whole argument expression would have made this
+        derivation the one instrument that kept reporting such a route bounded
+        (`test_the_derivation_refuses_a_bound_on_a_transformed_argument`).
+        """
+        return {
+            argument.id
+            for argument in [*call.args, *(kw.value for kw in call.keywords)]
+            if isinstance(argument, ast.Name)
         }
 
     def _target_names(statement) -> set[str]:
@@ -3944,11 +4002,17 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
             if isinstance(name, ast.Name)
         }
 
-    def _walrus_refusal(statement) -> tuple[tuple[int, int], ast.Call] | None:
+    def _walrus_refusal(
+        statement,
+    ) -> tuple[tuple[int, int], ast.Call, str] | None:
         """`if not (<name> := _validated_form_id(...)):` — bind and refuse in one.
 
         The `if`'s own position, because for this spelling the binding and the
         refusal are the same statement — there is no gap between them to measure.
+        The walrus TARGET is returned alongside the call, rather than read back out
+        of the condition with `_mentioned`, so this spelling binds exactly what the
+        two-statement one does: the target and the bare arguments, not every name a
+        transformed argument happens to mention.
         """
         if not isinstance(statement, ast.If):
             return None
@@ -3958,6 +4022,7 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
         bound = test.operand
         if not (
             isinstance(bound, ast.NamedExpr)
+            and isinstance(bound.target, ast.Name)
             and isinstance(bound.value, ast.Call)
             and _named(bound.value, '_validated_form_id')
         ):
@@ -3968,12 +4033,19 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
             for child in ast.walk(node)
         ):
             return None
-        return (statement.lineno, statement.col_offset), bound.value
+        return (
+            (statement.lineno, statement.col_offset), bound.value, bound.target.id
+        )
 
     # name -> the earliest position from which it is known to be bounded. Both the
     # id handed TO the validator and the value handed BACK are bounded from the
     # refusal, since the refusal is what makes the one a well-formed id and the
     # other not None.
+    #
+    # Only the names the refusal actually vouches for: the statement's TARGETS and
+    # the call's BARE-NAME arguments (`_bare_arguments`). A transformed argument is
+    # deliberately not a bound on its source — `_validated_form_id(form_id.lower())`
+    # says nothing about `form_id`.
     bounded_at: dict[str, tuple[int, int]] = {}
 
     def _bind(names, position: tuple[int, int]) -> None:
@@ -3984,13 +4056,13 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     for statement in function.body:
         walrus = _walrus_refusal(statement)
         if walrus is not None:
-            position, call = walrus
-            _bind(_mentioned(call) | _mentioned(statement.test), position)
+            position, call, target = walrus
+            _bind(_bare_arguments(call) | {target}, position)
         for call in _calls(statement):
             if _named(call, '_load_form_for_query'):
                 # This one raises for itself, so the call is the refusal.
                 position = (statement.lineno, statement.col_offset)
-                _bind(_mentioned(call) | _target_names(statement), position)
+                _bind(_bare_arguments(call) | _target_names(statement), position)
             if not _named(call, '_validated_form_id'):
                 continue
             # The result has to be BOUND and then refused. An `Expr` statement, or
@@ -4000,13 +4072,13 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
             # and anything between the two runs with it.
             refusals = [refused[target] for target in targets if target in refused]
             if refusals:
-                _bind(targets | _mentioned(call), min(refusals))
+                _bind(targets | _bare_arguments(call), min(refusals))
 
     if not bounded_at:
         return False
     validated_at = min(bounded_at.values())
 
-    sinks = _sink_calls(function, _sink_bearing_helpers(tree))
+    sinks = _sink_calls(function, helpers)
     # No sink is not a pass by default: #379 was a route that touched no AWS
     # service at all and still put the id in its response, so a route that keys on
     # nothing yet takes an id out of the URL still has to establish the bound.
@@ -4049,6 +4121,25 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     return not any(
         mentioned & _unbounded_at(position) for position, mentioned in sinks
     )
+
+
+def _validates_its_form_id(source: str, function_name: str) -> bool:
+    """`_bounds_its_id` for the named function in `source`.
+
+    The route-facing entry point: it resolves the name against the module and
+    derives the sink-bearing helper set, which is the only thing the decision needs
+    beyond the function itself.
+    """
+    tree = ast.parse(source)
+    functions = [
+        node for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == function_name
+    ]
+    assert len(functions) == 1, (
+        f'expected exactly one def {function_name}, found {len(functions)}'
+    )
+    return _bounds_its_id(functions[0], _sink_bearing_helpers(tree))
 
 
 class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
@@ -4570,6 +4661,189 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
             'route that delegates one'
         )
 
+    @pytest.mark.parametrize(
+        'shape, helper',
+        [
+            pytest.param(
+                '''
+                def _writer(form_id):
+                    aggregates_table.put_item(Item={'sk': f'FORM#{form_id}'})
+                    if False:
+                        _validated_form_id(form_id)
+                ''',
+                '_writer',
+                id='the validator call is dead code',
+            ),
+            pytest.param(
+                '''
+                def _writer(form_id, brand):
+                    aggregates_table.put_item(Item={'sk': f'FORM#{form_id}'})
+                    if not _validated_form_id(brand):
+                        raise NotFoundError('Form not found')
+                ''',
+                '_writer',
+                id='it refuses a different value than the one it writes',
+            ),
+            pytest.param(
+                '''
+                def _anchor_form_brand(form_id, effective_brand):
+                    validated = _validated_form_id(form_id)
+                    aggregates_table.update_item(
+                        Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                    )
+                ''',
+                '_anchor_form_brand',
+                id='it validates but never refuses',
+            ),
+        ],
+    )
+    def test_the_helper_set_is_not_escaped_by_mentioning_the_validator(
+        self, shape, helper
+    ):
+        """A helper leaves the sink-bearing set by BOUNDING, not by mentioning.
+
+        The exclusion used to be `any(... == '_validated_form_id' ...)` over
+        `ast.walk` — the validator's name appearing anywhere in the body. Its own
+        docstring justified it with `_load_form_for_query`, "which bounds the id it
+        was handed BEFORE its own read": a refusal-and-order-and-linkage property.
+        The code asked the much weaker "does the name appear", so each shape here
+        dropped the helper out of the set, its write became invisible again, and a
+        route handing it a raw id was reported bounded on an EMPTY sink list — the
+        exact silence `_sink_bearing_helpers` was added to close.
+
+        None is exotic, and the third is not hypothetical at all: it is
+        `_anchor_form_brand` with a defensive-looking validator call added and the
+        two lines that refuse omitted, i.e. the plausible next hardening edit to the
+        one helper this set names — which under the old exclusion would silently
+        remove the control this class just gained for it.
+
+        `_bounds_its_id` is what decides the exclusion now, so "bounds its id" means
+        the same thing for a helper as for a route by construction.
+        """
+        helper_source = textwrap.dedent(shape)
+        source = helper_source + textwrap.dedent(
+            '''
+            @app.post("/feedback-forms/<form_id>/helper-write")
+            def post_helper_write(form_id: str):
+                _WRITER_(form_id, 'Acme')
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+            '''
+        ).replace('_WRITER_', helper)
+
+        assert _sink_bearing_helpers(ast.parse(source)) == {helper}, (
+            f'{helper} dropped out of the sink-bearing set because it MENTIONS '
+            '_validated_form_id — a dead, misdirected or unenforced call is not a '
+            'bound, and excluding on one makes the write it performs invisible'
+        )
+        assert not _validates_its_form_id(source, 'post_helper_write'), (
+            'the route handed a raw id to a helper that writes it and was reported '
+            'bounded — the helper escaped the set, so there was no sink to ask '
+            'either question about'
+        )
+
+    def test_the_helper_set_sees_an_async_writer(self):
+        """`async def` is a different node type, not a different question.
+
+        Candidates were `isinstance(node, ast.FunctionDef)` over `tree.body`, which
+        `ast.AsyncFunctionDef` is not — so an `async def` helper that wrote what it
+        was handed was never even considered, and the route calling it reported
+        bounded on an empty sink list. Nothing in this sync Lambda handler is
+        `async` today, which is exactly when the shape costs one token to close.
+
+        Pinned so the widening is deliberate rather than incidental. The two
+        remaining shapes — a `def` nested one level at module scope, and a helper
+        reached through a local alias — are named as accepted ceilings in
+        `_sink_bearing_helpers`'s docstring instead, since closing them needs
+        machinery rather than a token.
+        """
+        source = textwrap.dedent(
+            '''
+            async def _write_form(form_id):
+                aggregates_table.put_item(
+                    Item={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+
+            @app.post("/feedback-forms/<form_id>/async-write")
+            def post_async_write(form_id: str):
+                _write_form(form_id)
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+            '''
+        )
+
+        assert _sink_bearing_helpers(ast.parse(source)) == {'_write_form'}, (
+            'an async def helper that writes what it is handed was not a candidate '
+            'for the sink-bearing set — the node type is AsyncFunctionDef, and the '
+            'candidate filter has to admit both'
+        )
+        assert not _validates_its_form_id(source, 'post_async_write'), (
+            'a write through an async helper was reported as bounded — the sink '
+            'list was empty, so neither question was asked'
+        )
+
+    def test_the_derivation_refuses_a_bound_on_a_transformed_argument(self):
+        """Validating `form_id.lower()` is not validating `form_id`.
+
+        The linkage rule binds the names the refusal vouches for, and an earlier
+        version bound every name reachable inside the validator CALL. So a
+        normalizing spelling — `validated = _validated_form_id(form_id.lower())`,
+        refuse, then key on raw `form_id` — reported bounded, although only the
+        transformed value was ever checked and the key was built from the parameter.
+
+        This is the one shape worth its own case, because a normalizing validator is
+        a change this module has already anticipated twice and defended against:
+        `_validated_form_id`'s docstring argues at length against `.strip()`ing,
+        `_load_form_for_query`'s reasons about "a plausible 'form ids are
+        case-insensitive' change", and
+        `test_a_query_route_filters_on_the_id_it_read_even_if_the_validator_normalizes`
+        monkeypatches exactly that validator. The day such a change lands, this
+        derivation would have been the one instrument still reporting a route
+        bounded while it read a key it never checked.
+
+        Both directions, since narrowing the binding must not cost the spelling
+        every real route uses: the bare-name argument still binds the parameter.
+        """
+        transformed = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/normalized")
+            def get_normalized(form_id: str):
+                validated = _validated_form_id(form_id.lower())
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+            '''
+        )
+
+        assert not _validates_its_form_id(transformed, 'get_normalized'), (
+            'a route that validated form_id.lower() and keyed on raw form_id was '
+            'reported as bounded — the refusal vouches for the value handed IN, so '
+            'a transformed argument is not a bound on its source'
+        )
+
+        bare = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/plain")
+            def get_plain(form_id: str):
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+            '''
+        )
+
+        assert _validates_its_form_id(bare, 'get_plain'), (
+            'the bare-name spelling stopped binding its argument — every real route '
+            'in the module passes the parameter directly and keys on it or on the '
+            'value handed back, so this must stay accepted'
+        )
+
     def test_the_derivation_refuses_validating_the_wrong_capture(self):
         """Validating SOMETHING is not validating the id the read keys on.
 
@@ -5086,12 +5360,14 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
             == 'form_DeadBeef'
         )
 
+    @pytest.mark.parametrize('route', ['submissions', 'stats'])
     @patch('feedback_form_handler.feedback_table')
     @patch('feedback_form_handler.aggregates_table')
     def test_a_query_route_filters_on_the_id_it_read_even_if_the_validator_normalizes(
         self,
         mock_table,
         mock_feedback_table,
+        route,
         api_gateway_event,
         lambda_context,
         feedback_form_handler,
@@ -5114,6 +5390,16 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         parameter would filter on `form_DeadBeef` beside a key of `FORM#deadbeef`
         and select nothing — zero submissions for a form that has them, answered
         as a 200, which is #312's false zero.
+
+        The RESPONSE's `form_id` is asserted alongside them, because it is the
+        third use of the same string and the one a caller reads: a body naming
+        `DeadBeef` beside a count measured on `form_deadbeef` reports a number for
+        a record it does not name, and it looks authoritative while doing it. Both
+        query routes therefore echo the validated id, as
+        `submit_form_feedback` already stores it — which is why this case runs over
+        BOTH of them rather than over `/submissions` alone: they are two copies of
+        the same three-way agreement, and only pinning each catches the one that
+        drifts.
         """
         exact = feedback_form_handler._validated_form_id
         mock_table.get_item.return_value = {
@@ -5123,9 +5409,9 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
 
         event = api_gateway_event(
             method='GET',
-            path='/feedback-forms/DeadBeef/submissions',
+            path=f'/feedback-forms/DeadBeef/{route}',
             path_params={'form_id': 'DeadBeef'},
-            resource='/feedback-forms/{form_id}/submissions',
+            resource=f'/feedback-forms/{{form_id}}/{route}',
         )
 
         with patch.object(
@@ -5140,10 +5426,15 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         channel = mock_feedback_table.query.call_args.kwargs[
             'ExpressionAttributeValues'
         ][':sc']
-        assert (key, channel) == ('FORM#deadbeef', 'form_deadbeef'), (
-            f'the route read {key} and filtered on {channel} — the two are built '
-            'from different strings, so the filter names a source_channel no write '
-            'produced and the route reports zero for a form that has submissions'
+        reported = json.loads(response['body'])['form_id']
+        assert (key, channel, reported) == (
+            'FORM#deadbeef', 'form_deadbeef', 'deadbeef'
+        ), (
+            f'the route read {key}, filtered on {channel} and reported '
+            f'{reported!r} — these are built from different strings, so the filter '
+            'names a source_channel no write produced (zero rows for a form that '
+            'has submissions) or the body names an id other than the record the '
+            'count was measured on'
         )
 
 

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -4234,7 +4234,10 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
 
     That claim was false when it was written — `/config`, `/submit`, `/iframe`,
     `/stats` and `/submissions` were covered and the authenticated CRUD trio was
-    not, while the docstring enumerated five routes as if they were all of them.
+    not, while the docstring enumerated only those five public and read routes as
+    if they were all of them. (It now enumerates all eight, which is the number
+    `test_the_derivation_sees_the_routes_this_module_actually_has` pins; the five
+    here is the historical shape of the defect, not a live count.)
     A prose list is the wrong instrument for a universal claim: it goes stale
     silently, and the reader who trusts it assumes a protection that is not there.
 

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -5563,10 +5563,34 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         fix actually turns on is still refused, so a future widening cannot cite
         this one as precedent for `'` or `<`.
 
-        `:`, `+`, `@`, `%` and `é` are here for a different reason — they are the
-        exclusions the upgrade notes tell an operator to SCAN for, so they have to
-        be genuinely refused for that instruction to describe the code.
+        `:`, `+`, `@`, `%`, `é` and `my form` are here for a different reason — they
+        are the exclusions the upgrade notes tell an operator to SCAN for, so they
+        have to be genuinely refused for that instruction to describe the code.
+        `my form` earns its place for the same reason `a:b` has one: a stored id with
+        INTERIOR whitespace resolved before this change (every route keyed
+        `f'FORM#{form_id}'` with nothing checked) and answers 404 after it, so it is
+        reachable-then-orphaned rather than exempt. That is why the whitespace
+        exemption in `CHANGELOG.md` and `docs/feedback-forms.md` is scoped to an id
+        merely ADDRESSED with surrounding space — ` abc123` never resolved to
+        `abc123` — and not to whitespace-bearing ids as a category.
+
+        The accepting cases at the top are the vacuity control, and they are what
+        makes the two refusal loops an argument rather than a tautology. Adding a
+        character to a class can never make a previously-refused string accepted, so
+        the refusal loops alone are one-directional in the direction a NARROWING
+        travels — which is the direction the compatibility regression this change is
+        about actually moves. Without the accepting cases every assertion here is
+        satisfied by reverting the class to `[0-9A-Za-z_-]`, and also by an oracle
+        that refuses every input; with them, both of those fail.
         """
+        for accepted in ('acme.website', 'website-form', 'a_b',
+                         feedback_form_handler._minted_form_id()):
+            assert feedback_form_handler._validated_form_id(accepted) == accepted, (
+                f'{accepted!r} was refused — the refusal loops below only mean '
+                'something read against a class that still admits the shapes the '
+                'widening exists for, so this is the control that stops them '
+                'passing against a validator which refuses everything'
+            )
         for dangerous in ('a\'b', 'a"b', 'a(b', 'a)b', 'a;b', 'a<b', 'a>b',
                           'a&b', 'a\\b', 'a b', 'a\tb', 'a/b', 'a\nb'):
             assert feedback_form_handler._validated_form_id(dangerous) is None, (
@@ -5574,7 +5598,7 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
                 'depends on being outside the class, and admitting `.` must not '
                 'have moved it'
             )
-        for scanned in ('a:b', 'a+b', 'a@b', 'a%b', 'café', 'a~b'):
+        for scanned in ('a:b', 'a+b', 'a@b', 'a%b', 'café', 'a~b', 'my form'):
             assert feedback_form_handler._validated_form_id(scanned) is None, (
                 f'{scanned!r} was accepted — CHANGELOG.md tells an operator to '
                 'scan stored ids for exactly these, so if one is now admitted the '

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -1,8 +1,12 @@
 """
 Tests for feedback_form_handler.py - /feedback-forms/* endpoints.
 """
+import ast
+import inspect
 import json
+import os
 import re
+import textwrap
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -2143,4 +2147,472 @@ class TestTheAnchorCanOnlyEverUpdateAFormThatExists:
             'covering the pre-anchor partition means recording the prior brand '
             'and doubling the reads on a route that already pages a whole '
             'partition. If that changed, this expectation changes with it.'
+        )
+
+
+# ============================================
+# The public iframe page (issue #379)
+# ============================================
+#
+# `GET /feedback-forms/<form_id>/iframe` is the ONE route in this API that answers
+# with a document instead of JSON, unauthenticated, on the API's own origin, and
+# it is designed to be framed on customers' sites. Before this change it
+# interpolated the caller-supplied path segment straight into a `<script>` block
+# and returned 200 without reading the table at all, so
+# `a');alert(document.domain);x=('` — which the route's own pattern accepts — was
+# rendered as executable script.
+
+# The payload from the issue, kept as one constant because three separate tests
+# assert three different things about the same string: that the ROUTE admits it,
+# that the HANDLER refuses it, and that the SERIALIZER would have made it inert
+# even if it arrived. Its three dangerous characters are the quote that closes the
+# string literal, the `)` that closes the init call and the `;` that starts a
+# second statement.
+_INJECTION_PAYLOAD = "a');alert(document.domain);x=('"
+
+
+def _iframe_event(api_gateway_event, form_id: str) -> dict:
+    """A GET of the public iframe page for `form_id`.
+
+    `resource` is spelled the way API Gateway sends it for the deployed route
+    (`/feedback-forms/{form_id}/iframe`) rather than left to the fixture's
+    path-derived default, which would embed the id itself and stop Powertools
+    matching the dynamic route for an id containing a `/`.
+
+    `domainName` is set because the page's apiEndpoint is built from it, and it is
+    a REQUEST-supplied value like the id — asserted below to be serialized too.
+    """
+    event = api_gateway_event(
+        method='GET',
+        path=f'/feedback-forms/{form_id}/iframe',
+        path_params={'form_id': form_id},
+        resource='/feedback-forms/{form_id}/iframe',
+    )
+    event['requestContext']['domainName'] = 'api.example.com'
+    return event
+
+
+def _route_pattern_for_iframe(handler) -> re.Pattern:
+    """The regex Powertools compiled for the iframe route, off the live resolver.
+
+    Read from the app rather than restated: the point of the positive control
+    below is that the FRAMEWORK accepts the payload, so a copy of powertools'
+    capture group pasted here would prove nothing about the version installed.
+    """
+    routes = [
+        route for route in handler.app._dynamic_routes
+        if route.rule.pattern.endswith('/iframe/*$')
+    ]
+    assert len(routes) == 1, (
+        f'expected exactly one dynamic /iframe route on the resolver, found '
+        f'{len(routes)} — this helper needs updating, it is not a finding about '
+        'validation.'
+    )
+    return routes[0].rule
+
+
+def _init_call_argument(page: str) -> str:
+    """The text between `VoCFeedbackForm.init(` and the end of the page.
+
+    Everything the handler wrote AFTER the opening parenthesis of the init call,
+    deliberately unparsed: the assertions below decide where the argument ends by
+    handing this to a JSON decoder, which is the whole question. Slicing at a
+    matching `)` here would answer it in the helper.
+
+    `rfind`, because the inlined widget's own docblock contains a
+    `VoCFeedbackForm.init({` usage example; the call the handler emits is the last
+    one on the page.
+    """
+    marker = 'VoCFeedbackForm.init('
+    start = page.rfind(marker)
+    assert start != -1, (
+        'the rendered page contains no VoCFeedbackForm.init( call — the embed '
+        'contract changed; this is a broken helper, not an injection finding.'
+    )
+    return page[start + len(marker):]
+
+
+def _quoted_interpolations(source: str, function_name: str) -> list[str]:
+    """Interpolations inside `function_name` that a handwritten quote pair wraps.
+
+    Derived from the handler's SOURCE with `ast`, scoped to one function, because
+    the defect being pinned is a spelling rather than an output: `'{form_id}'` in
+    an f-string is a JavaScript string literal whose quotes the template chose, so
+    the value can close them. `json.dumps` brings its own quotes; wrapping its
+    result in another pair puts the value back outside them.
+
+    Returns the offending source snippets so a failure names them. An interpolated
+    expression that is followed by a quote but not preceded by one (or the reverse)
+    is reported too: an unbalanced quote around a value is not a safe spelling
+    either, it is a broken one.
+    """
+    tree = ast.parse(source)
+    functions = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == function_name
+    ]
+    assert len(functions) == 1, (
+        f'expected exactly one def {function_name} in the source given, found '
+        f'{len(functions)} — a rename would otherwise make this derivation '
+        'silently scan nothing.'
+    )
+    function = functions[0]
+    offenders = []
+    for joined in (n for n in ast.walk(function) if isinstance(n, ast.JoinedStr)):
+        parts = joined.values
+        for index, part in enumerate(parts):
+            if not isinstance(part, ast.FormattedValue):
+                continue
+            before = parts[index - 1] if index else None
+            after = parts[index + 1] if index + 1 < len(parts) else None
+            preceded = (
+                isinstance(before, ast.Constant)
+                and isinstance(before.value, str)
+                and before.value.endswith(('"', "'"))
+            )
+            followed = (
+                isinstance(after, ast.Constant)
+                and isinstance(after.value, str)
+                and after.value.startswith(('"', "'"))
+            )
+            if preceded or followed:
+                # The EXPRESSION, not the `{...}` around it: the name is what a
+                # failure has to report, since it is the value whose quoting is
+                # wrong and the thing the reader has to go and fix.
+                offenders.append(ast.unparse(part.value))
+    return offenders
+
+
+class TestThePublicIframePageRefusesAnIdItCannotHaveMinted:
+    """Both gates in front of the iframe page, and the page they gate (#379).
+
+    A malformed id and an id for a form that does not exist answer the same 404,
+    and both answer it BEFORE any HTML exists — the route used to render a page
+    for any string its pattern matched, having read nothing.
+    """
+
+    def test_the_route_pattern_admits_the_payload_this_class_refuses(
+        self, feedback_form_handler
+    ):
+        """The positive control, without which every 404 below is meaningless.
+
+        If powertools' capture group refused this string, the refusals asserted
+        below would be the FRAMEWORK's and the tests would pass with
+        `_validated_form_id` deleted. Read off the compiled route on the live
+        resolver, so it tracks the installed version.
+        """
+        rule = _route_pattern_for_iframe(feedback_form_handler)
+
+        assert rule.match(f'/feedback-forms/{_INJECTION_PAYLOAD}/iframe'), (
+            f'the route pattern {rule.pattern} no longer matches '
+            f'{_INJECTION_PAYLOAD!r}, so the 404s in this class prove nothing '
+            'about the handler. If powertools narrowed its capture group, this '
+            'class needs a payload that still reaches the handler.'
+        )
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_quote_paren_semicolon_id_is_refused_before_any_html(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The defect itself: this used to be 200 text/html with the payload in a
+        script block. It must be a 404, produced without touching the table —
+        format is decided before a read is paid for."""
+        response = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, _INJECTION_PAYLOAD), lambda_context
+        )
+
+        assert response['statusCode'] == 404
+        assert 'html' not in response['body'].lower()
+        assert 'alert(' not in response['body']
+        # Not echoed back in any form, either: the refusal names the resource,
+        # never the caller's string.
+        assert 'document.domain' not in response['body']
+        mock_table.get_item.assert_not_called()
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_an_over_long_id_is_refused_without_a_read(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """Length is bounded as well as character set, so a megabyte path segment
+        costs no DynamoDB call. Derived from the cap rather than hardcoded: a
+        literal would silently become a VALID length the day the cap is raised."""
+        too_long = 'a' * (feedback_form_handler.FORM_ID_MAX_LENGTH + 1)
+
+        response = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, too_long), lambda_context
+        )
+
+        assert response['statusCode'] == 404
+        mock_table.get_item.assert_not_called()
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_well_formed_id_for_an_absent_form_is_refused(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The gate the route did not have at all: /config and /submit 404 an id
+        the table does not hold, and this route rendered a page for it. An
+        attacker-chosen page on this origin is the thing that mattered, and it did
+        not need a malformed id."""
+        mock_table.get_item.return_value = {}
+
+        response = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, 'deadbeef'), lambda_context
+        )
+
+        assert response['statusCode'] == 404
+        assert 'html' not in response['body'].lower()
+        # The read HAPPENED — this is the existence gate, not the format one, and
+        # a 404 that skipped the lookup would be the format check refusing a
+        # legitimate id instead.
+        mock_table.get_item.assert_called_once()
+        assert (
+            mock_table.get_item.call_args.kwargs['Key']['sk'] == 'FORM#deadbeef'
+        )
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_server_minted_id_still_serves_the_embeddable_page(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The contract that must survive the two gates: a real form's page still
+        renders, inlines the widget and points it at that form's config and submit
+        endpoints on this request's own host.
+
+        The id comes from the mint (`_minted_form_id`) rather than from a literal,
+        so a validator narrowed past the format this service actually issues fails
+        here instead of in a customer's iframe.
+        """
+        form_id = feedback_form_handler._minted_form_id()
+        mock_table.get_item.return_value = {'Item': {'form_id': form_id}}
+
+        response = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, form_id), lambda_context
+        )
+        page = response['body']
+
+        assert response['statusCode'] == 200
+        assert response['multiValueHeaders']['Content-Type'] == ['text/html']
+        assert '<div id="voc-feedback-form"></div>' in page
+        # The widget is inlined, not linked: the page has no second request to
+        # make for its own code (get_widget_js).
+        assert 'window.VoCFeedbackForm' in page
+
+        options = json.loads(_json_prefix(_init_call_argument(page)))
+        assert options['formId'] == form_id
+        assert options['configEndpoint'] == f'/feedback-forms/{form_id}/config'
+        assert options['submitEndpoint'] == f'/feedback-forms/{form_id}/submit'
+        assert options['apiEndpoint'] == 'https://api.example.com/test'
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_hand_seeded_form_id_is_still_embeddable(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The bound is wider than the mint deliberately, and this is why.
+
+        Records seeded by hand or by an import carry readable ids
+        ('website-form'), and their /config and /submit routes answer, so an
+        iframe narrowed to `[0-9a-f]{8}` would 404 a form that otherwise works —
+        which reads as the product breaking rather than as a refusal. Pinned so
+        the width is a decision rather than an accident of the pattern.
+        """
+        mock_table.get_item.return_value = {'Item': {'form_id': 'website-form_2'}}
+
+        response = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, 'website-form_2'), lambda_context
+        )
+
+        assert response['statusCode'] == 200
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_the_page_carries_a_policy_that_still_lets_a_customer_frame_it(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """A CSP on the only HTML response in the API — with the ONE directive it
+        must not carry.
+
+        `frame-ancestors` (and X-Frame-Options) would refuse the embed this route
+        exists for, and `frame-ancestors` has no fallback to `default-src`, so its
+        absence is the deliberate half of the header rather than an omission. The
+        asserted half is `default-src 'none'`: no external script, image or frame
+        can load, so a value that somehow escaped the serializer has nowhere to
+        send anything.
+        """
+        mock_table.get_item.return_value = {'Item': {'form_id': 'deadbeef'}}
+        event = _iframe_event(api_gateway_event, 'deadbeef')
+        # The resolver only emits a CORS header for a request that carries an
+        # Origin it is configured to allow, so the last assertion below needs one
+        # sent. In this suite that is conftest's ALLOWED_ORIGIN; the deployed
+        # Lambda is given '*' (api-stack.ts) because the embed's origin is a
+        # customer's own domain.
+        event['headers']['Origin'] = os.environ['ALLOWED_ORIGIN']
+
+        headers = feedback_form_handler.lambda_handler(event, lambda_context)[
+            'multiValueHeaders'
+        ]
+
+        policy = headers['Content-Security-Policy'][0]
+        assert "default-src 'none'" in policy
+        assert 'frame-ancestors' not in policy, (
+            'frame-ancestors refuses the embed this route exists for — see '
+            'docs/feedback-forms.md, which publishes the iframe snippet'
+        )
+        assert 'X-Frame-Options' not in headers
+        # And the CORS header is still there: adding response headers of our own
+        # must not have replaced the ones the resolver contributes.
+        assert headers['Access-Control-Allow-Origin'] == [
+            os.environ['ALLOWED_ORIGIN']
+        ]
+
+
+def _json_prefix(text: str) -> str:
+    """The longest leading substring of `text` that is one JSON value.
+
+    `raw_decode` is the point rather than a convenience: it reports where the
+    value ENDS, so the caller can assert what follows it. That is how "the input
+    could not create a second statement" is checked without a JavaScript engine —
+    if a payload had closed the argument, the decoder would stop early and the
+    remainder would carry the caller's code instead of just `);`.
+    """
+    value, end = json.JSONDecoder().raw_decode(text)
+    assert value is not None
+    return text[:end]
+
+
+class TestEveryJavaScriptValueOnTheIframePageIsSerialized:
+    """Escaping, asserted independently of the validation in front of it.
+
+    The two are not alternatives: `_validated_form_id` bounds what reaches the
+    handler, and this bounds what a value can DO once there — so widening the
+    pattern later, or a change in the route regex underneath it, cannot turn into
+    executable script. Which means these cases have to reach the serializer
+    directly, since the route now refuses the payload before rendering.
+    """
+
+    def test_the_injection_payload_serializes_to_one_inert_string(
+        self, feedback_form_handler
+    ):
+        """Quote, `)` and `;` become data: one JSON string, nothing after it.
+
+        The failing spelling — `'{form_id}'` — produced
+        `formId: 'a');alert(document.domain);x=('',` i.e. a closed string, a
+        closed call and a second statement. The assertion is therefore about the
+        REMAINDER: a serialized value that consumed the whole text cannot have
+        ended early enough to start anything.
+        """
+        serialized = feedback_form_handler._js_value(_INJECTION_PAYLOAD)
+
+        value, end = json.JSONDecoder().raw_decode(serialized)
+        assert value == _INJECTION_PAYLOAD, (
+            'the value did not survive as itself — the widget would receive a '
+            'different form id than the caller asked for'
+        )
+        assert end == len(serialized), (
+            f'the JSON value ends at {end} of {len(serialized)}; '
+            f'{serialized[end:]!r} is trailing text a JavaScript engine would '
+            'read as further code'
+        )
+        # The serializer chose the delimiters, which is why the payload's
+        # apostrophe is harmless while still being emitted as itself: the literal
+        # is double-quoted, so `'` is an ordinary character inside it and the `)`
+        # and `;` after it never leave it. Asserted this way rather than as "`'`
+        # does not appear", which would be a claim about JSON's escaping style
+        # rather than about what the value can do.
+        assert serialized.startswith('"') and serialized.endswith('"')
+        assert '"' not in serialized[1:-1], (
+            'an unescaped double quote inside the literal would close the '
+            'delimiter the serializer chose, which is the same defect one '
+            'delimiter along'
+        )
+
+    def test_a_script_closing_tag_cannot_end_the_element(
+        self, feedback_form_handler
+    ):
+        """`</script>` ends a script element wherever it appears, INCLUDING inside
+        a JavaScript string literal — the HTML parser gets there first and knows
+        nothing about quoting. So `json.dumps` alone is not enough for this
+        position, and `html.escape` would be wrong (its `&lt;` is an entity the
+        script context never decodes, corrupting the value).
+        """
+        serialized = feedback_form_handler._js_value('</script><img src=x>')
+
+        assert '<' not in serialized
+        assert '>' not in serialized
+        # Still the same string to the JavaScript engine, which is the half a
+        # naive strip-the-characters fix would lose.
+        assert json.loads(serialized) == '</script><img src=x>'
+
+    def test_no_javascript_value_is_wrapped_in_a_handwritten_quote_pair(
+        self, feedback_form_handler
+    ):
+        """The spelling, not just this render's output.
+
+        Read off `get_form_iframe`'s source with `ast`: an interpolation with a
+        quote character on either side is a template deciding where a JavaScript
+        string begins and ends, which is the defect. A serializer's output brings
+        its own quotes, so it needs none around it — and quotes around it would
+        make the ones it wrote into data.
+        """
+        source = Path(inspect.getsourcefile(feedback_form_handler)).read_text(
+            encoding='utf-8'
+        )
+        offenders = _quoted_interpolations(source, 'get_form_iframe')
+
+        assert offenders == [], (
+            f'{offenders} are interpolated inside handwritten quotes in '
+            'get_form_iframe. A JS value must be emitted through _js_value, '
+            'which quotes it itself.'
+        )
+
+    def test_the_quoted_interpolation_check_can_fail(self):
+        """Positive control for the derivation above.
+
+        Without it, an `ast` walk that found no JoinedStr at all — a template
+        moved into a helper, a parse that quietly matched nothing — would report
+        an empty list and the test above would pass while pinning nothing. The
+        input is the exact spelling this change removed.
+        """
+        source = textwrap.dedent('''
+            def get_form_iframe(form_id):
+                return f"""
+                  formId: '{form_id}',
+                  options: {init_options}
+                """
+        ''')
+
+        offenders = _quoted_interpolations(source, 'get_form_iframe')
+
+        assert offenders == ['form_id'], (
+            'the derivation did not flag the exact spelling this change removed, '
+            f'it reported {offenders} — so a green result above means nothing.'
+        )
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_the_rendered_init_call_carries_exactly_one_statement(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """End to end, on a page that really renders: the init argument is one
+        JSON value and what follows it is only the call's own punctuation.
+
+        This is the property the route-level 404s cannot show, because they never
+        get as far as HTML — and it is the property that survives someone
+        widening the id pattern.
+        """
+        form_id = feedback_form_handler._minted_form_id()
+        mock_table.get_item.return_value = {'Item': {'form_id': form_id}}
+
+        page = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, form_id), lambda_context
+        )['body']
+
+        argument = _init_call_argument(page)
+        _value, end = json.JSONDecoder().raw_decode(argument)
+        remainder = argument[end:]
+
+        assert remainder.startswith(');'), (
+            f'the init argument is followed by {remainder[:40]!r} rather than '
+            'the call being closed immediately — anything between the value and '
+            "the `)` is code the page's own template put there"
+        )
+        # Nothing but the closing of the script and the document after it.
+        assert remainder.split(');', 1)[1].strip() == (
+            '</script>\n</body>\n</html>'
         )

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -10,6 +10,7 @@ import re
 import textwrap
 from datetime import datetime
 from pathlib import Path
+from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
 import boto3
@@ -3311,7 +3312,7 @@ class TestTheAuthenticatedCrudRoutesAreBoundedToo:
     # A VALID `PUT` body, and it has to be: `update_form` 400s on an empty update
     # (`No fields to update`), so a body with nothing in it would produce a refusal
     # that says nothing about the id. What is malformed in these cases is the ID.
-    A_VALID_UPDATE_BODY = {'name': 'pwn'}
+    A_VALID_UPDATE_BODY: ClassVar[dict[str, str]] = {'name': 'pwn'}
 
     @patch('feedback_form_handler.aggregates_table')
     def test_no_crud_route_turns_a_malformed_id_into_a_key(
@@ -5599,9 +5600,16 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         fix actually turns on is still refused, so a future widening cannot cite
         this one as precedent for `'` or `<`.
 
-        `:`, `+`, `@`, `%`, `é` and `my form` are here for a different reason — they
-        are the exclusions the upgrade notes tell an operator to SCAN for, so they
-        have to be genuinely refused for that instruction to describe the code.
+        The `scanned_ascii` loop is here for a different reason — those are the
+        exclusions the upgrade notes tell an operator to SCAN for, so they have to be
+        genuinely refused for that instruction to describe the code. All 24 of them,
+        not the five the notes name as illustrations: both documents now state that
+        set as a complement (every character the route's capture group admits and this
+        pattern does not) and print it, and a check covering only the memorable
+        characters is what let the prose stand at six of twenty-four. Seven of the
+        rest are the #379 payload's own, so the `dangerous` loop above asserts those
+        for their own reason and this loop re-covers them deliberately: they are in
+        both sets, and each set's claim should be readable without the other.
         `my form` earns its place for the same reason `a:b` has one: a stored id with
         an INTERIOR SPACE resolved before this change (every route keyed
         `f'FORM#{form_id}'` with nothing checked) and answers 404 after it, so it is
@@ -5648,12 +5656,20 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
                 'depends on being outside the class, and admitting `.` must not '
                 'have moved it'
             )
-        for scanned in ('a:b', 'a+b', 'a@b', 'a%b', 'café', 'a~b', 'my form'):
+        scanned_ascii = ' !$%&\'()*+,:;<=>@[]^{|}~'
+        for scanned in [f'a{c}b' for c in scanned_ascii] + ['café', 'my form']:
             assert feedback_form_handler._validated_form_id(scanned) is None, (
                 f'{scanned!r} was accepted — CHANGELOG.md tells an operator to '
                 'scan stored ids for exactly these, so if one is now admitted the '
                 'upgrade note describes a refusal that does not happen'
             )
+        assert len(scanned_ascii) == 24, (
+            f'{len(scanned_ascii)} ASCII characters here, not 24 — both documents '
+            'state the in-scope ASCII set as a COMPLEMENT and then print it, so '
+            'this literal is the copy that has to agree with them. '
+            'test_the_scan_is_scoped_to_ids_a_route_could_actually_resolve is where '
+            'membership is derived off the live resolver rather than listed.'
+        )
 
     def test_the_scan_is_scoped_to_ids_a_route_could_actually_resolve(
         self, feedback_form_handler
@@ -5682,8 +5698,17 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         enumerating all 0x110000 codepoints — so the reachable loop carries one id
         per `\\w` category (`Ll` `'café'`, `Lm` `'hawaiʼi-form'`, `Lo` `'表単'`,
         `Lt` `'ǅigit'`, `Lu` `'ÉCOLE'`, `Nd` `'form٠a'`, `Nl` `'section-Ⅷ'`, `No`
-        `'surface-m²'`) and the unreachable loop one per class `\\w` excludes
-        (`Mn`, `Mc`, `Me`, `Sc`, `Zs`, `Cf`, `Pc`).
+        `'surface-m²'`) and the unreachable loop one per class `\\w` excludes:
+        every class either document NAMES (`Mn`, `Mc`, `So`, `Pd`, `Pi`, `Pf`, `Zs`,
+        `Cf`, `Sc`), plus `Me`, `Pc`, `Zl` and `Zp`, which they do not name but which
+        are outside `\\w` for the same reason.
+
+        On the ASCII side the same principle applies to the CLASS rather than to a
+        category: the in-scope set is 24 characters, and the note named six of them,
+        so `'form(1)'` and `'a;b'` are sampled beside the named `'a:b'`. Those two
+        hold characters from the #379 payload itself, which is the reason a list
+        written by hand omits them — they read as attack syntax rather than as an id
+        anyone would seed, and they resolved regardless.
 
         Exhaustively rather than representatively, because a partial sample is what
         let the prose go wrong twice. `Lm` and `No` read to a human as punctuation,
@@ -5717,13 +5742,21 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         path that matches NOTHING — which would report every character as excluded
         and pass an assertion set made only of exclusions.
         """
-        # After the three ASCII cases, one id per `\w` category, so no category
-        # stands in for another: `Ll` `café`, `Lm` `hawaiʼi-form` (U+02BC, an
-        # apostrophe to the eye), `Lo` `表単`, `Lt` `ǅigit`, `Lu` `ÉCOLE`, `Nd`
-        # `form٠a` (ARABIC-INDIC DIGIT ZERO), `Nl` `section-Ⅷ`, `No` `surface-m²`.
-        for reachable in ('my form', '   ', 'a:b', 'café', 'hawaiʼi-form', '表単',
-                          'ǅigit', 'ÉCOLE', 'form٠a', 'section-Ⅷ',
-                          'surface-m²'):
+        # The ASCII cases first. `a:b` is one of the characters both documents name;
+        # `form(1)` and `a;b` are two they do NOT. The in-scope ASCII set is 24
+        # characters, and the seven the #379 payload is built from (`&`, `'`, `(`,
+        # `)`, `;`, `<`, `>`) are exactly the ones a hand-written list drops, because
+        # they read as attack syntax rather than as an id anyone would seed. They
+        # resolved all the same, so sampling only a NAMED character would pin the
+        # note's list rather than the class the classifier actually tests.
+        #
+        # Then one id per `\w` category, so no category stands in for another: `Ll`
+        # `café`, `Lm` `hawaiʼi-form` (U+02BC, an apostrophe to the eye), `Lo`
+        # `表単`, `Lt` `ǅigit`, `Lu` `ÉCOLE`, `Nd` `form٠a` (ARABIC-INDIC DIGIT
+        # ZERO), `Nl` `section-Ⅷ`, `No` `surface-m²`.
+        for reachable in ('my form', '   ', 'a:b', 'form(1)', 'a;b', 'café',
+                          'hawaiʼi-form', '表単', 'ǅigit', 'ÉCOLE',
+                          'form٠a', 'section-Ⅷ', 'surface-m²'):
             admitting = [
                 f'{method} {path}'
                 for method, path, rule in _form_id_route_paths(
@@ -5745,9 +5778,28 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
 
         # One id per class `\w` EXCLUDES, mirroring the per-category loop above so
         # that neither side of the boundary rests on a representative sample:
-        # `form€a` is `Sc`, `form\xa0a` is `Zs`, `cafe\u0301` is `Mn`, the Devanagari
-        # id is `Mc`, `form\u0488a` is `Me`, `form\u200da` is `Cf` (a zero-width
-        # joiner) and `form\uff3fa` is `Pc`.
+        # `form€a` is `Sc`, `form°a` and `form\U0001f600a` are `So`,
+        # `form—a` is `Pd`, `form«a` is `Pi`, `hawai\u2019i-form` is `Pf`,
+        # `form\uff3fa` is `Pc`, `cafe\u0301` is `Mn`, `form\u0488a` is `Me`,
+        # `form\u200da` is `Cf` (a zero-width joiner), `form\xa0a` is `Zs`, and
+        # `form\u2028a` / `form\u2029a` are `Zl` / `Zp`. The Devanagari id carries
+        # BOTH a matra (`Mc`) and a virama (`Mn`) — `['Lo','Mc','Lo','Mn','Lo']` — so
+        # it is the `Mc` sample and is NOT disjoint from the `Mn` one, which is
+        # `cafe\u0301`.
+        #
+        # `So`, `Pd`, `Pi` and `Pf` are in the loop because both documents NAME them:
+        # `€`, `°` and an emoji as symbols, `—` and `«` as punctuation, and U+2019
+        # as the out-of-scope half of the apostrophe look-alike pair. The criterion is
+        # the one this test's docstring states — a class named in either document and
+        # absent here would make their "asserts this split" citation false — and a
+        # selection of only marks, one symbol, one separator and one format character
+        # was in exactly that state.
+        #
+        # `Zl` and `Zp` are the pair NEITHER document's `Z*` illustration covers:
+        # U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR are not `Zs` like the
+        # U+00A0 and U+3000 both documents name, and they are the exact two characters
+        # `_js_value`'s `ensure_ascii=True` exists to escape — so a reader meets them
+        # in both roles and is owed the fact that no route admits them either.
         #
         # `Pc` earns its line because it is the NEAR MISS: `_` is the one `\w`
         # member outside `L*`/`N*`, and `_` is `Pc` — but the REST of `Pc` (U+FF3F
@@ -5770,9 +5822,11 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         # did. Both documents name `caf\u00e9` in scope without saying which of the
         # two spellings they mean. `\u200d` and `\u0488` would be invisible, or would
         # stack onto the preceding character, in an editor.
-        for unreachable in ('abc\tdef', 'abc\ndef', 'form€a', 'form\xa0a',
-                            'cafe\u0301', 'फॉर्म', 'form\u0488a',
-                            'form\u200da', 'form\uff3fa'):
+        for unreachable in ('abc\tdef', 'abc\ndef', 'form€a', 'form°a',
+                            'form\U0001f600a', 'form—a', 'form«a',
+                            'hawai\u2019i-form', 'form\uff3fa', 'cafe\u0301',
+                            'फॉर्म', 'form\u0488a', 'form\u200da',
+                            'form\xa0a', 'form\u2028a', 'form\u2029a'):
             admitting = [
                 f'{method} {path}'
                 for method, path, rule in _form_id_route_paths(

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -2267,6 +2267,17 @@ def _quoted_interpolations(source: str, function_name: str) -> list[str]:
     context and none is in an attribute. If a legitimate HTML-context value is
     added here, widen this derivation to allow it — do NOT remove the escaping to
     get green.
+
+    `ast.FunctionDef` alone, where `_sink_bearing_helpers` and
+    `_routes_keying_on_a_form_id` accept `ast.AsyncFunctionDef` too, and that is a
+    decision rather than the last place a widening was forgotten. The argument for
+    widening those two is a failure DIRECTION: a route or a helper they cannot see
+    leaves the universe silently, so the verdict is a vacuous pass. This function
+    fails LOUDLY instead — the assert below reports "found 0" and names the function
+    it could not find, because it is scoped to one concretely named subject rather
+    than deriving a set. So an `async def get_form_iframe` breaks this test rather
+    than emptying it, which is the outcome the widening exists to produce. Widen it
+    anyway if it ever takes its subject from a derivation.
     """
     tree = ast.parse(source)
     functions = [
@@ -2514,6 +2525,48 @@ class TestThePublicIframePageRefusesAnIdItCannotHaveMinted:
         )
 
         assert response['statusCode'] == 200
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_dotted_hand_seeded_form_id_still_resolves(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The sibling above pins the width for `-` and `_`; this pins it for `.`.
+
+        The one respect in which this change is not additive: the character class is
+        a NEW refusal applied to ids that are ALREADY STORED, so for a row outside
+        it the change turns a record that resolved into one that 404s on all five of
+        its routes. The whitespace case in the upgrade notes is exempt from that by
+        an argument — ` abc123` never addressed `abc123`, the space was always part
+        of the key — but a dotted id has no such argument available: `acme.website`
+        was found, and nothing about it is malformed.
+
+        `.` is therefore inside the class, and it costs the #379 fix nothing: a dot
+        cannot close a JavaScript string, open a tag or begin a statement, so no
+        character the serializer depends on moved. The characters still outside
+        (`:`, `+`, `@`, `%`, non-ASCII) get an operator scan in the upgrade notes
+        instead, because for those the 404 is real.
+
+        Asserted on the KEY the route read rather than on the status alone: a 200
+        would also be produced by a route that had stopped keying on the id at all,
+        and it is reachability of the stored row — not the response code — that this
+        case is about.
+        """
+        mock_table.get_item.return_value = {'Item': {'form_id': 'acme.website'}}
+
+        response = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, 'acme.website'), lambda_context
+        )
+
+        assert response['statusCode'] == 200, (
+            'a dotted hand-seeded id was refused its page — that row resolved '
+            'before this change, so refusing it is a stored form becoming '
+            'unreachable rather than a probe being refused'
+        )
+        assert (
+            mock_table.get_item.call_args.kwargs['Key']['sk'] == 'FORM#acme.website'
+        )
+        options = json.loads(_json_prefix(_init_call_argument(response['body'])))
+        assert options['formId'] == 'acme.website'
 
     @patch('feedback_form_handler.aggregates_table')
     def test_a_disabled_form_still_serves_its_page_so_the_widget_can_say_so(
@@ -5449,6 +5502,7 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
             'deadbeef',
             'DEADBEEF',
             'website-form_2',
+            'acme.website',
             'a',
             'a' * feedback_form_handler.FORM_ID_MAX_LENGTH,
             feedback_form_handler._minted_form_id(),
@@ -5458,6 +5512,73 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
                 f'{feedback_form_handler._validated_form_id(valid)!r} — a '
                 'normalized return makes the record a route reads and the id it '
                 'echoes back describe two different forms'
+            )
+
+    def test_the_two_relative_path_segments_are_not_form_ids(
+        self, feedback_form_handler
+    ):
+        """`.` and `..` are refused, and this is why admitting `.` is safe.
+
+        The exclusion is about URL RESOLUTION rather than about DynamoDB, so it is
+        the one part of the character class whose reason is not "this character
+        could close a string". `feedbackFormPublicUrl` and the snippet in
+        `docs/feedback-forms.md` both build a path by joining a base to
+        `feedback-forms/<id>/iframe`; with an id of `..` a client resolves that to a
+        path with the segment REMOVED before any request is sent, so the caller
+        reaches a different resource and sees it working rather than being refused.
+        A stored row cannot be addressed at all under those two ids, which makes
+        admitting them worse than refusing them.
+
+        Exactly those two strings, which is the reason for a negative lookahead
+        anchored with `\\Z` rather than a ban on dots in some position: `'...'` is an
+        ordinary path segment, and `.hidden-form` and `form.` are ordinary ids. A
+        blanket "no leading dot" rule would refuse three reachable shapes to
+        exclude two unreachable ones.
+        """
+        for relative in ('.', '..'):
+            assert feedback_form_handler._validated_form_id(relative) is None, (
+                f'{relative!r} was accepted as a form id — it is a relative-path '
+                'segment, so a client resolves it away and addresses a different '
+                'resource than the one asked for'
+            )
+        # The other direction, and the whole reason the exclusion is exact: without
+        # these the lookahead could be widened to any leading dot (or to any id
+        # containing one) and nothing would notice.
+        for ordinary in ('...', '.hidden-form', 'form.', 'acme.website'):
+            assert feedback_form_handler._validated_form_id(ordinary) == ordinary, (
+                f'{ordinary!r} was refused — it is an ordinary path segment, not a '
+                'relative one, so the exclusion has been widened past the two '
+                'strings it is for'
+            )
+
+    def test_widening_the_class_for_a_dot_moved_no_character_the_fix_needs(
+        self, feedback_form_handler
+    ):
+        """The control on the compatibility widening above.
+
+        `.` was added to the character class so a hand-seeded `acme.website` keeps
+        resolving, and the argument for that being free is that a dot cannot end a
+        JavaScript string, open an HTML tag or begin a statement. This is that
+        argument as an assertion rather than a sentence: every character the #379
+        fix actually turns on is still refused, so a future widening cannot cite
+        this one as precedent for `'` or `<`.
+
+        `:`, `+`, `@`, `%` and `é` are here for a different reason — they are the
+        exclusions the upgrade notes tell an operator to SCAN for, so they have to
+        be genuinely refused for that instruction to describe the code.
+        """
+        for dangerous in ('a\'b', 'a"b', 'a(b', 'a)b', 'a;b', 'a<b', 'a>b',
+                          'a&b', 'a\\b', 'a b', 'a\tb', 'a/b', 'a\nb'):
+            assert feedback_form_handler._validated_form_id(dangerous) is None, (
+                f'{dangerous!r} was accepted — this is a character the #379 fix '
+                'depends on being outside the class, and admitting `.` must not '
+                'have moved it'
+            )
+        for scanned in ('a:b', 'a+b', 'a@b', 'a%b', 'café', 'a~b'):
+            assert feedback_form_handler._validated_form_id(scanned) is None, (
+                f'{scanned!r} was accepted — CHANGELOG.md tells an operator to '
+                'scan stored ids for exactly these, so if one is now admitted the '
+                'upgrade note describes a refusal that does not happen'
             )
 
     def test_a_trailing_newline_is_not_a_valid_form_id(

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -3466,31 +3466,73 @@ _FORM_ID_SINKS = frozenset({
     'aggregates_table', 'feedback_table', 'sqs', 'dynamodb',
 })
 
+# The OPERATION names, which is the property that is closed over spellings where
+# the receiver names above are not.
+#
+# A receiver allowlist cannot be complete for "reaches a form id into a sink",
+# because the handle can be produced by anything: this repo alone reads the same
+# table as `aggregates_table.get_item(...)`, as
+# `dynamodb.Table(AGGREGATES_TABLE).get_item(...)` (module scope, line ~40), as
+# `table = get_aggregates_table()` then `table.get_item(...)` (the PREVAILING
+# style — `ballots_handler.py:379`, `projects_handler.py:1347`/`:2283`/`:2402`,
+# `integrations_handler.py:545`, `scrapers_handler.py:228`, twelve sites), and
+# `lambda/shared/tables.py` routes that factory through
+# `get_dynamodb_resource().Table(...)`. Every one of those names a different
+# receiver and the same METHOD, and it is the method that makes the call a read or
+# a write. `ballots_handler` is the sibling `_validated_form_id`'s docstring names
+# as this design's model, so the shape the receiver allowlist could not see was the
+# one a new form-id route was most likely to be written in.
+#
+# Adding a name to the frozenset above closes one spelling; matching the operation
+# closes the class. Both are kept: the receiver match still catches a call whose
+# method this set does not name (a `meta.client` call, a paginator), and the
+# operation match catches a named method through any handle at all.
+#
+# Erring toward calling something a sink is the right side of this: a false
+# positive costs a route author an explanation, while a false negative is a read
+# NOBODY reports — an empty `sink_positions` makes `_validates_its_form_id`'s
+# `all(...)` vacuously True, so the instrument answers "bounded" when it understood
+# nothing.
+_SINK_OPERATIONS = frozenset({
+    'get_item', 'put_item', 'update_item', 'delete_item', 'query', 'scan',
+    'batch_get_item', 'batch_write_item', 'send_message', 'send_message_batch',
+})
+
 
 def _sink_call_positions(function: ast.FunctionDef) -> list[tuple[int, int]]:
     """Positions of every call in `function` that reaches a form id into a sink.
 
-    Matched on the CALLEE CHAIN rather than on `<sink>.<method>` alone, which is
-    what an earlier version of this derivation did — and it recognised a read only
-    when spelled `aggregates_table.get_item(...)` literally. Two shapes therefore
-    reported as bounded while reading before validating, and the failure mode was
+    A call counts as a sink two ways, and either is enough:
+
+    - its METHOD is one of `_SINK_OPERATIONS`, whatever handle it arrives through.
+      That is the one that is closed over spellings; the constant's comment carries
+      the argument and the in-repo lines it is derived from.
+    - a sink NAME appears anywhere in the callee chain — including a local alias of
+      one — which still catches a call whose method that set does not name.
+
+    Both exist because an earlier version had only the second, spelled as
+    `<sink>.<method>` on the immediate owner, and every shape it could not see
+    reported as bounded while reading before validating. The failure mode is
     SILENCE rather than a wrong answer: no sink found makes `sink_positions` empty,
-    and `all(...)` over an empty list is vacuously True.
+    and `all(...)` over an empty list is vacuously True. Each shape below is a
+    control in `TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes`:
 
-    - `table = aggregates_table` then `table.get_item(...)`. Locally bound sinks
-      are tracked below for this one.
-    - `dynamodb.Table(AGGREGATES_TABLE).get_item(...)`, where the sink name sits
-      further down the chain than `call.func.value`. Walking the whole callee
-      subtree is what catches it, and it is the more plausible of the two because
-      the module itself demonstrates that spelling.
+    - `table = aggregates_table` then `table.get_item(...)` — alias tracking.
+    - `dynamodb.Table(AGGREGATES_TABLE).get_item(...)` — the sink name sits deeper
+      in the chain than `call.func.value`.
+    - `table = get_aggregates_table()` then `table.get_item(...)`, and
+      `get_dynamodb_resource().Table(T).get_item(...)` — no sink name anywhere, so
+      only the operation match sees them.
 
-    Both are controls in `TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes`.
-
-    Aliases are collected from the function's TOP LEVEL, in source order, and only
-    from a plain `name = <expression mentioning a sink>`. A conditionally bound
-    alias is not tracked, deliberately: this derivation errs toward calling
-    something a sink, and the cost of a false positive is a route author being made
-    to say why — whereas a false negative is a read nobody reports.
+    Aliases are collected in source order and from NESTED bodies as well as the top
+    level (`try`, `with`, `if`, `for`), because every table read in this handler
+    sits inside a `try:` — so the plausible spelling of an alias is an indented
+    one, and three of the twelve in-repo `table = get_aggregates_table()` sites are
+    themselves inside one. An untracked alias is a FALSE NEGATIVE, not a cautious
+    false positive: the call drops out of `sink_positions` and the shorter list
+    makes the `all()` MORE likely to pass. That is the same vacuous pass the
+    controls exist to prevent, which is why alias collection is generous while the
+    REFUSAL's top-level requirement — a separate axis — stays strict.
     """
     aliases: set[str] = set()
 
@@ -3501,22 +3543,31 @@ def _sink_call_positions(function: ast.FunctionDef) -> list[tuple[int, int]]:
             for child in ast.walk(node)
         )
 
-    for statement in function.body:
-        if not isinstance(statement, ast.Assign):
-            continue
-        if not _mentions_a_sink(statement.value):
-            continue
-        aliases |= {
-            target.id for target in statement.targets
-            if isinstance(target, ast.Name)
-        }
+    def _collect_aliases(body: list[ast.stmt]) -> None:
+        for statement in body:
+            if isinstance(statement, ast.Assign) and _mentions_a_sink(
+                statement.value
+            ):
+                aliases.update(
+                    target.id for target in statement.targets
+                    if isinstance(target, ast.Name)
+                )
+            # A sink handle bound inside a `try:`/`with`/`if`/`for` is still bound.
+            for field in ('body', 'orelse', 'finalbody'):
+                nested = getattr(statement, field, None)
+                if isinstance(nested, list):
+                    _collect_aliases(nested)
+            for handler in getattr(statement, 'handlers', []):
+                _collect_aliases(handler.body)
+
+    _collect_aliases(function.body)
 
     return [
         (call.lineno, call.col_offset)
         for call in ast.walk(function)
         if isinstance(call, ast.Call)
         and isinstance(call.func, ast.Attribute)
-        and _mentions_a_sink(call.func)
+        and (call.func.attr in _SINK_OPERATIONS or _mentions_a_sink(call.func))
     ]
 
 
@@ -3546,7 +3597,43 @@ def _refused_names(function: ast.FunctionDef) -> dict[str, tuple[int, int]]:
     one, so hoisting just the assignment out of the dead block escaped the
     top-level requirement while nothing was ever refused
     (`test_the_derivation_refuses_a_refusal_that_only_runs_sometimes`).
+
+    A NEGATIVE test of the name — `if not <name>:` or `if <name> is None:` — and
+    not any `if` mentioning it. An earlier version accepted whatever the test
+    asserted, so an `if` returning on the SUCCESS path was credited as the
+    refusal: `if validated: return render(validated)` and
+    `if validated in _PAGE_CACHE: return _PAGE_CACHE[validated]` both reported a
+    bound while refusing nothing at all — the malformed id falls THROUGH the
+    condition with None bound and reaches the read. The second is the natural
+    spelling of the in-Lambda half of the `Cache-Control` follow-up recorded in
+    `lib/stacks/api-stack.ts`, so the gap sat in front of the next planned change
+    (`test_the_derivation_refuses_a_success_path_return`,
+    `test_the_derivation_refuses_a_cache_hit_return`).
+
+    Those two spellings are the only ones the module uses, so narrowing to them
+    changed no verdict. If a third legitimate one appears (`if validated is None
+    or ...`), widen this deliberately and add the control; do not go back to
+    accepting any test that names the value, because "the name is mentioned in a
+    condition" was never the claim.
     """
+    def _negatively_tested(test: ast.expr) -> list[str]:
+        # `if not <name>:`
+        if isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not):
+            if isinstance(test.operand, ast.Name):
+                return [test.operand.id]
+            return []
+        # `if <name> is None:`
+        if (
+            isinstance(test, ast.Compare)
+            and isinstance(test.left, ast.Name)
+            and len(test.ops) == 1
+            and isinstance(test.ops[0], ast.Is)
+            and isinstance(test.comparators[0], ast.Constant)
+            and test.comparators[0].value is None
+        ):
+            return [test.left.id]
+        return []
+
     refused: dict[str, tuple[int, int]] = {}
     for node in function.body:
         if not isinstance(node, ast.If):
@@ -3558,11 +3645,9 @@ def _refused_names(function: ast.FunctionDef) -> dict[str, tuple[int, int]]:
         ):
             continue
         position = (node.lineno, node.col_offset)
-        for name in ast.walk(node.test):
-            if not isinstance(name, ast.Name):
-                continue
-            known = refused.get(name.id)
-            refused[name.id] = position if known is None else min(known, position)
+        for name in _negatively_tested(node.test):
+            known = refused.get(name)
+            refused[name] = position if known is None else min(known, position)
     return refused
 
 
@@ -3578,7 +3663,7 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     and each has a control below — the second one mattering most, since a route
     with no bound at all looked identical to a correct one.
 
-    A validating statement is one of two spellings, both required to sit at the
+    A validating statement is one of three spellings, all required to sit at the
     function's TOP LEVEL:
 
     - `<name> = _validated_form_id(...)` where `<name>` is later tested in an `if`
@@ -3587,6 +3672,16 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
       REFUSAL's, not the assignment's: an assignment that binds None costs nothing,
       so a read between it and the raise is a read of `FORM#None` that the check
       was supposed to prevent.
+    - `if not (<name> := _validated_form_id(...)):` — the walrus form, ACCEPTED
+      rather than tolerated. It is strictly safer than the two-statement one: there
+      is no statement boundary between the binding and the refusal, so the
+      `FORM#None` window the bullet above has to measure cannot exist in it at all.
+      An earlier version of this helper recognised only the two-statement spelling
+      and would therefore have reported a correctly guarded route as unbounded —
+      pushing whoever wrote the safer form back to the weaker one to get green,
+      which runs the cost of a false positive the wrong way
+      (`test_the_derivation_accepts_the_walrus_spelling`). The `if`'s own position
+      is the refusal's, because they are the same statement.
     - a call to `_load_form_for_query(...)`, which needs no result check because it
       RAISES for itself — so for that spelling the call's own position IS the
       refusal's. Following the delegation rather than demanding the direct call is
@@ -3598,7 +3693,7 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     validation together — a check that only runs on some paths is not a bound, and
     `if False:` is just the extreme of that. If a legitimate spelling ever needs to
     nest (validation inside a `with`, say), widen this deliberately and add the
-    control alongside the three below; do not relax it to get green.
+    control alongside the ones below; do not relax it to get green.
     """
     tree = ast.parse(source)
     functions = [
@@ -3617,8 +3712,37 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     def _named(call: ast.Call, name: str) -> bool:
         return isinstance(call.func, ast.Name) and call.func.id == name
 
+    def _walrus_refusal(statement) -> tuple[int, int] | None:
+        """`if not (<name> := _validated_form_id(...)):` — bind and refuse in one.
+
+        The `if`'s own position, because for this spelling the binding and the
+        refusal are the same statement — there is no gap between them to measure.
+        """
+        if not isinstance(statement, ast.If):
+            return None
+        test = statement.test
+        if not (isinstance(test, ast.UnaryOp) and isinstance(test.op, ast.Not)):
+            return None
+        bound = test.operand
+        if not (
+            isinstance(bound, ast.NamedExpr)
+            and isinstance(bound.value, ast.Call)
+            and _named(bound.value, '_validated_form_id')
+        ):
+            return None
+        if not any(
+            isinstance(child, (ast.Raise, ast.Return))
+            for node in statement.body
+            for child in ast.walk(node)
+        ):
+            return None
+        return (statement.lineno, statement.col_offset)
+
     validated_at = None
     for statement in function.body:
+        walrus = _walrus_refusal(statement)
+        if walrus is not None:
+            validated_at = min(validated_at or walrus, walrus)
         for call in _calls(statement):
             if _named(call, '_load_form_for_query'):
                 # This one raises for itself, so the call is the refusal.
@@ -3935,6 +4059,226 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
             'this is the spelling the module demonstrates at module scope'
         )
 
+    def test_the_derivation_refuses_a_read_through_a_table_factory(self):
+        """The sink-side gap in the spelling this PACKAGE actually prefers.
+
+        `table = get_aggregates_table()` is not a hypothetical: it is how the
+        aggregates table is read at twelve sites here — `ballots_handler.py:379`
+        (the sibling `_validated_form_id`'s docstring names as this design's model),
+        `projects_handler.py:1347`/`:2283`/`:2402`, `integrations_handler.py:545`,
+        `scrapers_handler.py:228` among them — and `lambda/shared/tables.py:17`
+        routes that factory through `get_dynamodb_resource().Table(...)`, which
+        `feedback_form_handler.py:31` is itself a caller of.
+
+        So the single most likely way the NEXT form-id route gets written in this
+        repo was the one shape a receiver-name allowlist could not see: no sink name
+        appears anywhere in the callee chain, `sink_positions` comes back empty, and
+        `all(...)` over an empty list is vacuously True. Matching the OPERATION
+        (`_SINK_OPERATIONS`) rather than the receiver is what closes the class
+        instead of one more spelling — the method is what makes a call a read.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/factory-read")
+            def get_factory_read(form_id: str):
+                table = get_aggregates_table()
+                item = table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return item
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_factory_read'), (
+            'a read through get_aggregates_table() was not recognised as a read — '
+            'no sink NAME appears in the chain, so only matching the operation '
+            'sees it, and this is the prevailing read idiom in this package'
+        )
+
+        # And the factory one level further out, which `shared/tables.py` itself
+        # composes and this module calls at line ~31 to obtain `dynamodb`.
+        resource_factory = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/resource-read")
+            def get_resource_read(form_id: str):
+                item = get_dynamodb_resource().Table(AGGREGATES_TABLE).get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return item
+            '''
+        )
+
+        assert not _validates_its_form_id(resource_factory, 'get_resource_read'), (
+            'a read through get_dynamodb_resource().Table(...) was not recognised '
+            'as a read — the receiver is produced by a call, so no name in the '
+            'chain is a sink and the verdict came from an EMPTY sink list'
+        )
+
+    def test_the_derivation_refuses_a_read_through_an_alias_bound_in_a_try(self):
+        """The alias one indentation level in, which is where the real ones are.
+
+        Aliases used to be collected from `function.body` only, so an alias bound
+        inside a `try:` was untracked — and EVERY table read in this handler sits
+        inside a `try:`, as do three of the twelve in-repo
+        `table = get_aggregates_table()` sites. The existing alias control passes
+        only because its own alias happens to be at the top level, which is the
+        less likely of the two placements.
+
+        Worth being precise about the direction, because the helper's own docstring
+        used to have it backwards: an untracked alias is a FALSE NEGATIVE. The call
+        drops out of `sink_positions`, and `all(...)` over the shorter list is MORE
+        likely to pass — so the read is not reported at all. That is the vacuous
+        pass these controls exist for, not a cautious over-report.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/nested-alias")
+            def get_nested_alias(form_id: str):
+                try:
+                    table = aggregates_table
+                    table.get_item(
+                        Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                    )
+                except Exception:
+                    pass
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_nested_alias'), (
+            'a read through an alias bound inside a try: was not recognised as a '
+            'read — alias collection has to descend into nested bodies, because '
+            'every read in this handler is inside one'
+        )
+
+    def test_the_derivation_refuses_a_success_path_return(self):
+        """An `if` that returns on the SUCCESS path is not a refusal.
+
+        `_refused_names` used to accept any top-level `if` whose body contained a
+        `Raise` or a `Return`, without looking at what the test asserted. So
+        `if validated: return render(validated)` was credited as the refusal while
+        refusing nothing at all: a malformed id falls THROUGH the condition with
+        `validated` bound to None and reaches the read below it, which is the
+        `Key={'sk': 'FORM#None'}` call the whole cost argument exists to avoid.
+
+        This is why the refusal is now recognised only as a NEGATIVE test of the
+        name — `if not <name>:` or `if <name> is None:`, the two spellings the
+        module uses. "An `if` mentions the value" was never the claim.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/success-return")
+            def get_success_return(form_id: str):
+                validated = _validated_form_id(form_id)
+                if validated:
+                    return render(validated)
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
+                )
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_success_return'), (
+            'a success-path return was counted as the refusal — nothing in this '
+            'function refuses anything, and the malformed id falls through to the '
+            'read with None bound'
+        )
+
+    def test_the_derivation_refuses_a_cache_hit_return(self):
+        """The same shape in the spelling the NEXT planned change would produce.
+
+        `lib/stacks/api-stack.ts` records a `Cache-Control` follow-up as unblocked
+        by #379. If it lands as an in-Lambda cache rather than at the edge, this is
+        what the route looks like — `if validated in _PAGE_CACHE: return ...` — and
+        under the old derivation it was credited as the refusal because the test
+        mentions the name and the body returns.
+
+        So the gap sat directly in front of the one change this PR declares next,
+        which is what makes it worth a case of its own rather than being covered by
+        the success-path one: they fail for the same reason, but only this one is
+        already on somebody's list.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/cached")
+            def get_cached(form_id: str):
+                validated = _validated_form_id(form_id)
+                if validated in _PAGE_CACHE:
+                    return _PAGE_CACHE[validated]
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
+                )
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_cached'), (
+            'a cache-hit return was counted as the refusal — a cache MISS for a '
+            'malformed id falls through to the read with None bound, so this '
+            'function has no bound at all'
+        )
+
+    def test_the_derivation_accepts_the_walrus_spelling(self):
+        """The one spelling that CANNOT exhibit the window the others are measured
+        against — accepted, not merely tolerated.
+
+        `if not (validated := _validated_form_id(form_id)):` binds and refuses in a
+        single statement, so there is no boundary between the two for a read to be
+        inserted into. Every other control in this class is about that gap: the
+        assignment binds None for free, so it is the refusal's position that has to
+        beat the first sink.
+
+        The derivation used to reject it, which is the wrong direction for the cost
+        of a false positive to run: the explanation offered to whoever wrote it
+        would have been "rewrite your safe code into the shape with the window in
+        it" to get green. Reported here as the accepting side so a future narrowing
+        of the helper cannot quietly reintroduce that.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/walrus")
+            def get_walrus(form_id: str):
+                if not (validated := _validated_form_id(form_id)):
+                    raise NotFoundError('Form not found')
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
+                )
+            '''
+        )
+
+        assert _validates_its_form_id(source, 'get_walrus'), (
+            'the walrus guard was reported as unbounded — it is strictly safer '
+            'than the two-statement form it models, so rejecting it pushes an '
+            'author toward the weaker spelling'
+        )
+
+        # And the same spelling with the read moved AHEAD of it, so acceptance is
+        # not simply "a walrus anywhere passes": the position still has to win.
+        read_first = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/walrus-late")
+            def get_walrus_late(form_id: str):
+                item = aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+                if not (validated := _validated_form_id(form_id)):
+                    raise NotFoundError('Form not found')
+                return item
+            '''
+        )
+
+        assert not _validates_its_form_id(read_first, 'get_walrus_late'), (
+            'a walrus guard AFTER the read was reported as a bound — recognising '
+            'the spelling must not cost the ordering that is the actual claim'
+        )
+
     def test_the_derivation_refuses_a_validator_whose_result_is_discarded(self):
         """The shape that has NO bound while looking exactly like one.
 
@@ -4067,22 +4411,29 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
 class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
     """`_validated_form_id` returns what it was given, and that is load-bearing.
 
-    Callers use their own `form_id` for things that are not the key —
-    `source_channel` in `/submissions`, the id echoed in a response — so the
+    Callers use their own `form_id` for the id echoed in a response, so the
     validated value and the parameter have to be the same string. `.strip()` was
     removed for a related reason, but exactness is the broader property and it was
     carried entirely by a sentence in a docstring.
+
+    The `source_channel` those routes filter on no longer depends on it — it is
+    built from the id `_load_form_for_query` hands back, which is the same string
+    the write side used — but the identity below is what keeps the echoed id and
+    the key describing the same form, and it is the assertion a future "form ids
+    are case-insensitive" change has to come and argue with.
     """
 
     def test_the_validator_returns_its_input_unchanged(self, feedback_form_handler):
         """Identity, not merely truthiness.
 
         A normalizing validator — lower-casing, say, for a plausible "form ids are
-        case-insensitive" change — would pass every existing test while splitting
-        the module: `/stats` would read the record its key names and then filter
-        submissions on a `source_channel` its CALLER built from the raw id, which
-        no write ever used. Zero submissions for a form that has them, which is
-        the false zero `_load_form_for_query` exists to prevent (#312).
+        case-insensitive" change — would pass every existing test while making the
+        record a route reads and the id it echoes describe two different forms: the
+        caller answers with its own `form_id` while the key names the normalized
+        one, so a client that stores what it was told would then address something
+        else. The `source_channel` half of that split is closed structurally
+        (`_load_form_for_query` hands the validated id to both read routes), which
+        is why this identity is the assertion that remains.
 
         So the invariant gets a test instead of a sentence. If ids ever should be
         case-insensitive, the normalization belongs at the mint and at every read
@@ -4157,11 +4508,17 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
     ):
         """The consequence, end to end on the route where it would surface.
 
-        `_load_form_for_query` keys on the VALIDATED value while its callers build
-        `source_channel` from the parameter. Both are asserted here against the id
-        in the URL, so the two halves cannot drift apart without a failure — which
-        is the only way this defect would ever have been noticed, since it produces
-        a plausible-looking zero rather than an error.
+        The `sk` read and the `source_channel` filtered on are asserted TOGETHER
+        against the id in the URL, because it is their agreement rather than either
+        one that decides whether the route reports the submissions a form has. Both
+        now come from the same string — `_load_form_for_query` returns the validated
+        id and its caller builds the channel from that — where the filter used to
+        be built from the raw parameter beside a key built from the validated one.
+
+        This is the only way the defect would ever have been noticed: a filter that
+        names a channel no write used produces a plausible-looking zero, not an
+        error. So the case has to be the composite one; asserting the key alone
+        passes while the filter is wrong.
         """
         mock_table.get_item.return_value = {
             'Item': {'form_id': 'DeadBeef', 'brand_name': 'acme'}
@@ -4184,6 +4541,66 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
                 'ExpressionAttributeValues'
             ][':sc']
             == 'form_DeadBeef'
+        )
+
+    @patch('feedback_form_handler.feedback_table')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_query_route_filters_on_the_id_it_read_even_if_the_validator_normalizes(
+        self,
+        mock_table,
+        mock_feedback_table,
+        api_gateway_event,
+        lambda_context,
+        feedback_form_handler,
+    ):
+        """The case above cannot fail while the two strings are equal; this one can.
+
+        `test_the_key_a_query_route_reads_is_the_id_in_its_url` asserts the key and
+        the filter against the URL's id, which they both match whether the route
+        builds them from the validated value or from the raw parameter — so it
+        pins the OUTCOME today without pinning the DERIVATION. That leaves the very
+        coupling this test class exists for resting on the identity next door, and
+        a "form ids are case-insensitive" change would edit that identity rather
+        than discover this.
+
+        So the validator is made to normalize FOR THIS CASE ONLY, and the two are
+        asserted to still agree with each other. That is the property: whatever the
+        validator returns, the channel a read route filters on is the id its read
+        was keyed on, which is the id `submit_form_feedback` wrote
+        (`f'form_{validated}'`). A route that rebuilt the channel from its raw
+        parameter would filter on `form_DeadBeef` beside a key of `FORM#deadbeef`
+        and select nothing — zero submissions for a form that has them, answered
+        as a 200, which is #312's false zero.
+        """
+        exact = feedback_form_handler._validated_form_id
+        mock_table.get_item.return_value = {
+            'Item': {'form_id': 'deadbeef', 'brand_name': 'acme'}
+        }
+        mock_feedback_table.query.return_value = {'Items': []}
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/DeadBeef/submissions',
+            path_params={'form_id': 'DeadBeef'},
+            resource='/feedback-forms/{form_id}/submissions',
+        )
+
+        with patch.object(
+            feedback_form_handler,
+            '_validated_form_id',
+            lambda raw: (exact(raw) or '').lower() or None,
+        ):
+            response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        key = mock_table.get_item.call_args.kwargs['Key']['sk']
+        channel = mock_feedback_table.query.call_args.kwargs[
+            'ExpressionAttributeValues'
+        ][':sc']
+        assert (key, channel) == ('FORM#deadbeef', 'form_deadbeef'), (
+            f'the route read {key} and filtered on {channel} — the two are built '
+            'from different strings, so the filter names a source_channel no write '
+            'produced and the route reports zero for a form that has submissions'
         )
 
 

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -2596,11 +2596,25 @@ class TestThePublicIframePageRefusesAnIdItCannotHaveMinted:
             (r'<iframe\b', 'frame-src'),
             (r'<form\b', "form-action — currently 'none'"),
         ):
-            assert not re.search(pattern, widget), (
-                f'feedback-widget.js now matches {pattern!r}, so the page needs '
-                f'{directive} in _IFRAME_SECURITY_HEADERS. Without it the asset '
-                'is blocked in every embed and nothing else reports it — '
-                "default-src 'none' fails closed and silently."
+            match = re.search(pattern, widget)
+            # The MATCHED TEXT and its line, not just the pattern that fired.
+            # Several of these patterns are broad on purpose — `data:` matches a
+            # Content-Type literal or the word in a comment as readily as a real
+            # URI — so a failure has to hand the reader the thing to look at.
+            # Otherwise the message points at CSP for what may be a false
+            # positive, and the derivation gets deleted rather than narrowed.
+            context = ''
+            if match:
+                line_number = widget.count('\n', 0, match.start()) + 1
+                line = widget.splitlines()[line_number - 1].strip()
+                context = f' at line {line_number}: {line[:120]!r}'
+            assert not match, (
+                f'feedback-widget.js now matches {pattern!r}{context}, so the '
+                f'page needs {directive} in _IFRAME_SECURITY_HEADERS. Without it '
+                'the asset is blocked in every embed and nothing else reports '
+                "it — default-src 'none' fails closed and silently. If the match "
+                'is not a real asset request, narrow the pattern rather than '
+                'dropping the case.'
             )
 
     def test_a_minted_id_always_satisfies_the_validator(

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -3884,12 +3884,18 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
 
         assert unbounded == [], (
             f'{unbounded} take a form id out of the URL without establishing the '
-            'bound before their first read or send. Three shapes report here, and '
-            'the message cannot tell them apart: no validator call at all; a call '
-            'whose None result is never refused (which is no bound — see '
-            '_refused_names); or a call that comes AFTER the table or the queue is '
-            "touched. Add the check rather than narrowing the claim: the value of a "
-            'universal bound is that a reader does not have to hold the exceptions.'
+            'bound before their first read or send. Several shapes report here and '
+            'the message cannot tell them apart, so check each in turn: no '
+            'validator call at all; a result that is never refused, or refused by '
+            'something that is not a NEGATIVE test of it — a success-path or '
+            'cache-hit `return` is not a refusal (see `_refused_names`); a refusal '
+            'that is nested, so it runs on some paths only; or a REFUSAL that comes '
+            'after the table or the queue is touched. Add the check rather than '
+            'narrowing the claim: the value of a universal bound is that a reader '
+            'does not have to hold the exceptions. And if the route is genuinely '
+            'bounded in a spelling this derivation does not know, widen the '
+            'derivation and add a control for it — '
+            '`test_the_derivation_accepts_the_walrus_spelling` is the precedent.'
         )
 
     def test_the_derivation_sees_the_routes_this_module_actually_has(
@@ -4519,8 +4525,8 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
             assert feedback_form_handler._validated_form_id(valid) == valid, (
                 f'{valid!r} came back as '
                 f'{feedback_form_handler._validated_form_id(valid)!r} — a '
-                'normalized return splits the key a route reads from the '
-                'source_channel it filters on'
+                'normalized return makes the record a route reads and the id it '
+                'echoes back describe two different forms'
             )
 
     def test_a_trailing_newline_is_not_a_valid_form_id(
@@ -4539,9 +4545,9 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
 
         Two consequences, both asserted:
 
-        - It reached `f'FORM#{validated}'`, `source_channel = f'form_{form_id}'` and
-          the log line in `_load_form_for_query`, where an embedded newline in a
-          structured log record is its own small problem.
+        - It reached `f'FORM#{validated}'`, the `source_channel` the query routes
+          filter on, and the log line in `_load_form_for_query`, where an embedded
+          newline in a structured log record is its own small problem.
         - The length cap bounded the matched PREFIX rather than the id, so
           `'a' * FORM_ID_MAX_LENGTH + '\\n'` was admitted at 65 characters while
           `'a' * (FORM_ID_MAX_LENGTH + 1)` was refused. Derived from the constant

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -3,6 +3,7 @@ Tests for feedback_form_handler.py - /feedback-forms/* endpoints.
 """
 import ast
 import inspect
+import itertools
 import json
 import os
 import re
@@ -3486,11 +3487,20 @@ def _routes_keying_on_a_form_id(source: str) -> dict[str, str]:
     under this prefix that captures something OTHER than a form id (a submission
     id, say) would be included and would have to establish the bound or say why —
     which is the right side to err on, since the alternative is silence.
+
+    `async def` is selected too, and this is the one place where a node type the
+    selector cannot see costs more than anywhere else: a route missing from THIS
+    dict is not judged unbounded, it leaves the universal claim entirely. The
+    decision function answers correctly for an `async` route when asked — it was
+    never asked, and the pinned-route assertion in
+    `test_the_derivation_sees_the_routes_this_module_actually_has` cannot catch the
+    omission either, because an absent route matches the pinned set on both sides.
+    `test_an_async_route_is_inside_the_universal_claim` is the control.
     """
     tree = ast.parse(source)
     routes = {}
     for node in ast.walk(tree):
-        if not isinstance(node, ast.FunctionDef):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
         for decorator in node.decorator_list:
             if not isinstance(decorator, ast.Call):
@@ -3611,6 +3621,23 @@ def _sink_bearing_helpers(tree: ast.Module) -> frozenset[str]:
     re-asked on every pass, since a helper joining the set can give another one a
     sink it did not have before — the set only ever grows, so this terminates.
 
+    Termination is not the whole argument, though, and the other half is what makes
+    the ANSWER well defined rather than merely reached. Each candidate is judged
+    against `known`, the set as it stands on THIS pass, and a name is never
+    re-examined once added — so the result is a LEAST fixpoint, and its value rests
+    on growth being monotone: adding a helper can only give a caller MORE sinks, and
+    more sinks can only move `_bounds_its_id` from True to False, never back. So a
+    candidate excluded early against a small set cannot become includable later in a
+    way this loop misses, and one added cannot need withdrawing.
+
+    Worth stating because `candidates` is a dict and its iteration order is SOURCE
+    order: if that invariant broke, the symptom would be a verdict that depends on
+    the order two helpers happen to be defined in — a failure that reproduces only
+    under the file it was written against.
+    `test_the_helper_set_does_not_depend_on_definition_order` is the control, over
+    every permutation of a three-link chain and of the case that actually exercises
+    re-evaluation (a helper whose own bound comes AFTER its indirect write).
+
     Three ceilings, all in the same direction — a write this set cannot see is one
     no question is asked about, so the verdict is the vacuous pass the helper
     exists to close. Named rather than implied, so the next reader knows they are
@@ -3658,7 +3685,8 @@ def _sink_bearing_helpers(tree: ast.Module) -> frozenset[str]:
 
 
 def _sink_calls(
-    function: ast.FunctionDef, helpers: frozenset[str] = frozenset()
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+    helpers: frozenset[str] = frozenset(),
 ) -> list[tuple[tuple[int, int], frozenset[str]]]:
     """Every call in `function` that reaches a form id into a sink.
 
@@ -3783,7 +3811,9 @@ def _sink_calls(
     ]
 
 
-def _refused_names(function: ast.FunctionDef) -> dict[str, tuple[int, int]]:
+def _refused_names(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> dict[str, tuple[int, int]]:
     """Name -> position of the earliest top-level `if` refusing it.
 
     `_validated_form_id` returns None rather than raising — deliberately, since
@@ -3864,13 +3894,17 @@ def _refused_names(function: ast.FunctionDef) -> dict[str, tuple[int, int]]:
 
 
 def _bounds_its_id(
-    function, helpers: frozenset[str] = frozenset()
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+    helpers: frozenset[str] = frozenset(),
 ) -> bool:
     """Does `function` reach the validator, and REFUSE, before keying on anything?
 
-    THE decision, asked of any `FunctionDef` — a route (`_validates_its_form_id`,
-    which is this with the module parsed for it) or a module-level helper
-    (`_sink_bearing_helpers`, which excludes one that bounds for itself). One
+    THE decision, asked of any `FunctionDef` or `AsyncFunctionDef` — a route
+    (`_validates_its_form_id`, which is this with the module parsed for it) or a
+    module-level helper (`_sink_bearing_helpers`, which excludes one that bounds
+    for itself). Both node types are real inputs at both call sites, which is what
+    `test_the_helper_set_sees_an_async_writer` and
+    `test_an_async_route_is_inside_the_universal_claim` pin. One
     function rather than two, because the two callers were asking the same
     question and only one of them was asking it properly: the helper exclusion
     used to test whether `_validated_form_id` was MENTIONED anywhere in the body,
@@ -4257,7 +4291,8 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
         for route, function_name in _routes_keying_on_a_form_id(source).items():
             function = next(
                 node for node in ast.walk(tree)
-                if isinstance(node, ast.FunctionDef) and node.name == function_name
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name == function_name
             )
             counted[route] = len(_sink_calls(function, helpers))
 
@@ -4782,6 +4817,160 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
         assert not _validates_its_form_id(source, 'post_async_write'), (
             'a write through an async helper was reported as bounded — the sink '
             'list was empty, so neither question was asked'
+        )
+
+    @pytest.mark.parametrize(
+        'definitions, expected',
+        [
+            pytest.param(
+                {
+                    '_a': '''
+                        def _a(form_id):
+                            aggregates_table.put_item(Item={'sk': f'FORM#{form_id}'})
+                    ''',
+                    '_b': '''
+                        def _b(form_id):
+                            _a(form_id)
+                    ''',
+                    '_c': '''
+                        def _c(form_id):
+                            _b(form_id)
+                    ''',
+                },
+                {'_a', '_b', '_c'},
+                id='a three-link chain, every link reached transitively',
+            ),
+            pytest.param(
+                {
+                    '_a': '''
+                        def _a(form_id):
+                            aggregates_table.put_item(Item={'sk': f'FORM#{form_id}'})
+                    ''',
+                    '_h': '''
+                        def _h(form_id):
+                            _a(form_id)
+                            validated = _validated_form_id(form_id)
+                            if not validated:
+                                raise NotFoundError('Form not found')
+                    ''',
+                },
+                {'_a', '_h'},
+                id='a helper whose own bound comes after its indirect write',
+            ),
+            pytest.param(
+                {
+                    '_a': '''
+                        def _a(form_id):
+                            aggregates_table.put_item(Item={'sk': f'FORM#{form_id}'})
+                    ''',
+                    '_g': '''
+                        def _g(form_id):
+                            validated = _validated_form_id(form_id)
+                            if not validated:
+                                raise NotFoundError('Form not found')
+                            _a(validated)
+                    ''',
+                },
+                {'_a'},
+                id='a helper that refuses before its indirect write',
+            ),
+        ],
+    )
+    def test_the_helper_set_does_not_depend_on_definition_order(
+        self, definitions, expected
+    ):
+        """The fixpoint's value, not just its termination.
+
+        Each candidate is judged against the set as it stands on the current pass,
+        and a name is never re-examined once added — so the result is a least
+        fixpoint whose value rests on growth being monotone (more helpers ⇒ more
+        sinks ⇒ `_bounds_its_id` only ever goes True→False). `candidates` is a
+        source-ordered dict, so the symptom of that invariant breaking is not a
+        wrong answer but an answer that depends on the order two helpers happen to
+        be defined in — which reproduces only under the file it was written against
+        and looks like a flake everywhere else.
+
+        Every permutation is asserted, so no single ordering can be the one that
+        happens to work. The second and third cases are the ones that exercise
+        re-evaluation rather than merely transitivity: `_h` acquires its sink only
+        once `_a` is in the set, and it must then be judged UNBOUNDED because its
+        refusal sits after that write — under a single-pass exclusion it escapes.
+        `_g` is the same shape with the refusal first, and must stay out, so the
+        pair pins both directions rather than "everything ends up in the set".
+        """
+        for order in itertools.permutations(definitions):
+            source = ''.join(
+                textwrap.dedent(definitions[name]) for name in order
+            )
+
+            assert _sink_bearing_helpers(ast.parse(source)) == expected, (
+                f'definition order {order} derived a different sink-bearing set '
+                'than its permutations — the fixpoint judges each candidate '
+                'against the partial set of the current pass, so its result is '
+                'well defined only while growth is monotone (see '
+                '_sink_bearing_helpers). An order-dependent answer means an edit '
+                'broke that, not that this expectation is stale'
+            )
+
+    def test_an_async_route_is_inside_the_universal_claim(self):
+        """A route the selector cannot see does not fail the claim — it leaves it.
+
+        The `async def` widening landed at the two functions that DECIDE (the helper
+        set and the name resolution) and stopped one short of the one that chooses
+        the UNIVERSE. So an `async` route keying on a raw id was answered correctly
+        whenever it was asked — and it was never asked, because
+        `_routes_keying_on_a_form_id` short-circuited on `ast.FunctionDef`.
+
+        That is a worse failure than a wrong verdict, and it is the direction this
+        whole class exists to close: an unbounded route that fails is a red test
+        naming it, while an unbounded route that is not in the universe is a green
+        one. The sibling pinned-route assertion cannot substitute for this control,
+        because it asserts set EQUALITY against the eight known routes — an added
+        `async` route is absent from the derived set and from the pinned set alike,
+        so it matches.
+
+        Both halves are asserted: the route is selected, and once selected it is
+        judged unbounded. Asserting only the first would pass with the decision
+        function broken; asserting only the second is what already passed while the
+        route sat outside the claim.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/sync")
+            def get_sync(form_id: str):
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return aggregates_table.get_item(Key={'sk': f'FORM#{validated}'})
+
+            @app.get("/feedback-forms/<form_id>/asyncroute")
+            async def get_async(form_id: str):
+                return aggregates_table.get_item(Key={'sk': f'FORM#{form_id}'})
+            '''
+        )
+
+        routes = _routes_keying_on_a_form_id(source)
+
+        assert routes == {
+            'GET /feedback-forms/<form_id>/sync': 'get_sync',
+            'GET /feedback-forms/<form_id>/asyncroute': 'get_async',
+        }, (
+            'an async def route under /feedback-forms/<...> was not selected into '
+            'the universe the universal claim is asked about — the node type is '
+            'AsyncFunctionDef, and a route the selector cannot see is one no '
+            'question is asked about, so the suite stays green while it reads a raw '
+            'id'
+        )
+        # And the route the selector now admits is genuinely judged, so the
+        # widening buys a verdict rather than only an entry.
+        unbounded = sorted(
+            function for function in routes.values()
+            if not _validates_its_form_id(source, function)
+        )
+        assert unbounded == ['get_async'], (
+            'the async route was selected but its verdict is wrong — it keys on the '
+            'raw parameter with no refusal anywhere, so it must report unbounded, '
+            'and the bounded sync route beside it must not'
         )
 
     def test_the_derivation_refuses_a_bound_on_a_transformed_argument(self):

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -2161,17 +2161,38 @@ class TestTheAnchorCanOnlyEverUpdateAFormThatExists:
 # with a document instead of JSON, unauthenticated, on the API's own origin, and
 # it is designed to be framed on customers' sites. Before this change it
 # interpolated the caller-supplied path segment straight into a `<script>` block
-# and returned 200 without reading the table at all, so
-# `a');alert(document.domain);x=('` — which the route's own pattern accepts — was
-# rendered as executable script.
+# inside handwritten quotes, and returned 200 without reading the table at all — so
+# an id the route's own pattern accepts could close those quotes and be executed as
+# script. `a',x:alert(1),y:'` is the shortest one that does through this exact
+# template (verified by rendering the merge-base f-string and running it); the
+# issue's own `a');alert(document.domain);x=('` was written for a bare-argument call
+# and leaves the object literal unparseable, which is why the constant below carries
+# that distinction rather than the tests resting on the sample's remainder.
 
 # The payload from the issue, kept as one constant because three separate tests
 # assert three different things about the same string: that the ROUTE admits it,
 # that the HANDLER refuses it, and that the SERIALIZER would have made it inert
-# even if it arrived. Its three dangerous characters are the quote that closes the
-# string literal, the `)` that closes the init call and the `;` that starts a
-# second statement.
+# even if it arrived. Its dangerous character is the quote, which closes the string
+# literal the template wrote. The `)` and `;` after it close a call and start a
+# statement in the bare-argument shape `init('<id>')` this string was written for,
+# but the merge-base template interpolates the id inside an OBJECT LITERAL, so
+# through THIS template they close nothing and the `<script>` block does not parse —
+# meaning this exact string would not have executed here. That is a fact about the
+# sample, not about the defect: `a',x:alert(1),y:'` closes the same handwritten
+# quote using neither, parses, and runs. So the assertions below are about the
+# quote reaching a position where it can close a delimiter, which is what
+# `_js_value` removes, rather than about this string's own remainder executing.
 _INJECTION_PAYLOAD = "a');alert(document.domain);x=('"
+
+# The same class tailored to the shape this template actually writes, and the
+# reason the four prose sites can say the hole was real without leaning on the
+# sample above. It closes the handwritten quote and then supplies further OBJECT
+# KEYS rather than statements, so it needs no `)` and no `;`: rendered through the
+# merge-base f-string it parses, and its `alert` runs. Kept beside its sibling
+# because the pair is the point — one string shows the route admits the issue's
+# characters, the other shows the position was exploitable — and a reader who
+# only meets `_INJECTION_PAYLOAD` will conclude the defect was theoretical.
+_EXECUTING_PAYLOAD = "a',x:alert(1),y:'"
 
 
 def _iframe_event(api_gateway_event, form_id: str) -> dict:
@@ -2938,10 +2959,15 @@ class TestEveryJavaScriptValueOnTheIframePageIsSerialized:
         """Quote, `)` and `;` become data: one JSON string, nothing after it.
 
         The failing spelling — `'{form_id}'` — produced
-        `formId: 'a');alert(document.domain);x=('',` i.e. a closed string, a
-        closed call and a second statement. The assertion is therefore about the
-        REMAINDER: a serialized value that consumed the whole text cannot have
-        ended early enough to start anything.
+        `formId: 'a');alert(document.domain);x=('',` i.e. a string the VALUE
+        decided the end of, with its own text after it. In this template that
+        remainder does not parse (the id sits in an object literal, so the `)`
+        closes nothing — see `_INJECTION_PAYLOAD`), which is exactly why the
+        assertion is about the remainder EXISTING rather than about what it does:
+        a value that can put text outside its own literal is the defect, and
+        whether that text happens to be valid JavaScript is the attacker's choice,
+        not the fix's business. A serialized value that consumed the whole text
+        cannot put anything out there at all.
         """
         serialized = feedback_form_handler._js_value(_INJECTION_PAYLOAD)
 
@@ -2966,6 +2992,81 @@ class TestEveryJavaScriptValueOnTheIframePageIsSerialized:
             'an unescaped double quote inside the literal would close the '
             'delimiter the serializer chose, which is the same defect one '
             'delimiter along'
+        )
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_the_payload_that_really_executed_here_is_inert_too(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The sibling of the case above, and the one the prose rests on.
+
+        `_INJECTION_PAYLOAD` is the issue's sample and it does NOT execute through
+        this template: the id sits inside an object literal, so its `)` closes
+        nothing and the `<script>` block fails to parse. Asserting only that string
+        would leave every "was executable script" claim in `CHANGELOG.md`,
+        `docs/feedback-forms.md` and `_FORM_ID_PATTERN`'s comment resting on a
+        payload that could not have run — which is the defect those four sites were
+        corrected for.
+
+        `_EXECUTING_PAYLOAD` is the same class fitted to the real shape: it closes
+        the handwritten quote and continues with object KEYS, needing neither `)`
+        nor `;`. So this asserts the two properties that make the fix the fix, on
+        the string that actually ran — the id never reaches a page (the format gate
+        refuses it, unread), and had it arrived the serializer would have kept it
+        inside one literal.
+        """
+        # The gate, on the string that was genuinely exploitable rather than on the
+        # sample. Same 404, no read paid for.
+        response = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, _EXECUTING_PAYLOAD), lambda_context
+        )
+
+        assert response['statusCode'] == 404
+        assert response['multiValueHeaders']['Content-Type'] != ['text/html']
+        assert 'alert(' not in response['body']
+        mock_table.get_item.assert_not_called()
+
+        # And the serializer behind it, independently: no text escapes the literal,
+        # so there is no position for a further key or statement. This is the
+        # assertion that would still hold if the pattern were widened.
+        serialized = feedback_form_handler._js_value(_EXECUTING_PAYLOAD)
+
+        value, end = json.JSONDecoder().raw_decode(serialized)
+        assert value == _EXECUTING_PAYLOAD
+        assert end == len(serialized), (
+            f'{serialized[end:]!r} is outside the literal — for THIS payload that '
+            'remainder parses, so unlike the issue sample it would really run'
+        )
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_the_init_argument_is_an_object_literal_not_a_bare_argument(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The template shape the corrected decomposition turns on.
+
+        Four prose sites now say the issue payload's `)` and `;` close a call and
+        start a statement only in a bare-argument `init('<id>')`, and that through
+        THIS template they close nothing because the id is inside an object
+        literal — which is why the sample could not have executed here and why
+        `_EXECUTING_PAYLOAD` exists. That is a claim about the page as emitted, so
+        it is asserted on a real render rather than described: were the template
+        ever to become `init('<id>')`, those four paragraphs would be wrong in the
+        direction that understates the sample, and the pair of payload constants
+        would need re-deriving.
+        """
+        form_id = feedback_form_handler._minted_form_id()
+        mock_table.get_item.return_value = {'Item': {'form_id': form_id}}
+
+        page = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, form_id), lambda_context
+        )['body']
+        argument = _init_call_argument(page)
+
+        assert argument.lstrip().startswith('{'), (
+            f'the init call now opens with {argument.lstrip()[:40]!r} rather than '
+            'an object literal — re-check the payload decomposition in '
+            'CHANGELOG.md, docs/feedback-forms.md and _FORM_ID_PATTERN, which say '
+            "the sample's `)` closes nothing because of this shape"
         )
 
     def test_a_script_closing_tag_cannot_end_the_element(
@@ -5608,12 +5709,12 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         pattern does not) and print it, and a check covering only the memorable
         characters is what let the prose stand at six of twenty-four. Seven of the
         rest are the characters the #379 fix turns on — the quote, parens and
-        semicolon the payload breaks out with (three of those four in the payload
-        itself, decomposed at `_INJECTION_PAYLOAD`), plus the `<`, `>` and `&`
-        `_js_value` escapes for the HTML parser — so the `dangerous` loop above
-        asserts those for their own reason and this loop re-covers them deliberately:
-        they are in both sets, and each set's claim should be readable without the
-        other.
+        semicolon the payload breaks out with (only the quote does so in the payload
+        itself, and through this template; decomposed at `_INJECTION_PAYLOAD`), plus
+        the `<`, `>` and `&` `_js_value` escapes for the HTML parser — so the
+        `dangerous` loop above asserts those for their own reason and this loop
+        re-covers them deliberately: they are in both sets, and each set's claim
+        should be readable without the other.
 
         The set's MEMBERSHIP is derived from the installed resolver rather than
         counted, and the derived set is then held against all THREE copies of it —
@@ -5796,9 +5897,9 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         category: the in-scope set is 24 characters, and the note named six of them,
         so `'form(1)'` and `'a;b'` are sampled beside the named `'a:b'`. Those two
         hold characters the #379 fix turns on — `(`, `)` and `;` are three of the four
-        the payload breaks out with, and the `)` and `;` are two of the three
-        `_INJECTION_PAYLOAD`'s own comment names — which is the reason a list written
-        by hand omits them: they read as attack syntax rather
+        the payload breaks out with, though `_INJECTION_PAYLOAD`'s own comment records
+        that through THIS template only its quote breaks anything — which is the
+        reason a list written by hand omits them: they read as attack syntax rather
         than as an id anyone would seed, and they resolved regardless. The other half
         is asserted too: `"`, `#`, `/`, `?`, a backslash and a backtick are the
         printable-ASCII characters the ROUTE omits, which all three documents state

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -3576,16 +3576,23 @@ def _sink_bearing_helpers(tree: ast.Module) -> frozenset[str]:
     that hands an unvalidated id to a helper writes it to the table with no sink
     call of its own anywhere in its body. `_sink_calls` matched only an
     `ast.Attribute` callee, so a plain `helper(form_id)` was not a sink at all, the
-    list came back empty, and the vacuous `all(...)` reported the route as bounded.
-    Silence again, this time through the call SHAPE rather than the receiver name.
+    list came back empty, and a route with nothing to answer for was reported
+    bounded. Silence again, through the call SHAPE rather than the receiver name.
 
-    Excluded: any function that calls `_validated_form_id` itself. That is what
-    makes `_load_form_for_query` — which reads, and is called by three routes — not
-    a hole: it establishes the bound on the id it was handed before its own read,
-    which is the delegating spelling `_validates_its_form_id` already accepts as a
-    refusal. Counting it as an unguarded sink would report `/iframe`, `/stats` and
-    `/submissions` as unbounded, which is the false-positive direction. The same
-    rule excludes the route handlers, each of which validates.
+    Two exclusions, both in the false-positive direction, because this set only
+    ever ADDS sinks to a caller:
+
+    - A function that calls `_validated_form_id` itself. That is what keeps
+      `_load_form_for_query` — which reads, and which three routes delegate to —
+      a refusal rather than an unguarded sink: it bounds the id it was handed
+      before its own read, which `_validates_its_form_id` already accepts as the
+      delegating spelling. Counting it would report `/iframe`, `/stats` and
+      `/submissions` as unbounded.
+    - A ROUTE handler, since a route is entered by the resolver rather than called
+      by another function here. Without this the set names `list_forms`,
+      `create_form`, `get_form_stats` and `get_form_submissions` — true of them
+      (they do read) and useless, because nothing calls them; and the day something
+      did, the caller would be accused for a read the route bounds for itself.
 
     A fixpoint rather than one level, because a helper calling a helper is the same
     hole one step further out and the loop costs four lines. It resolves NAMES in
@@ -3593,15 +3600,25 @@ def _sink_bearing_helpers(tree: ast.Module) -> frozenset[str]:
     which is the remaining ceiling — worth stating rather than implying, since the
     failure mode is the vacuous pass this whole helper exists to close.
     """
-    candidates = {
-        node.name: node for node in tree.body
-        if isinstance(node, ast.FunctionDef)
-        and not any(
+    def _eligible(node: ast.FunctionDef) -> bool:
+        validates = any(
             isinstance(call, ast.Call)
             and isinstance(call.func, ast.Name)
             and call.func.id == '_validated_form_id'
             for call in ast.walk(node)
         )
+        routed = any(
+            isinstance(decorator, ast.Call)
+            and isinstance(decorator.func, ast.Attribute)
+            and isinstance(decorator.func.value, ast.Name)
+            and decorator.func.value.id == 'app'
+            for decorator in node.decorator_list
+        )
+        return not validates and not routed
+
+    candidates = {
+        node.name: node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and _eligible(node)
     }
     helpers: set[str] = set()
     growing = True
@@ -4179,6 +4196,37 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
             'answer when the call really does reach an id into a table, and both '
             'are a false positive otherwise — the earliest sink is what decides '
             'the verdict, so one spurious early entry accuses a correct route.'
+        )
+
+    def test_the_only_helper_that_writes_what_it_is_handed_is_the_brand_anchor(
+        self, feedback_form_handler
+    ):
+        """The helper set is exactly one function, and the two exclusions earn it.
+
+        `_sink_bearing_helpers` only ever ADDS sinks to a caller, so its
+        over-reporting direction is the one that accuses a correct route. Both
+        exclusions were needed to get here and neither is cosmetic: without the
+        `_validated_form_id` one, `_load_form_for_query` becomes an unguarded sink
+        and `/iframe`, `/stats` and `/submissions` are all reported unbounded;
+        without the route-decorator one, the set names `list_forms`, `create_form`,
+        `get_form_stats` and `get_form_submissions` — each of which does read, and
+        none of which is CALLED by anything here, so naming them buys nothing and
+        would accuse whatever first called one.
+
+        Pinned as a set rather than a count so the failure says which function
+        arrived. A helper that starts writing SHOULD appear here — that is the
+        finding, not the breakage — and then every route calling it has to bound its
+        id first.
+        """
+        source = Path(inspect.getsourcefile(feedback_form_handler)).read_text(
+            encoding='utf-8'
+        )
+
+        assert _sink_bearing_helpers(ast.parse(source)) == {'_anchor_form_brand'}, (
+            'the set of module-level helpers that write what they are handed '
+            'changed. If a new helper appears, check every route that calls it '
+            'validates first; if one disappeared, check the exclusions have not '
+            'started swallowing a real write.'
         )
 
     def test_the_derivation_can_fail(self):

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -2198,15 +2198,27 @@ def _route_pattern_for_iframe(handler) -> re.Pattern:
     Read from the app rather than restated: the point of the positive control
     below is that the FRAMEWORK accepts the payload, so a copy of powertools'
     capture group pasted here would prove nothing about the version installed.
+
+    `app._dynamic_routes` is PRIVATE powertools API, used deliberately and for
+    that same reason — the installed version's compiled regex is the only thing
+    that answers the question, and it is not exposed publicly. So an upgrade that
+    renames the attribute should fail HERE, in a helper whose docstring says why
+    it reaches in, rather than anywhere else.
+
+    Selected on the full route path rather than on the `/iframe` suffix alone: a
+    second `<something>/iframe` route added later would otherwise be a candidate,
+    and this helper would either pick it or trip its own count assertion for a
+    reason that has nothing to do with the form id.
     """
     routes = [
         route for route in handler.app._dynamic_routes
         if route.rule.pattern.endswith('/iframe/*$')
+        and '/feedback-forms/' in route.rule.pattern
     ]
     assert len(routes) == 1, (
-        f'expected exactly one dynamic /iframe route on the resolver, found '
-        f'{len(routes)} — this helper needs updating, it is not a finding about '
-        'validation.'
+        f'expected exactly one dynamic /feedback-forms/<id>/iframe route on the '
+        f'resolver, found {len(routes)} — this helper needs updating, it is not '
+        'a finding about validation.'
     )
     return routes[0].rule
 
@@ -2245,6 +2257,14 @@ def _quoted_interpolations(source: str, function_name: str) -> list[str]:
     expression that is followed by a quote but not preceded by one (or the reverse)
     is reported too: an unbalanced quote around a value is not a safe spelling
     either, it is a broken one.
+
+    NOTE for whoever this fails on: an interpolation adjacent to a quote is not
+    universally wrong — `id="{html.escape(x, quote=True)}"` is the CORRECT spelling
+    for a value rendered as MARKUP, and `_js_value`'s docstring says so. This check
+    is about the page as it stands, where the only reflected value is in SCRIPT
+    context and none is in an attribute. If a legitimate HTML-context value is
+    added here, widen this derivation to allow it — do NOT remove the escaping to
+    get green.
     """
     tree = ast.parse(source)
     functions = [
@@ -2257,8 +2277,23 @@ def _quoted_interpolations(source: str, function_name: str) -> list[str]:
         'silently scan nothing.'
     )
     function = functions[0]
+    joined_strings = [
+        n for n in ast.walk(function) if isinstance(n, ast.JoinedStr)
+    ]
+    # THE VACUITY GUARD, and the reason it is an assert rather than an early
+    # return: "no offenders" and "nothing to judge" are the same empty list to the
+    # caller, and only one of them is a pass. `get_form_iframe` renders the page
+    # from an f-string, so finding none means the template moved — most plausibly
+    # into a private helper, since the function is long — and the caller's green
+    # result would be about a function that no longer renders anything.
+    assert joined_strings, (
+        f'{function_name} contains no f-string, so this derivation has nothing '
+        'to judge and a green result from it would mean nothing. If the HTML '
+        'template moved into a helper, point the caller at that helper (or scan '
+        'both) rather than deleting this guard.'
+    )
     offenders = []
-    for joined in (n for n in ast.walk(function) if isinstance(n, ast.JoinedStr)):
+    for joined in joined_strings:
         parts = joined.values
         for index, part in enumerate(parts):
             if not isinstance(part, ast.FormattedValue):
@@ -2322,7 +2357,12 @@ class TestThePublicIframePageRefusesAnIdItCannotHaveMinted:
         )
 
         assert response['statusCode'] == 404
-        assert 'html' not in response['body'].lower()
+        # "This response is not a document" — stated as the response's own
+        # content type, which is the positive assertion
+        # test_a_server_minted_id_still_serves_the_embeddable_page makes. Asserted
+        # this way rather than as "the letters h-t-m-l are absent from the body",
+        # which is a property of an unrelated JSON error message.
+        assert response['multiValueHeaders']['Content-Type'] != ['text/html']
         assert 'alert(' not in response['body']
         # Not echoed back in any form, either: the refusal names the resource,
         # never the caller's string.
@@ -2360,7 +2400,8 @@ class TestThePublicIframePageRefusesAnIdItCannotHaveMinted:
         )
 
         assert response['statusCode'] == 404
-        assert 'html' not in response['body'].lower()
+        # Not a document — see the note on the same assertion above.
+        assert response['multiValueHeaders']['Content-Type'] != ['text/html']
         # The read HAPPENED — this is the existence gate, not the format one, and
         # a 404 that skipped the lookup would be the format check refusing a
         # legitimate id instead.
@@ -2462,6 +2503,170 @@ class TestThePublicIframePageRefusesAnIdItCannotHaveMinted:
             os.environ['ALLOWED_ORIGIN']
         ]
 
+    def test_the_policy_names_every_directive_the_page_needs_and_no_wildcard(
+        self, feedback_form_handler
+    ):
+        """The FUNCTIONAL half of the policy, pinned in both directions.
+
+        The case above pins the two deliberate OMISSIONS. This one pins what the
+        page needs in order to work at all, because `default-src 'none'` is the
+        fallback for anything not named: delete `script-src 'unsafe-inline'` and
+        the inlined widget never executes, delete `style-src 'unsafe-inline'` and
+        the <style> block plus every `style.cssText` assignment is dropped, delete
+        `connect-src 'self'` and the widget's /config fetch and submit POST are
+        blocked. Each is a TOTAL, SILENT failure of the product on every customer
+        site — the frame renders an empty div, and no assertion about `default-src`
+        alone notices.
+
+        Compared as a whole mapping rather than directive by directive, so the
+        other direction fails too: widening `script-src` to `'unsafe-inline' *`, or
+        adding `img-src *`, undoes the containment argument on
+        `_IFRAME_SECURITY_HEADERS` — that a value which escaped the serializer has
+        nowhere to send anything — and an `in`-style assertion would stay green
+        through it.
+        """
+        policy = feedback_form_handler._IFRAME_SECURITY_HEADERS[
+            'Content-Security-Policy'
+        ]
+
+        directives = {}
+        for directive in policy.split(';'):
+            name, _, sources = directive.strip().partition(' ')
+            assert name not in directives, (
+                f'{name} is stated twice in the policy; a browser honours the '
+                'FIRST occurrence, so the second is silently dead'
+            )
+            directives[name] = sources.split()
+
+        assert directives == {
+            'default-src': ["'none'"],
+            'script-src': ["'unsafe-inline'"],
+            'style-src': ["'unsafe-inline'"],
+            'connect-src': ["'self'"],
+            'base-uri': ["'none'"],
+            'form-action': ["'none'"],
+        }, (
+            f'the policy is now {directives}. A REMOVAL from script-src, '
+            'style-src or connect-src breaks every embed silently (default-src '
+            "'none' is the fallback); an ADDITION or a widening undoes the "
+            'containment argument on _IFRAME_SECURITY_HEADERS. Either way this '
+            'expectation and that comment change together.'
+        )
+        # Restated as its own assertion because it is the failure worth naming:
+        # a wildcard anywhere is what turns the policy from a bound into a
+        # formality, and the mapping above would report it as a diff of quoted
+        # strings rather than as "this is now open".
+        assert not any(
+            '*' in source for sources in directives.values() for source in sources
+        ), f'a wildcard source makes the policy no bound at all: {directives}'
+
+    def test_the_widget_asks_for_no_asset_the_policy_would_block(
+        self, feedback_form_handler
+    ):
+        """`default-src 'none'` also blocks images, fonts and frames — and that is
+        only safe because the widget asks for none of them.
+
+        The policy deliberately carries no `img-src`, `font-src` or `frame-src`,
+        on the grounds that feedback-widget.js builds its UI from DOM elements,
+        text and CSS alone. That is a claim about ANOTHER file, so it is derived
+        from that file rather than trusted: the day the widget grows an icon, a
+        `url(...)` background or a webfont, this fails and names the directive the
+        policy needs — instead of the asset silently not loading in every
+        customer's iframe.
+
+        `form-action 'none'` rides on the same derivation: the widget submits
+        through `fetch`, and a real <form> would need that directive relaxed.
+
+        Read through `get_widget_js` rather than off the path, so this judges the
+        script the page actually inlines — including the fallback, if the static
+        file is ever missing.
+        """
+        widget = feedback_form_handler.get_widget_js()
+
+        # `data:` is included because it is a source EXPRESSION, not just a URL
+        # scheme: `default-src 'none'` blocks a `data:` image or font as surely as
+        # a remote one, and a `data:` URI is the shape an inlined icon takes.
+        for pattern, directive in (
+            (r'<img\b', 'img-src'),
+            (r'\.src\s*=', 'img-src (or script-src for a loaded script)'),
+            (r'url\(', 'img-src / font-src, for a CSS-referenced asset'),
+            (r'data:', 'img-src / font-src, for an inlined asset'),
+            (r'@font-face', 'font-src'),
+            (r'<iframe\b', 'frame-src'),
+            (r'<form\b', "form-action — currently 'none'"),
+        ):
+            assert not re.search(pattern, widget), (
+                f'feedback-widget.js now matches {pattern!r}, so the page needs '
+                f'{directive} in _IFRAME_SECURITY_HEADERS. Without it the asset '
+                'is blocked in every embed and nothing else reports it — '
+                "default-src 'none' fails closed and silently."
+            )
+
+    def test_a_minted_id_always_satisfies_the_validator(
+        self, feedback_form_handler
+    ):
+        """The ONE coupling between the mint and the validator that must hold.
+
+        The two are deliberately independent — the validator is wider, for the
+        reason `test_a_hand_seeded_form_id_is_still_embeddable` pins — so nothing
+        else ties `FORM_ID_LENGTH` to `_FORM_ID_PATTERN`. But an id this service
+        ISSUES must always be one it will serve a page for, or `create_form`
+        would hand back an id whose iframe 404s.
+
+        Asserted over many mints rather than one, because the failure mode is
+        value-dependent: a mint that emitted a separator, or a length raised past
+        what the pattern admits, would only show up for some draws.
+
+        Also pins the format the mint's docstring CLAIMS — hex, no separator —
+        which the pattern alone would not, since it admits `-`. That assertion is
+        what makes `FORM_ID_LENGTH` safe to RAISE: the dashed spelling of a uuid4
+        puts a '-' at offset 8, so slicing 9 or more characters of it mints an id
+        holding a separator the docstring does not describe. With this here,
+        raising the constant is a one-line change rather than a trap.
+        """
+        for _ in range(200):
+            minted = feedback_form_handler._minted_form_id()
+
+            assert feedback_form_handler._FORM_ID_PATTERN.match(minted), (
+                f'_minted_form_id() produced {minted!r}, which _validated_form_id '
+                'refuses — every public route would 404 an id this service just '
+                'issued. The mint and the pattern are independent by design, but '
+                'not in this direction.'
+            )
+            assert len(minted) == feedback_form_handler.FORM_ID_LENGTH
+            assert re.fullmatch(r'[0-9a-f]+', minted), (
+                f'_minted_form_id() produced {minted!r}, which is not the "hex '
+                'characters" its docstring describes. This is what fails if the '
+                'slice goes back to `str(uuid.uuid4())` — harmless at length 8, '
+                'a separator in the id at 9 or more.'
+            )
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_an_id_padded_with_whitespace_is_not_an_alias_for_the_id(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """A form id is EXACT: `' deadbeef'` is not `'deadbeef'`.
+
+        `ballots_handler._validated_session_id`, the sibling this is modelled on,
+        `.strip()`s — harmlessly, since a session id is a 128-bit token. Inheriting
+        that here would make every whitespace variant of an id a distinct URL
+        serving byte-identical HTML, which is a cache-key multiplier for the
+        `Cache-Control` follow-up recorded in `lib/stacks/api-stack.ts` — whose
+        premise is that this response is a pure function of the id and the host.
+        With a strip it is a pure function of the STRIPPED id while the cache keys
+        on the raw path.
+
+        So the leniency is dropped rather than inherited, and pinned here so
+        re-adding it is a decision. No id this service mints has whitespace to
+        forgive (`test_a_minted_id_always_satisfies_the_validator`).
+        """
+        response = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, ' deadbeef'), lambda_context
+        )
+
+        assert response['statusCode'] == 404
+        mock_table.get_item.assert_not_called()
+
 
 def _json_prefix(text: str) -> str:
     """The longest leading substring of `text` that is one JSON value.
@@ -2540,6 +2745,53 @@ class TestEveryJavaScriptValueOnTheIframePageIsSerialized:
         # naive strip-the-characters fix would lose.
         assert json.loads(serialized) == '</script><img src=x>'
 
+    def test_an_ampersand_cannot_reach_the_html_parser(
+        self, feedback_form_handler
+    ):
+        """`&` is the other character the HTML parser gives meaning to, and it is
+        escaped by the implementation — asserted here because it was the one of the
+        three replacements nothing covered.
+
+        It matters for the same reason `<` does and for one more: an entity the
+        parser decodes could reconstitute a character the escaping above removed,
+        so leaving `&` as itself would make the `<`/`>` handling conditional on
+        the parser's behaviour rather than absolute.
+        """
+        serialized = feedback_form_handler._js_value('a &lt; b &amp; c')
+
+        assert '&' not in serialized, (
+            'an unescaped & lets the HTML parser decode an entity inside the '
+            'script, which is how a removed character comes back'
+        )
+        assert json.loads(serialized) == 'a &lt; b &amp; c'
+
+    def test_a_line_separator_cannot_end_the_statement(
+        self, feedback_form_handler
+    ):
+        """U+2028 and U+2029 terminate a JavaScript LINE but are legal, raw, inside
+        a JSON string — so a serializer that emitted them as themselves would end
+        the statement from inside the literal, which is the same defect as an
+        unescaped quote arriving by a route JSON considers valid.
+
+        They are handled by `ensure_ascii=True`, which is `json.dumps`'s default
+        AND is now passed explicitly — this case is what fails if someone writes
+        `ensure_ascii=False` to make a non-ASCII value readable in a debug dump.
+        Before this test, the safety of the two most JavaScript-specific
+        characters on the page rested on an implicit default that nothing checked.
+        """
+        # Spelled as escapes, deliberately: a literal U+2028 in this file is
+        # invisible to a reader and is exactly the character some tools
+        # normalise away, which would make the case pass by having no subject.
+        value = 'before\u2028after\u2029end'
+
+        serialized = feedback_form_handler._js_value(value)
+
+        assert '\u2028' not in serialized and '\u2029' not in serialized, (
+            'a raw U+2028/U+2029 ends the JavaScript line inside the string '
+            'literal — check that _js_value still passes ensure_ascii=True'
+        )
+        assert json.loads(serialized) == value
+
     def test_no_javascript_value_is_wrapped_in_a_handwritten_quote_pair(
         self, feedback_form_handler
     ):
@@ -2563,12 +2815,11 @@ class TestEveryJavaScriptValueOnTheIframePageIsSerialized:
         )
 
     def test_the_quoted_interpolation_check_can_fail(self):
-        """Positive control for the derivation above.
+        """Positive control for the derivation above: it flags the real defect.
 
-        Without it, an `ast` walk that found no JoinedStr at all — a template
-        moved into a helper, a parse that quietly matched nothing — would report
-        an empty list and the test above would pass while pinning nothing. The
-        input is the exact spelling this change removed.
+        Without it, a parse that quietly matched nothing would report an empty
+        list and the test above would pass while pinning nothing. The input is the
+        exact spelling this change removed.
         """
         source = textwrap.dedent('''
             def get_form_iframe(form_id):
@@ -2584,6 +2835,35 @@ class TestEveryJavaScriptValueOnTheIframePageIsSerialized:
             'the derivation did not flag the exact spelling this change removed, '
             f'it reported {offenders} — so a green result above means nothing.'
         )
+
+    def test_the_quoted_interpolation_check_refuses_to_pass_vacuously(self):
+        """The OTHER way the derivation could be meaningless: nothing to judge.
+
+        The control above proves the walk flags the defect when the template is
+        inline. It does not cover the case where `get_form_iframe` contains no
+        f-string at all — which is what happens if the ~90-line HTML template is
+        ever refactored into a private helper, a very plausible change. The walk
+        would then find no `JoinedStr`, return `[]`, and
+        `test_no_javascript_value_is_wrapped_in_a_handwritten_quote_pair` would
+        pass while checking nothing.
+
+        So that case must RAISE rather than return `[]`. The input is the
+        moved-to-helper shape, with the offending spelling sitting in the helper
+        where the derivation cannot see it: the guard has to fire on the absence
+        of a subject, not on the absence of offenders.
+        """
+        source = textwrap.dedent('''
+            def _iframe_page(form_id):
+                return f"""
+                  formId: '{form_id}'
+                """
+
+            def get_form_iframe(form_id):
+                return _iframe_page(form_id)
+        ''')
+
+        with pytest.raises(AssertionError, match='no f-string'):
+            _quoted_interpolations(source, 'get_form_iframe')
 
     @patch('feedback_form_handler.aggregates_table')
     def test_the_rendered_init_call_carries_exactly_one_statement(
@@ -2616,3 +2896,152 @@ class TestEveryJavaScriptValueOnTheIframePageIsSerialized:
         assert remainder.split(');', 1)[1].strip() == (
             '</script>\n</body>\n</html>'
         )
+
+
+class TestEveryRouteThatKeysOnAFormIdChecksItsFormatFirst:
+    """`_validated_form_id` at every route that turns a URL segment into a key.
+
+    Its docstring makes a general argument — "a format check before any read
+    means a probe for `/feedback-forms/admin` or a 1 MB path segment costs no
+    DynamoDB call" — and that argument is only true where it is applied. It was
+    applied on `/iframe` alone, so the two sibling PUBLIC routes (`/config`,
+    `/submit`) took the raw capture group straight into a `get_item`, which is the
+    cost basis the throttle pair in `lib/stacks/api-stack.ts` is argued from. The
+    two authenticated read routes reach the same check through
+    `_load_form_for_query`.
+
+    Not an injection finding on any of them — those four answer JSON through
+    `json.dumps` — but the gap is what would make the next reader of
+    `_validated_form_id` assume a protection that was not there.
+    `ballots_handler` applies its equivalent at all five of its routes; this
+    mirrors that.
+
+    Asserted as "no read happened", route by route, because that is the property
+    the comment claims and the only one a 404 alone would not distinguish from a
+    lookup that merely found nothing.
+    """
+
+    # (route path suffix, method, whether the route needs a JSON body). The
+    # malformed id must be refused BEFORE the body is considered too, which is why
+    # `/submit` is exercised with a valid one: a 404 that only happened because
+    # the body failed validation would prove nothing about the id.
+    ROUTES = (
+        ('config', 'GET', None),
+        ('submit', 'POST', {'text': 'a real submission'}),
+        ('stats', 'GET', None),
+        ('submissions', 'GET', None),
+    )
+
+    @staticmethod
+    def _malformed_ids(handler) -> tuple[str, ...]:
+        """The two shapes the pattern refuses, derived rather than restated.
+
+        The over-length one comes off `FORM_ID_MAX_LENGTH` so that raising the cap
+        does not silently turn this case into a VALID id — the same reason
+        `test_an_over_long_id_is_refused_without_a_read` derives its own.
+        """
+        return (_INJECTION_PAYLOAD, 'a' * (handler.FORM_ID_MAX_LENGTH + 1))
+
+    @patch('feedback_form_handler.feedback_table')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_malformed_id_never_reaches_dynamodb_on_any_of_them(
+        self,
+        mock_table,
+        _mock_feedback_table,
+        api_gateway_event,
+        lambda_context,
+        feedback_form_handler,
+    ):
+        """The cost argument, checked where it is stated.
+
+        A 4000-character path segment or the #379 payload must cost zero
+        `get_item` calls on every route that keys on a form id — not just on the
+        one whose rendering made it a security defect.
+        """
+        for suffix, method, body in self.ROUTES:
+            for malformed in self._malformed_ids(feedback_form_handler):
+                mock_table.reset_mock()
+                event = api_gateway_event(
+                    method=method,
+                    path=f'/feedback-forms/{malformed}/{suffix}',
+                    path_params={'form_id': malformed},
+                    body=body,
+                    resource=f'/feedback-forms/{{form_id}}/{suffix}',
+                )
+
+                response = feedback_form_handler.lambda_handler(
+                    event, lambda_context
+                )
+
+                assert response['statusCode'] == 404, (
+                    f'{method} /{suffix} answered {response["statusCode"]} for a '
+                    f'malformed id ({malformed[:20]!r}...) rather than the same '
+                    '404 every sibling gives'
+                )
+                mock_table.get_item.assert_not_called()
+                # Nor echoed: none of these four renders HTML, but a message that
+                # quotes an unbounded path segment back is its own problem.
+                assert malformed not in response['body']
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_well_formed_id_is_still_read_and_answered(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The other direction: the format gate must not have become the answer.
+
+        `/config` with a real form still reads the table and serves its
+        projection — so the 404s above are the validator refusing a shape, not a
+        route that stopped working. The id is the hand-seeded style the pattern is
+        deliberately wide enough for.
+        """
+        mock_table.get_item.return_value = {
+            'Item': {'form_id': 'website-form', 'enabled': True}
+        }
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/website-form/config',
+            path_params={'form_id': 'website-form'},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        assert json.loads(response['body'])['config']['enabled'] is True
+        assert (
+            mock_table.get_item.call_args.kwargs['Key']['sk']
+            == 'FORM#website-form'
+        )
+
+    @patch('feedback_form_handler.sqs')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_malformed_id_never_reaches_the_queue_either(
+        self,
+        mock_table,
+        mock_sqs,
+        api_gateway_event,
+        lambda_context,
+        feedback_form_handler,
+    ):
+        """`/submit` is the one public route that also WRITES, so its refusal has a
+        second thing to prove.
+
+        A record enqueued for a form id that cannot be one of ours would be
+        processed downstream — a Comprehend, Translate and Bedrock invocation
+        each — and would land in the feedback partition under a `source_channel`
+        no form can ever be read back through. So the refusal has to come before
+        the send, not just before the read.
+        """
+        event = api_gateway_event(
+            method='POST',
+            path=f'/feedback-forms/{_INJECTION_PAYLOAD}/submit',
+            path_params={'form_id': _INJECTION_PAYLOAD},
+            body={'text': 'a real submission'},
+            resource='/feedback-forms/{form_id}/submit',
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 404
+        mock_table.get_item.assert_not_called()
+        mock_sqs.send_message.assert_not_called()

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -5665,9 +5665,9 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         or space — is NOT something the scan has to find. Both halves rest on one
         fact about a file this one does not own: powertools' capture group lists a
         literal space but no other whitespace, and reaches past ASCII only through
-        `\\w`, which is Unicode-aware for LETTERS AND DIGITS alone. So an id holding
-        a tab, a newline, or a non-ASCII symbol never matched a route and answered
-        404 before this change as well as after — unreachable rather than
+        `\\w`, which matches any Unicode LETTER OR NUMBER. So an id holding a tab, a
+        newline, or a non-ASCII symbol never matched a route and answered 404 before
+        this change as well as after — unreachable rather than
         reachable-then-orphaned.
 
         The `\\w` half is asserted rather than the ASCII boundary, because that is
@@ -5675,6 +5675,20 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         `'表単'` are both non-ASCII and both resolved, while `'form€a'` is non-ASCII
         and never did. An upgrade note that said "any non-ASCII character" would send
         an operator to rename a row that was never served.
+
+        The `\\w` boundary is sampled across CATEGORIES rather than at the ASCII
+        line, and that is the point of `'hawaiʼi-form'` and `'surface-m²'` being in
+        the reachable loop next to `'café'`. `\\w` spans every `L*` and `N*`
+        category — `Ll`, `Lm`, `Lo`, `Lt`, `Lu`, `Nd`, `Nl`, `No` — so a modifier
+        letter (U+02BC, the correct ʻokina, which looks like an apostrophe) and a
+        superscript or fraction are routable while reading to a human as
+        punctuation. A note glossing `\\w` as "a letter or a digit" puts those in the
+        SAME sentence as `€` and `—`, and that error runs in the expensive
+        direction: an operator sees `hawaiʼi-form` printed by the scan, classifies
+        it out of scope, skips the rename, and the row 404s in production. Every
+        other imprecision in this note over-reports; this one loses a reachable row,
+        which is why the loop samples `Lm` and `No` rather than trusting `Ll` and
+        `Lo` to stand for all eight.
 
         That is the SAME distinction the whole upgrade note turns on, applied one
         level down: ` abc123` is exempt because it never resolved, and `abc<TAB>def`
@@ -5695,7 +5709,8 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         path that matches NOTHING — which would report every character as excluded
         and pass an assertion set made only of exclusions.
         """
-        for reachable in ('my form', '   ', 'a:b', 'café', '表単'):
+        for reachable in ('my form', '   ', 'a:b', 'café', '表単',
+                          'hawaiʼi-form', 'surface-m²'):
             admitting = [
                 f'{method} {path}'
                 for method, path, rule in _form_id_route_paths(
@@ -5715,7 +5730,15 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
                 'not belong in the scan at all'
             )
 
-        for unreachable in ('abc\tdef', 'abc\ndef', 'form€a', 'form\xa0a'):
+        # The last entry is the DECOMPOSED spelling of `caf\u00e9`, written with an
+        # escape because it is visually identical to the composed `caf\u00e9` in
+        # the loop above, and the whole point is that the two are different strings
+        # with different verdicts: a combining accent is a MARK, which `\w` does
+        # not match, so the decomposed form never reached a route while the composed
+        # one did. Both documents name `caf\u00e9` in scope without saying which of
+        # the two spellings they mean.
+        for unreachable in ('abc\tdef', 'abc\ndef', 'form€a', 'form\xa0a',
+                            'cafe\u0301'):
             admitting = [
                 f'{method} {path}'
                 for method, path, rule in _form_id_route_paths(

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -2534,7 +2534,7 @@ class TestThePublicIframePageRefusesAnIdItCannotHaveMinted:
 
         The one respect in which this change is not additive: the character class is
         a NEW refusal applied to ids that are ALREADY STORED, so for a row outside
-        it the change turns a record that resolved into one that 404s on all five of
+        it the change turns a record that resolved into one that 404s on all eight of
         its routes. The whitespace case in the upgrade notes is exempt from that by
         an argument — ` abc123` never addressed `abc123`, the space was always part
         of the key — but a dotted id has no such argument available: `acme.website`

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -2515,6 +2515,44 @@ class TestThePublicIframePageRefusesAnIdItCannotHaveMinted:
         assert response['statusCode'] == 200
 
     @patch('feedback_form_handler.aggregates_table')
+    def test_a_disabled_form_still_serves_its_page_so_the_widget_can_say_so(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The gate checks EXISTENCE, not `enabled` — and that is a decision.
+
+        It reads like an oversight, especially since the returned record is
+        discarded: someone arriving via "the iframe route now checks the form
+        exists" has a standing invitation to add `if not form.get('enabled')` here,
+        and it would look like tightening.
+
+        It would be a regression. The widget has to RUN in order to render its own
+        disabled state, so refusing the page replaces that with a raw API Gateway
+        404 frame on the customer's site — a broken embed for a customer who merely
+        turned the form off. The division of labour is `GET /config` publishing
+        `enabled` in its projection and `submit_form_feedback` enforcing it, and
+        this route matches /config rather than /submit.
+
+        Asserted on the PAGE, not just the status, because a 200 alone would not
+        show that the widget is present to do the saying.
+        """
+        mock_table.get_item.return_value = {
+            'Item': {'form_id': 'deadbeef', 'enabled': False}
+        }
+
+        response = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, 'deadbeef'), lambda_context
+        )
+
+        assert response['statusCode'] == 200, (
+            'a disabled form was refused its page — the visitor now sees a raw '
+            'API Gateway error frame instead of the widget saying the form is '
+            'unavailable. `enabled` belongs to /config and /submit, not to this '
+            'existence gate.'
+        )
+        assert response['multiValueHeaders']['Content-Type'] == ['text/html']
+        assert 'window.VoCFeedbackForm' in response['body']
+
+    @patch('feedback_form_handler.aggregates_table')
     def test_the_page_carries_a_policy_that_still_lets_a_customer_frame_it(
         self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
     ):
@@ -3371,17 +3409,35 @@ def _routes_keying_on_a_form_id(source: str) -> dict[str, str]:
 _FORM_ID_SINKS = frozenset({'aggregates_table', 'feedback_table', 'sqs'})
 
 
-def _refused_names(function: ast.FunctionDef) -> set[str]:
-    """Names this function tests in an `if` that then raises or returns.
+def _refused_names(function: ast.FunctionDef) -> dict[str, tuple[int, int]]:
+    """Name -> position of the earliest top-level `if` refusing it.
 
     `_validated_form_id` returns None rather than raising — deliberately, since
     every caller answers the same 404 — so the CALL is not the bound; the refusal
     after it is. A function that calls the validator and ignores what comes back
     has no bound at all, which is the natural mistake for someone copying the call
     and dropping the two lines that follow it at every current site.
+
+    A POSITION rather than a bare name, because WHERE the refusal sits is half the
+    claim and an earlier version of this helper answered only WHETHER one existed.
+    That let the refusal sit AFTER the read: the assignment binds None for a
+    malformed id, `get_item` runs with `Key={'sk': 'FORM#None'}` — the call the
+    whole cost argument exists to avoid — and the raise happens once it has been
+    paid for. Reported as a bound, because only the assignment's position was ever
+    compared against the sinks.
+    `test_the_derivation_refuses_a_refusal_that_happens_after_the_read` is the
+    control.
+
+    `function.body` rather than `ast.walk`, for the same reason
+    `_validates_its_form_id` requires the assignment at the top level: a refusal
+    nested under a condition refuses on some paths only, and `if False:` is the
+    extreme of that. Walking the whole function counted a dead refusal as a real
+    one, so hoisting just the assignment out of the dead block escaped the
+    top-level requirement while nothing was ever refused
+    (`test_the_derivation_refuses_a_refusal_that_only_runs_sometimes`).
     """
-    refused = set()
-    for node in ast.walk(function):
+    refused: dict[str, tuple[int, int]] = {}
+    for node in function.body:
         if not isinstance(node, ast.If):
             continue
         if not any(
@@ -3390,9 +3446,12 @@ def _refused_names(function: ast.FunctionDef) -> set[str]:
             for child in ast.walk(statement)
         ):
             continue
-        refused |= {
-            name.id for name in ast.walk(node.test) if isinstance(name, ast.Name)
-        }
+        position = (node.lineno, node.col_offset)
+        for name in ast.walk(node.test):
+            if not isinstance(name, ast.Name):
+                continue
+            known = refused.get(name.id)
+            refused[name.id] = position if known is None else min(known, position)
     return refused
 
 
@@ -3413,12 +3472,16 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
 
     - `<name> = _validated_form_id(...)` where `<name>` is later tested in an `if`
       whose body raises or returns. The assignment alone is not enough (see
-      `_refused_names`).
+      `_refused_names`), and the position that has to beat the sinks is the
+      REFUSAL's, not the assignment's: an assignment that binds None costs nothing,
+      so a read between it and the raise is a read of `FORM#None` that the check
+      was supposed to prevent.
     - a call to `_load_form_for_query(...)`, which needs no result check because it
-      RAISES for itself. Following the delegation rather than demanding the direct
-      call is deliberate: `/stats` and `/submissions` validate through it, and a
-      derivation that named only `_validated_form_id` would push someone into
-      adding a redundant second call to each.
+      RAISES for itself — so for that spelling the call's own position IS the
+      refusal's. Following the delegation rather than demanding the direct call is
+      deliberate: `/stats` and `/submissions` validate through it, and a derivation
+      that named only `_validated_form_id` would push someone into adding a
+      redundant second call to each.
 
     Top level rather than anywhere is what excludes dead code and conditional
     validation together — a check that only runs on some paths is not a bound, and
@@ -3447,6 +3510,7 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     for statement in function.body:
         for call in _calls(statement):
             if _named(call, '_load_form_for_query'):
+                # This one raises for itself, so the call is the refusal.
                 position = (statement.lineno, statement.col_offset)
                 validated_at = min(validated_at or position, position)
             if not _named(call, '_validated_form_id'):
@@ -3458,11 +3522,16 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
                 else [statement.target] if isinstance(statement, ast.AnnAssign)
                 else []
             )
-            if any(
-                isinstance(target, ast.Name) and target.id in refused
-                for target in targets
-            ):
-                position = (statement.lineno, statement.col_offset)
+            # The REFUSAL's position, not the assignment's: binding None is free,
+            # and anything between the two runs with it. Taking the earliest over
+            # the targets keeps `min` below meaningful when a function validates
+            # more than one id.
+            refusals = [
+                refused[target.id] for target in targets
+                if isinstance(target, ast.Name) and target.id in refused
+            ]
+            if refusals:
+                position = min(refusals)
                 validated_at = min(validated_at or position, position)
 
     if validated_at is None:
@@ -3615,6 +3684,80 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
             'a get_item before the validator was reported as validated — the '
             'derivation is order-insensitive again, and the cost argument it '
             'checks is about order'
+        )
+
+    def test_the_derivation_refuses_a_refusal_that_happens_after_the_read(self):
+        """The order defect one step along: the CALL beats the read, the RAISE
+        does not.
+
+        `test_the_derivation_refuses_a_read_that_happens_before_the_check` moves
+        the whole validating statement after the sink. This moves only the two
+        lines that do the refusing — which is both subtler to read and the shape a
+        reorder produces naturally, since the assignment looks like the check.
+
+        It is unsafe for exactly the reason that test's shape is: `validated` binds
+        None for an id the pattern refuses, so `get_item` runs with
+        `Key={'sk': 'FORM#None'}` before the raise. The DynamoDB call the bound
+        exists to prevent is paid for, and the 404 the caller sees is
+        indistinguishable from the correct one — which is why nothing but this
+        derivation would report it.
+
+        So the position compared against the sinks has to be the refusal's, not the
+        assignment's (`_refused_names` returns it for that reason). This is what
+        fails if it goes back to reporting a bare set of names.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/late-refusal")
+            def get_late_refusal(form_id: str):
+                validated = _validated_form_id(form_id)
+                item = aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
+                )
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return item
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_late_refusal'), (
+            'a refusal placed after the read was reported as a bound — the '
+            'assignment binds None for free, so it is the RAISE that has to beat '
+            "the first sink. `Key={'sk': 'FORM#None'}` is still a get_item."
+        )
+
+    def test_the_derivation_refuses_a_refusal_that_only_runs_sometimes(self):
+        """The dead-code defect one step along: the ASSIGNMENT is hoisted, the
+        refusal is not.
+
+        `test_the_derivation_refuses_validation_that_only_runs_sometimes` nests the
+        whole block, so the top-level requirement on the assignment catches it.
+        Hoisting just the assignment out satisfies that requirement while the
+        refusal stays unreachable — no request is ever refused, and the read runs
+        with None bound exactly as in the case above.
+
+        This is why `_refused_names` iterates `function.body` rather than walking:
+        a refusal found anywhere in the tree includes ones that never execute, and
+        "the check is somewhere in the source" was never the claim.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/dead-refusal")
+            def get_dead_refusal(form_id: str):
+                validated = _validated_form_id(form_id)
+                if False:
+                    if not validated:
+                        raise NotFoundError('Form not found')
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
+                )
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_dead_refusal'), (
+            'a refusal inside dead code was reported as a bound — the assignment '
+            'being at the top level is not the property that matters, the refusal '
+            'running on every path is'
         )
 
     def test_the_derivation_refuses_a_validator_whose_result_is_discarded(self):

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -2225,6 +2225,39 @@ def _route_pattern_for_iframe(handler) -> re.Pattern:
     return routes[0].rule
 
 
+def _form_id_route_paths(handler, form_id: str) -> list[tuple[str, str, re.Pattern]]:
+    """Every form-id route's concrete path with `form_id` substituted in.
+
+    The generalization of `_route_pattern_for_iframe` to the whole set, and it
+    reaches into `app._dynamic_routes` for the same reason that one does: the
+    question is what the INSTALLED powertools admits, so a copy of its capture
+    group pasted here would answer it in the helper.
+
+    Substituting into the compiled pattern rather than composing the path from a
+    route table restated here, so the eight paths cannot drift from the eight
+    routes. The group is spliced out by locating `(?P<form_id>` and the `]+)` that
+    closes it, NOT by a non-greedy `\\(\\?P<form_id>.+?\\)` — powertools' class
+    contains a literal `)`, so the lazy form stops inside it and yields a path
+    every route rejects. That failure is silent in the direction that matters (an
+    "excluded" verdict for every character), which is why the caller's positive
+    control on a well-formed id is not optional.
+    """
+    paths = []
+    for route in handler.app._dynamic_routes:
+        pattern = route.rule.pattern
+        start = pattern.find('(?P<form_id>')
+        if start < 0:
+            continue
+        end = pattern.index(']+)', start) + len(']+)')
+        path = pattern[:start] + form_id + pattern[end:]
+        paths.append((
+            route.method,
+            path.removeprefix('^').removesuffix('/*$'),
+            route.rule,
+        ))
+    return paths
+
+
 def _init_call_argument(page: str) -> str:
     """The text between `VoCFeedbackForm.init(` and the end of the page.
 
@@ -5570,12 +5603,18 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         are the exclusions the upgrade notes tell an operator to SCAN for, so they
         have to be genuinely refused for that instruction to describe the code.
         `my form` earns its place for the same reason `a:b` has one: a stored id with
-        INTERIOR whitespace resolved before this change (every route keyed
+        an INTERIOR SPACE resolved before this change (every route keyed
         `f'FORM#{form_id}'` with nothing checked) and answers 404 after it, so it is
         reachable-then-orphaned rather than exempt. That is why the whitespace
         exemption in `CHANGELOG.md` and `docs/feedback-forms.md` is scoped to an id
         merely ADDRESSED with surrounding space — ` abc123` never resolved to
         `abc123` — and not to whitespace-bearing ids as a category.
+
+        A space rather than whitespace generally, which is the narrower claim and
+        the true one: a tab or a newline inside an id never matched the route either,
+        so such a row is unreachable rather than orphaned and is out of the scan's
+        scope. `test_the_scan_is_scoped_to_ids_a_route_could_actually_resolve` below
+        is where that split is asserted, off the live resolver.
 
         `my form` is deliberately NOT an independent detector, and saying so is the
         honest version: `'a b'` in the loop above already fails on any class that
@@ -5614,6 +5653,75 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
                 f'{scanned!r} was accepted — CHANGELOG.md tells an operator to '
                 'scan stored ids for exactly these, so if one is now admitted the '
                 'upgrade note describes a refusal that does not happen'
+            )
+
+    def test_the_scan_is_scoped_to_ids_a_route_could_actually_resolve(
+        self, feedback_form_handler
+    ):
+        """The scan's REACH, which is a different claim from its accuracy.
+
+        `CHANGELOG.md` tells an operator that the ids it names went from resolving
+        to answering 404, and that a literal tab or newline is NOT something the
+        scan has to find. Both halves rest on one fact about a file this one does
+        not own: powertools' capture group admits a space but excludes a tab and a
+        newline, so an id containing either never matched a route and answered 404
+        before this change as well as after — unreachable rather than
+        reachable-then-orphaned.
+
+        That is the SAME distinction the whole upgrade note turns on, applied one
+        level down: ` abc123` is exempt because it never resolved, and `abc<TAB>def`
+        is out of scope for the same reason. Only `my form` and `'   '` are in
+        scope, because those really did resolve — the merge base keyed
+        `f'FORM#{form_id}'` with nothing checked — and now do not.
+
+        Asserted off the live resolver rather than from the pattern quoted in the
+        note, because the note's scope is only as true as the installed powertools:
+        an upgrade that widened the class to admit a tab would make a tab-bearing id
+        reachable, and then the paragraph saying the scan need not look for one
+        would be wrong in the under-reporting direction. This is that sentence as an
+        assertion.
+
+        The `my form` half is the positive control, and it is doing real work here
+        rather than balancing the loop for symmetry: `_form_id_route_paths` splices
+        a substring out of a regex, and the plausible way for it to break yields a
+        path that matches NOTHING — which would report every character as excluded
+        and pass an assertion set made only of exclusions.
+        """
+        for reachable in ('my form', '   ', 'a:b', 'café'):
+            admitting = [
+                f'{method} {path}'
+                for method, path, rule in _form_id_route_paths(
+                    feedback_form_handler, reachable
+                )
+                if rule.match(path)
+            ]
+            assert len(admitting) == 8, (
+                f'{reachable!r} is admitted by {len(admitting)} of the form-id '
+                'routes, expected all 8 — CHANGELOG.md lists this id as one that '
+                'DID resolve before the validator existed, so if no route matches '
+                'it the upgrade note is telling an operator to scan for a row that '
+                'was never reachable'
+            )
+            assert feedback_form_handler._validated_form_id(reachable) is None, (
+                f'{reachable!r} is accepted, so it did not stop resolving and does '
+                'not belong in the scan at all'
+            )
+
+        for unreachable in ('abc\tdef', 'abc\ndef'):
+            admitting = [
+                f'{method} {path}'
+                for method, path, rule in _form_id_route_paths(
+                    feedback_form_handler, unreachable
+                )
+                if rule.match(path)
+            ]
+            assert not admitting, (
+                f'{unreachable!r} is now admitted by {admitting} — powertools has '
+                'widened its capture group, so an id containing a tab or a newline '
+                'CAN reach a handler and is reachable-then-orphaned after all. '
+                "CHANGELOG.md's paragraph saying the scan need not find one is now "
+                'wrong, and the scan itself cannot find one through a line-oriented '
+                'pipeline'
             )
 
     def test_a_trailing_newline_is_not_a_valid_form_id(

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -2592,6 +2592,55 @@ class TestThePublicIframePageRefusesAnIdItCannotHaveMinted:
             os.environ['ALLOWED_ORIGIN']
         ]
 
+    @patch('feedback_form_handler.aggregates_table')
+    def test_the_response_carries_the_two_headers_the_csp_does_not(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """`nosniff` and `no-referrer`, which nothing else in this suite reads.
+
+        The CSP is pinned in both directions by the case below, but that case reads
+        `_IFRAME_SECURITY_HEADERS['Content-Security-Policy']` BY KEY — so it sees no
+        other entry in the dict, and deleting either of the other two headers left
+        the whole suite green.
+
+        Asserted as the WHOLE key set rather than as two `in` checks, so a header
+        added later has to be argued for here and in the comment above the dict
+        together — which is the convention the CSP already follows.
+
+        Read off the rendered response rather than off the constant, because the
+        constant being right is only half of it: `get_form_iframe` passes
+        `headers=dict(_IFRAME_SECURITY_HEADERS)`, and a `Response` that dropped them
+        or a resolver that overwrote them would leave the dict itself untouched.
+        """
+        mock_table.get_item.return_value = {'Item': {'form_id': 'deadbeef'}}
+
+        headers = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, 'deadbeef'), lambda_context
+        )['multiValueHeaders']
+
+        assert set(feedback_form_handler._IFRAME_SECURITY_HEADERS) == {
+            'Content-Security-Policy',
+            'X-Content-Type-Options',
+            'Referrer-Policy',
+        }, (
+            'a header was added to or removed from _IFRAME_SECURITY_HEADERS. A '
+            'REMOVAL of X-Content-Type-Options or Referrer-Policy is otherwise '
+            'silent — the CSP case reads the policy by key and sees no other '
+            'entry — and an ADDITION needs its reason recorded in the comment '
+            'above the dict, as the CSP and these two both are.'
+        )
+
+        # nosniff, because this is the only text/html in an otherwise all-JSON API:
+        # the one response a browser would otherwise be free to type for itself,
+        # and the one whose point is to be parsed as a document on this origin.
+        assert headers['X-Content-Type-Options'] == ['nosniff']
+        # no-referrer, because the page is framed on a customer's site, so the
+        # Referer on the widget's own fetches would put the customer's page URL in
+        # this API's access logs. The submit body carries `page_url` deliberately,
+        # so the product is not losing the URL — a log is just not where it was
+        # asked for.
+        assert headers['Referrer-Policy'] == ['no-referrer']
+
     def test_the_policy_names_every_directive_the_page_needs_and_no_wildcard(
         self, feedback_form_handler
     ):
@@ -3406,7 +3455,69 @@ def _routes_keying_on_a_form_id(source: str) -> dict[str, str]:
 # cannot be one of ours costs a Comprehend, Translate and Bedrock invocation
 # downstream. A call on any of these is what "keys on it" means below, and the
 # first one is the deadline the validation has to beat.
-_FORM_ID_SINKS = frozenset({'aggregates_table', 'feedback_table', 'sqs'})
+#
+# `dynamodb` is here for a different reason than the other three: no route calls
+# it today, but `dynamodb.Table(AGGREGATES_TABLE).get_item(...)` is the spelling
+# the module DEMONSTRATES at module scope (line ~40), so it is the one a route
+# needing a different table would copy — and a resource handle obtained inline is
+# a read just as much as one bound at import. Only module-level uses exist now,
+# which is why adding it costs nothing and closes the shape before it appears.
+_FORM_ID_SINKS = frozenset({
+    'aggregates_table', 'feedback_table', 'sqs', 'dynamodb',
+})
+
+
+def _sink_call_positions(function: ast.FunctionDef) -> list[tuple[int, int]]:
+    """Positions of every call in `function` that reaches a form id into a sink.
+
+    Matched on the CALLEE CHAIN rather than on `<sink>.<method>` alone, which is
+    what an earlier version of this derivation did — and it recognised a read only
+    when spelled `aggregates_table.get_item(...)` literally. Two shapes therefore
+    reported as bounded while reading before validating, and the failure mode was
+    SILENCE rather than a wrong answer: no sink found makes `sink_positions` empty,
+    and `all(...)` over an empty list is vacuously True.
+
+    - `table = aggregates_table` then `table.get_item(...)`. Locally bound sinks
+      are tracked below for this one.
+    - `dynamodb.Table(AGGREGATES_TABLE).get_item(...)`, where the sink name sits
+      further down the chain than `call.func.value`. Walking the whole callee
+      subtree is what catches it, and it is the more plausible of the two because
+      the module itself demonstrates that spelling.
+
+    Both are controls in `TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes`.
+
+    Aliases are collected from the function's TOP LEVEL, in source order, and only
+    from a plain `name = <expression mentioning a sink>`. A conditionally bound
+    alias is not tracked, deliberately: this derivation errs toward calling
+    something a sink, and the cost of a false positive is a route author being made
+    to say why — whereas a false negative is a read nobody reports.
+    """
+    aliases: set[str] = set()
+
+    def _mentions_a_sink(node: ast.AST) -> bool:
+        return any(
+            isinstance(child, ast.Name)
+            and (child.id in _FORM_ID_SINKS or child.id in aliases)
+            for child in ast.walk(node)
+        )
+
+    for statement in function.body:
+        if not isinstance(statement, ast.Assign):
+            continue
+        if not _mentions_a_sink(statement.value):
+            continue
+        aliases |= {
+            target.id for target in statement.targets
+            if isinstance(target, ast.Name)
+        }
+
+    return [
+        (call.lineno, call.col_offset)
+        for call in ast.walk(function)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Attribute)
+        and _mentions_a_sink(call.func)
+    ]
 
 
 def _refused_names(function: ast.FunctionDef) -> dict[str, tuple[int, int]]:
@@ -3537,14 +3648,7 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     if validated_at is None:
         return False
 
-    sink_positions = [
-        (call.lineno, call.col_offset)
-        for call in ast.walk(function)
-        if isinstance(call, ast.Call)
-        and isinstance(call.func, ast.Attribute)
-        and isinstance(call.func.value, ast.Name)
-        and call.func.value.id in _FORM_ID_SINKS
-    ]
+    sink_positions = _sink_call_positions(function)
     # No sink is not a pass by default: #379 was a route that touched no AWS
     # service at all and still put the id in its response, so a route that keys on
     # nothing yet takes an id out of the URL still has to establish the bound.
@@ -3760,6 +3864,77 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
             'running on every path is'
         )
 
+    def test_the_derivation_refuses_a_read_through_a_local_alias(self):
+        """The SINK side of the derivation, where the previous rounds' fixes did
+        not reach.
+
+        Every control above moves the validation relative to a sink spelled
+        `aggregates_table.get_item(...)`. This leaves the validation alone and
+        changes how the READ is spelled: bind the table to a local name first, and a
+        selector matching only `<sink>.<method>` stops recognising it.
+
+        The failure mode is what makes this worth a case rather than a note — it is
+        SILENCE, not a wrong answer. `sink_positions` comes back empty, and
+        `all(validated_at < sink for sink in [])` is vacuously True, so a route
+        reading before validating is reported as bounded. A derivation that reports
+        "fine" when it understood nothing is worse than no derivation, because the
+        docstring above it is then trusted.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/aliased-read")
+            def get_aliased_read(form_id: str):
+                table = aggregates_table
+                item = table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return item
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_aliased_read'), (
+            'a read through a local alias of a sink was not recognised as a read, '
+            'so the route was reported as bounded on an EMPTY sink list — '
+            'vacuously, which is the silent failure this control exists for'
+        )
+
+    def test_the_derivation_refuses_a_read_through_a_freshly_built_table(self):
+        """The same sink-side gap, in the spelling the module itself demonstrates.
+
+        `dynamodb.Table(AGGREGATES_TABLE).get_item(...)` puts the sink name deeper
+        in the callee chain than `call.func.value`, so a selector looking only at
+        the attribute's immediate owner sees no sink and `sink_positions` is empty —
+        vacuously True again.
+
+        This is the more plausible of the two shapes, and that is the whole argument
+        for the case: the module binds its tables exactly this way at module scope,
+        so a route that needs a different table has a working example of the
+        spelling in front of it. Nothing in the module does it inside a function
+        today, which is precisely when to close the shape — before the first one.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/fresh-table")
+            def get_fresh_table(form_id: str):
+                item = dynamodb.Table(AGGREGATES_TABLE).get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return item
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_fresh_table'), (
+            'a read through dynamodb.Table(...) built inline was not recognised '
+            'as a read — the sink name sits further down the callee chain, and '
+            'this is the spelling the module demonstrates at module scope'
+        )
+
     def test_the_derivation_refuses_a_validator_whose_result_is_discarded(self):
         """The shape that has NO bound while looking exactly like one.
 
@@ -3927,6 +4102,48 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
                 'normalized return splits the key a route reads from the '
                 'source_channel it filters on'
             )
+
+    def test_a_trailing_newline_is_not_a_valid_form_id(
+        self, feedback_form_handler
+    ):
+        """`$` matches before a final newline; `\\Z` is why this now refuses.
+
+        The one whitespace character the character class did not actually exclude.
+        `re`'s `$` also matches immediately BEFORE a trailing newline, so
+        `_FORM_ID_PATTERN.match('deadbeef\\n')` succeeded and the validator returned
+        the newline-bearing string — while the pattern's own comment says "No
+        whitespace either, and that is a choice rather than an oversight" and
+        `test_an_id_padded_with_whitespace_is_not_an_alias_for_the_id` pins only the
+        LEADING-space case. So the single character that got through was precisely
+        the one nothing checked.
+
+        Two consequences, both asserted:
+
+        - It reached `f'FORM#{validated}'`, `source_channel = f'form_{form_id}'` and
+          the log line in `_load_form_for_query`, where an embedded newline in a
+          structured log record is its own small problem.
+        - The length cap bounded the matched PREFIX rather than the id, so
+          `'a' * FORM_ID_MAX_LENGTH + '\\n'` was admitted at 65 characters while
+          `'a' * (FORM_ID_MAX_LENGTH + 1)` was refused. Derived from the constant
+          rather than spelled as a literal, for the same reason every other
+          over-length case here is.
+
+        Unreachable through the deployed route today — powertools' capture group
+        excludes `\\n`, and `%0A` arrives as the three literal characters `%0A`,
+        which `%` already refuses — and that is exactly the argument for fixing it
+        HERE: the pattern is documented as the bound that does not depend on the
+        route regex, so it has to hold on its own terms.
+        """
+        assert feedback_form_handler._validated_form_id('deadbeef\n') is None, (
+            "a trailing newline was accepted — check that _FORM_ID_PATTERN ends "
+            'in \\Z rather than $, which also matches before a final newline'
+        )
+        over_long = 'a' * feedback_form_handler.FORM_ID_MAX_LENGTH + '\n'
+        assert feedback_form_handler._validated_form_id(over_long) is None, (
+            f'{len(over_long)} characters were accepted against a cap of '
+            f'{feedback_form_handler.FORM_ID_MAX_LENGTH} — with `$` the cap bounds '
+            'the matched prefix, not the id'
+        )
 
     @patch('feedback_form_handler.feedback_table')
     @patch('feedback_form_handler.aggregates_table')

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -2412,6 +2412,56 @@ class TestThePublicIframePageRefusesAnIdItCannotHaveMinted:
         )
 
     @patch('feedback_form_handler.aggregates_table')
+    def test_a_read_that_fails_refuses_the_page_rather_than_rendering_it(
+        self, mock_table, capsys, api_gateway_event, lambda_context,
+        feedback_form_handler
+    ):
+        """The availability trade `get_form_iframe`'s docstring argues, pinned.
+
+        Having an existence gate means this route can now FAIL: before it, a page
+        was served having read nothing, so a table blip could not affect it. That
+        paragraph calls the 500 acceptable rather than a regression on two grounds,
+        and both of them are assertions here rather than prose:
+
+        - The page must NOT render for a form whose existence could not be
+          confirmed. A future `except` that swallowed the read failure and rendered
+          anyway — the obvious "keep the embed working" fix — restores exactly
+          #379's hole, a page on this origin for a form that may not exist, and
+          nothing else in the suite would notice.
+        - It must be OBSERVABLE. `FeedbackFormReadFailed` is the whole basis for
+          calling this a trade: a 500 the customer sees and operations does not is
+          the silent half of the defect `_load_form_for_query` was introduced for
+          (#312). Asserted all the way out through the EMF flush, like the /stats
+          case, so a metric that is buffered and never published still fails.
+        """
+        mock_table.get_item.side_effect = Exception(
+            'ProvisionedThroughputExceededException'
+        )
+
+        response = feedback_form_handler.lambda_handler(
+            _iframe_event(api_gateway_event, 'deadbeef'), lambda_context
+        )
+
+        assert response['statusCode'] == 500
+        assert json.loads(response['body'])['success'] is False
+        # No document, which is the security half: the 500 has to be INSTEAD of
+        # the page, not alongside a rendered one.
+        assert response['multiValueHeaders']['Content-Type'] != ['text/html']
+        assert 'VoCFeedbackForm' not in response['body']
+
+        emitted = _emitted_metrics(capsys, 'FeedbackFormReadFailed')
+        assert emitted, (
+            'the iframe read failed and emitted no CloudWatch metric — the '
+            'customer sees a broken frame and operations sees nothing, which is '
+            'what would make this existence check a regression rather than the '
+            'trade the docstring argues'
+        )
+        assert _namespaces_of(emitted) == {feedback_form_handler.metrics.namespace}, (
+            f'metric emitted under {_namespaces_of(emitted)}, not the namespace '
+            'shared/logging sets on the Metrics singleton'
+        )
+
+    @patch('feedback_form_handler.aggregates_table')
     def test_a_server_minted_id_still_serves_the_embeddable_page(
         self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
     ):
@@ -3084,9 +3134,10 @@ class TestTheAuthenticatedCrudRoutesAreBoundedToo:
       keyed on whatever the caller put in the path.
     """
 
-    # The three shapes, and what each must not do. Kept as data so a route added
-    # to the trio is a one-line addition rather than a fourth near-copy.
-    MALFORMED_BODY = {'name': 'pwn'}
+    # A VALID `PUT` body, and it has to be: `update_form` 400s on an empty update
+    # (`No fields to update`), so a body with nothing in it would produce a refusal
+    # that says nothing about the id. What is malformed in these cases is the ID.
+    A_VALID_UPDATE_BODY = {'name': 'pwn'}
 
     @patch('feedback_form_handler.aggregates_table')
     def test_no_crud_route_turns_a_malformed_id_into_a_key(
@@ -3101,7 +3152,7 @@ class TestTheAuthenticatedCrudRoutesAreBoundedToo:
         """
         for method, body in (
             ('GET', None),
-            ('PUT', self.MALFORMED_BODY),
+            ('PUT', self.A_VALID_UPDATE_BODY),
             ('DELETE', None),
         ):
             for malformed in (
@@ -3150,7 +3201,7 @@ class TestTheAuthenticatedCrudRoutesAreBoundedToo:
             method='PUT',
             path=f'/feedback-forms/{_INJECTION_PAYLOAD}',
             path_params={'form_id': _INJECTION_PAYLOAD},
-            body=self.MALFORMED_BODY,
+            body=self.A_VALID_UPDATE_BODY,
             resource='/feedback-forms/{form_id}',
         )
 
@@ -3257,7 +3308,7 @@ class TestTheAuthenticatedCrudRoutesAreBoundedToo:
 
 
 def _routes_keying_on_a_form_id(source: str) -> dict[str, str]:
-    """Every `@app.<method>` route whose path captures `<form_id>`, from source.
+    """Every `@app.<method>` route under `/feedback-forms/` that captures anything.
 
     Returns route path -> handler function name, read off the module with `ast`
     rather than listed here. The two classes above name their routes explicitly,
@@ -3265,8 +3316,20 @@ def _routes_keying_on_a_form_id(source: str) -> dict[str, str]:
     lists is what the module is measured against. A route added later appears here
     for free, and if it does not validate its id the test below fails naming it.
 
-    Only `<form_id>` counts: `/feedback-forms` and `POST /feedback-forms` take no
-    id out of the URL and have nothing to check.
+    Selected on the PATH PREFIX plus the presence of a `<...>` capture, and
+    deliberately NOT on the literal `<form_id>`: the capture's NAME is the route
+    author's choice, so `<id>`, `<formId>` or `<form>` are all plausible spellings
+    for a route added later — and every one of them would have escaped a
+    `'<form_id>' in path` filter while keying on the same partition. A universal
+    claim whose universe is chosen by a name nobody has to use is not a universal
+    claim; `test_a_route_that_captures_the_id_under_another_name_is_still_judged`
+    is the control.
+
+    Still excludes `/feedback-forms` and `POST /feedback-forms`: those carry no
+    capture, so they take no id out of the URL and have nothing to check. A route
+    under this prefix that captures something OTHER than a form id (a submission
+    id, say) would be included and would have to establish the bound or say why —
+    which is the right side to err on, since the alternative is silence.
     """
     tree = ast.parse(source)
     routes = {}
@@ -3289,25 +3352,79 @@ def _routes_keying_on_a_form_id(source: str) -> dict[str, str]:
             path = decorator.args[0]
             if not (isinstance(path, ast.Constant) and isinstance(path.value, str)):
                 continue
-            if '<form_id>' in path.value:
+            if path.value.startswith('/feedback-forms/') and '<' in path.value:
                 routes[f'{target.attr.upper()} {path.value}'] = node.name
     assert routes, (
-        'no @app route capturing <form_id> was found in the handler source — the '
-        'derivation found nothing to judge, so a green result below would be '
-        'meaningless. If the routes moved or the decorator spelling changed, fix '
-        'this helper; do not delete the assertion.'
+        'no @app route under /feedback-forms/ with a <...> capture was found in '
+        'the handler source — the derivation found nothing to judge, so a green '
+        'result below would be meaningless. If the routes moved or the decorator '
+        'spelling changed, fix this helper; do not delete the assertion.'
     )
     return routes
 
 
-def _validates_its_form_id(source: str, function_name: str) -> bool:
-    """Does `function_name` reach `_validated_form_id` before it keys on anything?
+# The objects a route reaches a form id INTO: the two DynamoDB tables, and the
+# queue because `/submit` writes there and an enqueued record for an id that
+# cannot be one of ours costs a Comprehend, Translate and Bedrock invocation
+# downstream. A call on any of these is what "keys on it" means below, and the
+# first one is the deadline the validation has to beat.
+_FORM_ID_SINKS = frozenset({'aggregates_table', 'feedback_table', 'sqs'})
 
-    True if the function calls it directly, or calls `_load_form_for_query` — the
-    one read `/stats` and `/submissions` make, which validates on their behalf.
-    Following the delegation rather than requiring the direct call is the point:
-    the alternative is a test that demands a particular spelling and fails on a
-    legitimate refactor.
+
+def _refused_names(function: ast.FunctionDef) -> set[str]:
+    """Names this function tests in an `if` that then raises or returns.
+
+    `_validated_form_id` returns None rather than raising — deliberately, since
+    every caller answers the same 404 — so the CALL is not the bound; the refusal
+    after it is. A function that calls the validator and ignores what comes back
+    has no bound at all, which is the natural mistake for someone copying the call
+    and dropping the two lines that follow it at every current site.
+    """
+    refused = set()
+    for node in ast.walk(function):
+        if not isinstance(node, ast.If):
+            continue
+        if not any(
+            isinstance(child, (ast.Raise, ast.Return))
+            for statement in node.body
+            for child in ast.walk(statement)
+        ):
+            continue
+        refused |= {
+            name.id for name in ast.walk(node.test) if isinstance(name, ast.Name)
+        }
+    return refused
+
+
+def _validates_its_form_id(source: str, function_name: str) -> bool:
+    """Does `function_name` reach the validator, and REFUSE, before keying on
+    anything?
+
+    Positional and result-aware, because the order and the refusal are the whole
+    claim. An earlier version of this helper was an order-insensitive set-membership
+    test over every call name in the body, which three unsafe shapes satisfied: a
+    `get_item` before the validator, a validator whose return value was discarded,
+    and a validator mentioned only inside `if False:`. Each is reported False now,
+    and each has a control below — the second one mattering most, since a route
+    with no bound at all looked identical to a correct one.
+
+    A validating statement is one of two spellings, both required to sit at the
+    function's TOP LEVEL:
+
+    - `<name> = _validated_form_id(...)` where `<name>` is later tested in an `if`
+      whose body raises or returns. The assignment alone is not enough (see
+      `_refused_names`).
+    - a call to `_load_form_for_query(...)`, which needs no result check because it
+      RAISES for itself. Following the delegation rather than demanding the direct
+      call is deliberate: `/stats` and `/submissions` validate through it, and a
+      derivation that named only `_validated_form_id` would push someone into
+      adding a redundant second call to each.
+
+    Top level rather than anywhere is what excludes dead code and conditional
+    validation together — a check that only runs on some paths is not a bound, and
+    `if False:` is just the extreme of that. If a legitimate spelling ever needs to
+    nest (validation inside a `with`, say), widen this deliberately and add the
+    control alongside the three below; do not relax it to get green.
     """
     tree = ast.parse(source)
     functions = [
@@ -3317,12 +3434,52 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     assert len(functions) == 1, (
         f'expected exactly one def {function_name}, found {len(functions)}'
     )
-    called = {
-        node.func.id
-        for node in ast.walk(functions[0])
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
-    }
-    return bool(called & {'_validated_form_id', '_load_form_for_query'})
+    function = functions[0]
+    refused = _refused_names(function)
+
+    def _calls(statement) -> list[ast.Call]:
+        return [n for n in ast.walk(statement) if isinstance(n, ast.Call)]
+
+    def _named(call: ast.Call, name: str) -> bool:
+        return isinstance(call.func, ast.Name) and call.func.id == name
+
+    validated_at = None
+    for statement in function.body:
+        for call in _calls(statement):
+            if _named(call, '_load_form_for_query'):
+                position = (statement.lineno, statement.col_offset)
+                validated_at = min(validated_at or position, position)
+            if not _named(call, '_validated_form_id'):
+                continue
+            # The result has to be BOUND and then refused. An `Expr` statement, or
+            # an assignment to a name nothing tests, is the shape that has no bound.
+            targets = (
+                statement.targets if isinstance(statement, ast.Assign)
+                else [statement.target] if isinstance(statement, ast.AnnAssign)
+                else []
+            )
+            if any(
+                isinstance(target, ast.Name) and target.id in refused
+                for target in targets
+            ):
+                position = (statement.lineno, statement.col_offset)
+                validated_at = min(validated_at or position, position)
+
+    if validated_at is None:
+        return False
+
+    sink_positions = [
+        (call.lineno, call.col_offset)
+        for call in ast.walk(function)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Attribute)
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id in _FORM_ID_SINKS
+    ]
+    # No sink is not a pass by default: #379 was a route that touched no AWS
+    # service at all and still put the id in its response, so a route that keys on
+    # nothing yet takes an id out of the URL still has to establish the bound.
+    return all(validated_at < sink for sink in sink_positions)
 
 
 class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
@@ -3340,13 +3497,13 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
     def test_no_route_keys_on_a_form_id_without_validating_it_first(
         self, feedback_form_handler
     ):
-        """Every `<form_id>` route validates, or the failure names the ones that do
-        not.
+        """Every route under `/feedback-forms/<...>` validates and refuses first, or
+        the failure names the ones that do not.
 
         This is the test that makes the docstring's "EVERY" audit itself. A route
-        added later is included automatically, so the next person to write
-        `@app.get("/feedback-forms/<form_id>/something")` finds out here rather
-        than in a review.
+        added later is included automatically — whatever it calls its capture — so
+        the next person to write `@app.get("/feedback-forms/<id>/something")` finds
+        out here rather than in a review.
         """
         source = Path(inspect.getsourcefile(feedback_form_handler)).read_text(
             encoding='utf-8'
@@ -3360,11 +3517,13 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
         )
 
         assert unbounded == [], (
-            f'{unbounded} take a form id out of the URL without reaching '
-            '_validated_form_id (directly or through _load_form_for_query), so '
-            "that function's docstring no longer describes the module. Add the "
-            'check rather than narrowing the claim: the value of a universal '
-            'bound is that a reader does not have to hold the exceptions.'
+            f'{unbounded} take a form id out of the URL without establishing the '
+            'bound before their first read or send. Three shapes report here, and '
+            'the message cannot tell them apart: no validator call at all; a call '
+            'whose None result is never refused (which is no bound — see '
+            '_refused_names); or a call that comes AFTER the table or the queue is '
+            "touched. Add the check rather than narrowing the claim: the value of a "
+            'universal bound is that a reader does not have to hold the exceptions.'
         )
 
     def test_the_derivation_sees_the_routes_this_module_actually_has(
@@ -3412,6 +3571,8 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
             @app.get("/feedback-forms/<form_id>/checked")
             def get_checked(form_id: str):
                 validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
                 return validated
             '''
         )
@@ -3422,9 +3583,148 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
             'GET /feedback-forms/<form_id>/checked': 'get_checked',
         }
         assert not _validates_its_form_id(source, 'get_new_thing')
-        # And the delegating spelling is accepted, so the check is about reaching
-        # the validator rather than about naming it.
+        # And the accepting side, so the check is not simply always False: the
+        # module's own spelling — validate, refuse on None, then proceed.
         assert _validates_its_form_id(source, 'get_checked')
+
+    def test_the_derivation_refuses_a_read_that_happens_before_the_check(self):
+        """ORDER is part of the claim, and the old derivation ignored it.
+
+        A route that reads first and validates afterwards satisfies "calls the
+        validator" while paying for the DynamoDB call the check exists to avoid —
+        which is the entire cost argument `_validated_form_id`'s docstring makes and
+        the basis for the throttle pair in `lib/stacks/api-stack.ts`. So the
+        validation has to beat the first sink, not merely appear somewhere in the
+        body.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/backwards")
+            def get_backwards(form_id: str):
+                item = aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return item
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_backwards'), (
+            'a get_item before the validator was reported as validated — the '
+            'derivation is order-insensitive again, and the cost argument it '
+            'checks is about order'
+        )
+
+    def test_the_derivation_refuses_a_validator_whose_result_is_discarded(self):
+        """The shape that has NO bound while looking exactly like one.
+
+        `_validated_form_id` returns None rather than raising — deliberately, since
+        every caller answers the same 404 — so the call is not the bound; the
+        refusal after it is. A route that calls it and drops the result reads a
+        malformed id straight into the table, and under the old set-membership
+        derivation it was indistinguishable from a correct route.
+
+        It is also the likeliest mistake in practice: the two-line
+        `if not validated: raise` is separable from the call, and every one of the
+        module's current sites spells it out by hand.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/discarded")
+            def get_discarded(form_id: str):
+                _validated_form_id(form_id)
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_discarded'), (
+            'a discarded validator result was reported as a bound — the value the '
+            'derivation is checking for is the REFUSAL, not the call'
+        )
+
+        # And the same thing one step subtler: the result is bound to a name, but
+        # nothing ever tests it. An assignment is not a refusal either.
+        assigned_but_unchecked = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/assigned")
+            def get_assigned(form_id: str):
+                validated = _validated_form_id(form_id)
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
+                )
+            '''
+        )
+
+        assert not _validates_its_form_id(assigned_but_unchecked, 'get_assigned'), (
+            'a validated value used as a key without being refused first was '
+            "reported as bounded — `f'FORM#None'` is still a read"
+        )
+
+    def test_the_derivation_refuses_validation_that_only_runs_sometimes(self):
+        """Dead or conditional validation is not validation.
+
+        `if False:` is the extreme of a check that does not run on every path, and
+        it passed the old derivation because the call was lexically present. The
+        general property is what matters: validation nested under a condition
+        bounds some requests and not others, so the derivation requires it at the
+        function's top level.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/dead")
+            def get_dead(form_id: str):
+                if False:
+                    validated = _validated_form_id(form_id)
+                    if not validated:
+                        raise NotFoundError('Form not found')
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_dead'), (
+            'validation inside dead code was reported as a bound — the check has '
+            'to be on every path, not merely in the source'
+        )
+
+    def test_a_route_that_captures_the_id_under_another_name_is_still_judged(self):
+        """The universe is chosen by the PATH, not by the capture's name.
+
+        This is the hole a `'<form_id>' in path` filter left: a route capturing the
+        same id as `<id>` keyed on the same partition while being invisible to the
+        claim, so `test_no_route_keys_on_a_form_id_without_validating_it_first`
+        passed with it unvalidated — silence, which is the failure mode this
+        derivation replaced a prose list to avoid. `<id>` is not a hypothetical
+        spelling; it is the shorter and more natural one for someone adding a
+        route.
+
+        Both directions, because only the pair makes the selector meaningful: the
+        renamed route must be REPORTED as part of the universe, and then reported
+        as UNVALIDATED. A selector that included it but a check that waved it
+        through would be the same hole one step along.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<id>/export")
+            def export_form(id: str):
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{id}'}
+                )
+            '''
+        )
+
+        routes = _routes_keying_on_a_form_id(source)
+
+        assert routes == {'GET /feedback-forms/<id>/export': 'export_form'}, (
+            f'the derivation reported {routes} — a route capturing the form id '
+            'under a name other than form_id escapes the universal claim entirely'
+        )
+        assert not _validates_its_form_id(source, 'export_form')
 
     def test_the_derivation_accepts_the_delegating_spelling(self):
         """`/stats` and `/submissions` validate through `_load_form_for_query`.

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -5708,7 +5708,10 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         so `'form(1)'` and `'a;b'` are sampled beside the named `'a:b'`. Those two
         hold characters from the #379 payload itself, which is the reason a list
         written by hand omits them — they read as attack syntax rather than as an id
-        anyone would seed, and they resolved regardless.
+        anyone would seed, and they resolved regardless. The complement's other half
+        is asserted too: `"`, `#`, `/`, `?`, a backslash and a backtick are the
+        printable-ASCII characters the ROUTE omits, which all three documents state
+        alongside the 24, so they are in the unreachable loop.
 
         Exhaustively rather than representatively, because a partial sample is what
         let the prose go wrong twice. `Lm` and `No` read to a human as punctuation,
@@ -5795,6 +5798,15 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         # selection of only marks, one symbol, one separator and one format character
         # was in exactly that state.
         #
+        # The six printable-ASCII entries are the other half of the in-scope
+        # complement above: all three documents state the in-scope ASCII set as the
+        # 24 characters the route admits and this pattern does not, and then name
+        # `"`, `#`, `/`, `?`, `\\` and a backtick as the printable characters the
+        # ROUTE omits. That is a claim about the capture group rather than about the
+        # validator, so it belongs in THIS loop — the validator refuses all six
+        # either way, which is why asserting refusal alone could not tell the two
+        # claims apart.
+        #
         # `Zl` and `Zp` are the pair NEITHER document's `Z*` illustration covers:
         # U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR are not `Zs` like the
         # U+00A0 and U+3000 both documents name, and they are the exact two characters
@@ -5822,7 +5834,8 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         # did. Both documents name `caf\u00e9` in scope without saying which of the
         # two spellings they mean. `\u200d` and `\u0488` would be invisible, or would
         # stack onto the preceding character, in an editor.
-        for unreachable in ('abc\tdef', 'abc\ndef', 'form€a', 'form°a',
+        for unreachable in ('abc\tdef', 'abc\ndef', 'a"b', 'a#b', 'a/b', 'a?b',
+                            'a\\b', 'a`b', 'form€a', 'form°a',
                             'form\U0001f600a', 'form—a', 'form«a',
                             'hawai\u2019i-form', 'form\uff3fa', 'cafe\u0301',
                             'फॉर्म', 'form\u0488a', 'form\u200da',

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -3393,6 +3393,75 @@ class TestTheAuthenticatedCrudRoutesAreBoundedToo:
         )
         assert 'ConditionExpression' not in mock_table.delete_item.call_args.kwargs
 
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_create_that_would_overwrite_a_stored_form_is_refused(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The mirror image of `PUT`'s condition, on the write that OVERWRITES.
+
+        `update_form` needed `attribute_exists(sk)` because UpdateItem creates
+        silently. PutItem replaces just as silently, so `create_form` is the other
+        half: with no condition, a minted id that collides with a stored form
+        REPLACES it — that customer's `enabled` flag, theme and prioritization link
+        gone, answered 200, the response echoing the NEW record so nothing anywhere
+        says a form was lost.
+
+        Not reachable by a caller, since the id is minted and never taken from the
+        body, so it takes a collision: two `_minted_form_id()` draws agreeing, a
+        birthday problem over 32 bits at `FORM_ID_LENGTH = 8`. Small, not zero —
+        and the constant's comment says it is safe to RAISE, which this condition
+        is what keeps a free choice rather than one eventually forced by the loss.
+
+        500 rather than a 4xx is the deliberate part: a collision is the server's
+        problem, the caller did nothing wrong, and a retry mints a different id.
+        """
+        mock_table.put_item.side_effect = ClientError(
+            {'Error': {'Code': 'ConditionalCheckFailedException',
+                       'Message': 'The conditional request failed'}},
+            'PutItem',
+        )
+
+        event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms',
+            body={'name': 'a form whose minted id is already taken'},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 500
+        assert json.loads(response['body'])['success'] is False
+        # The condition is on the REQUEST rather than only in the docstring —
+        # without it this write succeeds and the stored form is gone.
+        assert (
+            mock_table.put_item.call_args.kwargs['ConditionExpression']
+            == 'attribute_not_exists(sk)'
+        )
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_create_of_a_new_form_still_succeeds(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The contract the condition must not have broken.
+
+        Every create in practice is of an id nothing holds, so the condition has to
+        be invisible on the path that matters. Without this, the case above would
+        pass just as well with `create_form` broken outright.
+        """
+        event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms',
+            body={'name': 'A brand new form'},
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        form = json.loads(response['body'])['form']
+        assert form['name'] == 'A brand new form'
+        # And a real minted id came back, so the caller can address what it made.
+        assert feedback_form_handler._validated_form_id(form['form_id'])
+
 
 def _routes_keying_on_a_form_id(source: str) -> dict[str, str]:
     """Every `@app.<method>` route under `/feedback-forms/` that captures anything.

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -5608,20 +5608,35 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         pattern does not) and print it, and a check covering only the memorable
         characters is what let the prose stand at six of twenty-four. Seven of the
         rest are the characters the #379 fix turns on — the quote, parens and
-        semicolon the payload closes its handwritten string literal with, plus the
-        `<`, `>` and `&` `_js_value` escapes for the HTML parser — so the `dangerous`
-        loop above asserts those for their own reason and this loop re-covers them
-        deliberately: they are in both sets, and each set's claim should be readable
-        without the other.
+        semicolon the payload breaks out with (three of those four in the payload
+        itself, decomposed at `_INJECTION_PAYLOAD`), plus the `<`, `>` and `&`
+        `_js_value` escapes for the HTML parser — so the `dangerous` loop above
+        asserts those for their own reason and this loop re-covers them deliberately:
+        they are in both sets, and each set's claim should be readable without the
+        other.
 
         The set's MEMBERSHIP is derived from the installed resolver rather than
-        counted, and that is the assertion the documents actually rest on: they print
-        this set, and a cardinality check cannot tell a match from a swap. Trading
-        `!` for `"` keeps the count at 24 while replacing a character the route
-        admits with one it does not, and the refusal loop passes either way — the
-        validator refuses both — so the count alone let a genuinely in-scope
+        counted, and the derived set is then held against all THREE copies of it —
+        this file's literal and the fenced block each document prints. A count cannot
+        tell a match from a swap, and an assertion on the literal alone cannot tell
+        either document from a stale one: both printed sets could lose a character
+        with nothing failing (verified by mutation, dropping `~` from each). The
+        printed lines are the ones an operator reads to decide whether the row in
+        front of them needs renaming, so a character missing there is a row left to
+        404 in production — which is the same failure this test exists for, one level
+        out. Trading `!` for `"` keeps the count at 24 while replacing a character the
+        route admits with one it does not, and the refusal loop passes either way —
+        the validator refuses both — so the count alone let a genuinely in-scope
         character disappear from the printed set while asserting a refusal that is
         true for the wrong reason.
+
+        Equality against a hand-written literal rather than a derivation feeding the
+        refusal loop, which is the shape the vacuity control below turns on: a broken
+        splice reports every character as excluded, so a derived set used as the
+        SOURCE of the cases would silently check nothing, while one used as the ORACLE
+        against a written-down set cannot. The three-way equality inherits that — an
+        empty derivation fails against all three copies rather than passing against
+        none.
 
         `my form` earns its place for the same reason `a:b` has one: a stored id with
         an INTERIOR SPACE resolved before this change (every route keyed
@@ -5685,7 +5700,8 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         # character would drop out of the printed set unnoticed (verified by
         # mutation). A character is in scope exactly when all eight routes admit it
         # and this validator refuses it, which is the complement the documents state,
-        # so deriving it is also what keeps the two copies honest.
+        # so the derived set is the oracle both this literal and their printed blocks
+        # are checked against below.
         in_scope_ascii = {
             character
             for character in map(chr, range(0x20, 0x7f))
@@ -5701,12 +5717,48 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
             'the in-scope ASCII set derived from the installed resolver is '
             f'{"".join(sorted(in_scope_ascii))!r}, not the '
             f'{"".join(sorted(set(scanned_ascii)))!r} listed here — either the '
-            "route's capture group moved, or this literal and the set printed in "
-            'CHANGELOG.md and docs/feedback-forms.md are now wrong. Both documents '
-            'state that set as a COMPLEMENT (every character the route admits and '
-            'this pattern does not) and then print it, so this literal is the copy '
-            'that has to agree with them.'
+            "route's capture group moved, or this literal is now wrong. Both "
+            'documents state that set as a COMPLEMENT (every character the route '
+            'admits and this pattern does not) and then print it, and the '
+            'assertion below is what holds their copies to it.'
         )
+        # The documents' OWN copies, which are the ones an operator reads. The
+        # assertion above pins this file's literal and nothing else, so without this
+        # the set could be dropped from both printed blocks and the whole suite would
+        # stay green (verified by mutation: deleting `~` from each). That is the
+        # defect one level down from the one this test is for — the prose stood at six
+        # of twenty-four while the code was right — and there are four copies of the
+        # set now, so leaving three unchecked is how the fifth round of this arrives.
+        #
+        # The fenced line is located by its leading `space` token rather than by a
+        # line number: `space` is there because a literal space cannot be shown
+        # otherwise, which makes it a stable anchor and not a formatting choice.
+        # Exactly one match per document is required, so a block that is reworded
+        # away fails here rather than silently asserting nothing.
+        repo_root = Path(__file__).resolve().parents[4]
+        for relative in ('CHANGELOG.md', 'docs/feedback-forms.md'):
+            printed = [
+                line.split()
+                for line in (repo_root / relative).read_text(
+                    encoding='utf-8'
+                ).splitlines()
+                if line.split()[:1] == ['space']
+            ]
+            assert len(printed) == 1, (
+                f'{relative} has {len(printed)} fenced lines beginning with the '
+                '`space` token, not 1 — that line is the set of in-scope ASCII '
+                'characters the upgrade note tells an operator to scan for, and '
+                'this assertion cannot check a set it cannot find'
+            )
+            document_set = {' ' if token == 'space' else token for token in printed[0]}
+            assert document_set == in_scope_ascii, (
+                f'{relative} prints '
+                f'{"".join(sorted(document_set))!r} as the in-scope ASCII set, but '
+                f'{"".join(sorted(in_scope_ascii))!r} is what the installed '
+                'resolver admits and this validator refuses. An operator decides '
+                'whether the row in front of them needs renaming from that line, '
+                'so a character missing from it is a row left to 404 in production.'
+            )
 
     def test_the_scan_is_scoped_to_ids_a_route_could_actually_resolve(
         self, feedback_form_handler
@@ -5743,9 +5795,10 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         On the ASCII side the same principle applies to the CLASS rather than to a
         category: the in-scope set is 24 characters, and the note named six of them,
         so `'form(1)'` and `'a;b'` are sampled beside the named `'a:b'`. Those two
-        hold characters the #379 fix turns on — `(`, `)` and `;` are three of the
-        four the payload closes its handwritten string literal with — which is the
-        reason a list written by hand omits them: they read as attack syntax rather
+        hold characters the #379 fix turns on — `(`, `)` and `;` are three of the four
+        the payload breaks out with, and the `)` and `;` are two of the three
+        `_INJECTION_PAYLOAD`'s own comment names — which is the reason a list written
+        by hand omits them: they read as attack syntax rather
         than as an id anyone would seed, and they resolved regardless. The other half
         is asserted too: `"`, `#`, `/`, `?`, a backslash and a backtick are the
         printable-ASCII characters the ROUTE omits, which all three documents state
@@ -5786,12 +5839,12 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         # The ASCII cases first. `a:b` is one of the characters both documents name;
         # `form(1)` and `a;b` are two they do NOT. The in-scope ASCII set is 24
         # characters, and the seven the #379 fix turns on (`&`, `'`, `(`, `)`, `;`,
-        # `<`, `>` — the quote, parens and semicolon the payload closes its
-        # handwritten string literal with, plus the three `_js_value` escapes for the
-        # HTML parser) are exactly the ones a hand-written list drops, because they
-        # read as attack syntax rather than as an id anyone would seed. They resolved
-        # all the same, so sampling only a NAMED character would pin the note's list
-        # rather than the class the classifier actually tests.
+        # `<`, `>` — the quote, parens and semicolon the payload breaks out with, plus
+        # the three `_js_value` escapes for the HTML parser) are exactly the ones a
+        # hand-written list drops, because they read as attack syntax rather than as an
+        # id anyone would seed. They resolved all the same, so sampling only a NAMED
+        # character would pin the note's list rather than the class the classifier
+        # actually tests.
         #
         # Then one id per `\w` category, so no category stands in for another: `Ll`
         # `café`, `Lm` `hawaiʼi-form` (U+02BC, an apostrophe to the eye), `Lo`

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -5607,9 +5607,22 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         set as a complement (every character the route's capture group admits and this
         pattern does not) and print it, and a check covering only the memorable
         characters is what let the prose stand at six of twenty-four. Seven of the
-        rest are the #379 payload's own, so the `dangerous` loop above asserts those
-        for their own reason and this loop re-covers them deliberately: they are in
-        both sets, and each set's claim should be readable without the other.
+        rest are the characters the #379 fix turns on — the quote, parens and
+        semicolon the payload closes its handwritten string literal with, plus the
+        `<`, `>` and `&` `_js_value` escapes for the HTML parser — so the `dangerous`
+        loop above asserts those for their own reason and this loop re-covers them
+        deliberately: they are in both sets, and each set's claim should be readable
+        without the other.
+
+        The set's MEMBERSHIP is derived from the installed resolver rather than
+        counted, and that is the assertion the documents actually rest on: they print
+        this set, and a cardinality check cannot tell a match from a swap. Trading
+        `!` for `"` keeps the count at 24 while replacing a character the route
+        admits with one it does not, and the refusal loop passes either way — the
+        validator refuses both — so the count alone let a genuinely in-scope
+        character disappear from the printed set while asserting a refusal that is
+        true for the wrong reason.
+
         `my form` earns its place for the same reason `a:b` has one: a stored id with
         an INTERIOR SPACE resolved before this change (every route keyed
         `f'FORM#{form_id}'` with nothing checked) and answers 404 after it, so it is
@@ -5663,12 +5676,36 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
                 'scan stored ids for exactly these, so if one is now admitted the '
                 'upgrade note describes a refusal that does not happen'
             )
-        assert len(scanned_ascii) == 24, (
-            f'{len(scanned_ascii)} ASCII characters here, not 24 — both documents '
-            'state the in-scope ASCII set as a COMPLEMENT and then print it, so '
-            'this literal is the copy that has to agree with them. '
-            'test_the_scan_is_scoped_to_ids_a_route_could_actually_resolve is where '
-            'membership is derived off the live resolver rather than listed.'
+        # MEMBERSHIP, not the count: derived off the live resolver rather than
+        # counted, because the two documents print this exact set and a count cannot
+        # tell a swap from a match. Swapping `!` for `"` keeps the length at 24 while
+        # substituting a character the ROUTE does not admit for one it does — the
+        # refusal loop above passes either way, since the validator refuses both, so
+        # the assertion would be true for the wrong reason and one genuinely in-scope
+        # character would drop out of the printed set unnoticed (verified by
+        # mutation). A character is in scope exactly when all eight routes admit it
+        # and this validator refuses it, which is the complement the documents state,
+        # so deriving it is also what keeps the two copies honest.
+        in_scope_ascii = {
+            character
+            for character in map(chr, range(0x20, 0x7f))
+            if feedback_form_handler._validated_form_id(f'a{character}b') is None
+            and all(
+                rule.match(path)
+                for _, path, rule in _form_id_route_paths(
+                    feedback_form_handler, f'a{character}b'
+                )
+            )
+        }
+        assert in_scope_ascii == set(scanned_ascii), (
+            'the in-scope ASCII set derived from the installed resolver is '
+            f'{"".join(sorted(in_scope_ascii))!r}, not the '
+            f'{"".join(sorted(set(scanned_ascii)))!r} listed here — either the '
+            "route's capture group moved, or this literal and the set printed in "
+            'CHANGELOG.md and docs/feedback-forms.md are now wrong. Both documents '
+            'state that set as a COMPLEMENT (every character the route admits and '
+            'this pattern does not) and then print it, so this literal is the copy '
+            'that has to agree with them.'
         )
 
     def test_the_scan_is_scoped_to_ids_a_route_could_actually_resolve(
@@ -5706,9 +5743,10 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         On the ASCII side the same principle applies to the CLASS rather than to a
         category: the in-scope set is 24 characters, and the note named six of them,
         so `'form(1)'` and `'a;b'` are sampled beside the named `'a:b'`. Those two
-        hold characters from the #379 payload itself, which is the reason a list
-        written by hand omits them — they read as attack syntax rather than as an id
-        anyone would seed, and they resolved regardless. The complement's other half
+        hold characters the #379 fix turns on — `(`, `)` and `;` are three of the
+        four the payload closes its handwritten string literal with — which is the
+        reason a list written by hand omits them: they read as attack syntax rather
+        than as an id anyone would seed, and they resolved regardless. The other half
         is asserted too: `"`, `#`, `/`, `?`, a backslash and a backtick are the
         printable-ASCII characters the ROUTE omits, which all three documents state
         alongside the 24, so they are in the unreachable loop.
@@ -5747,11 +5785,13 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         """
         # The ASCII cases first. `a:b` is one of the characters both documents name;
         # `form(1)` and `a;b` are two they do NOT. The in-scope ASCII set is 24
-        # characters, and the seven the #379 payload is built from (`&`, `'`, `(`,
-        # `)`, `;`, `<`, `>`) are exactly the ones a hand-written list drops, because
-        # they read as attack syntax rather than as an id anyone would seed. They
-        # resolved all the same, so sampling only a NAMED character would pin the
-        # note's list rather than the class the classifier actually tests.
+        # characters, and the seven the #379 fix turns on (`&`, `'`, `(`, `)`, `;`,
+        # `<`, `>` — the quote, parens and semicolon the payload closes its
+        # handwritten string literal with, plus the three `_js_value` escapes for the
+        # HTML parser) are exactly the ones a hand-written list drops, because they
+        # read as attack syntax rather than as an id anyone would seed. They resolved
+        # all the same, so sampling only a NAMED character would pin the note's list
+        # rather than the class the classifier actually tests.
         #
         # Then one id per `\w` category, so no category stands in for another: `Ll`
         # `café`, `Lm` `hawaiʼi-form` (U+02BC, an apostrophe to the eye), `Lo`

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -5574,6 +5574,14 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         merely ADDRESSED with surrounding space — ` abc123` never resolved to
         `abc123` — and not to whitespace-bearing ids as a category.
 
+        `my form` is deliberately NOT an independent detector, and saying so is the
+        honest version: `'a b'` in the loop above already fails on any class that
+        admits a space, so widening the class would be caught with or without it
+        (verified by mutation). It is here as the spelling an operator will actually
+        recognise in their own table, next to the characters the scan names, so the
+        list a reader checks the upgrade note against is the same list the note
+        gives them.
+
         The accepting cases at the top are the vacuity control, and they are what
         makes the two refusal loops an argument rather than a tautology. Adding a
         character to a class can never make a previously-refused string accepted, so

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -3559,32 +3559,88 @@ _FORM_ID_SINKS = frozenset({
 #
 # Erring toward calling something a sink is the right side of this: a false
 # positive costs a route author an explanation, while a false negative is a read
-# NOBODY reports — an empty `sink_positions` makes `_validates_its_form_id`'s
-# `all(...)` vacuously True, so the instrument answers "bounded" when it understood
-# nothing.
+# NOBODY reports — a sink the derivation cannot see is a sink it asks no question
+# about, so `_validates_its_form_id` answers "bounded" having understood nothing.
 _SINK_OPERATIONS = frozenset({
     'get_item', 'put_item', 'update_item', 'delete_item', 'query', 'scan',
     'batch_get_item', 'batch_write_item', 'send_message', 'send_message_batch',
 })
 
 
-def _sink_call_positions(function: ast.FunctionDef) -> list[tuple[int, int]]:
-    """Positions of every call in `function` that reaches a form id into a sink.
+def _sink_bearing_helpers(tree: ast.Module) -> frozenset[str]:
+    """Module-level functions that reach what they are handed into a sink.
 
-    A call counts as a sink two ways, and either is enough:
+    A sink does not have to be spelled in the route. `_anchor_form_brand`
+    (`feedback_form_handler.py:269`) performs an `update_item` on a key built from
+    the id it is passed, and `submit_form_feedback` already calls it — so a route
+    that hands an unvalidated id to a helper writes it to the table with no sink
+    call of its own anywhere in its body. `_sink_calls` matched only an
+    `ast.Attribute` callee, so a plain `helper(form_id)` was not a sink at all, the
+    list came back empty, and the vacuous `all(...)` reported the route as bounded.
+    Silence again, this time through the call SHAPE rather than the receiver name.
+
+    Excluded: any function that calls `_validated_form_id` itself. That is what
+    makes `_load_form_for_query` — which reads, and is called by three routes — not
+    a hole: it establishes the bound on the id it was handed before its own read,
+    which is the delegating spelling `_validates_its_form_id` already accepts as a
+    refusal. Counting it as an unguarded sink would report `/iframe`, `/stats` and
+    `/submissions` as unbounded, which is the false-positive direction. The same
+    rule excludes the route handlers, each of which validates.
+
+    A fixpoint rather than one level, because a helper calling a helper is the same
+    hole one step further out and the loop costs four lines. It resolves NAMES in
+    this module only: a sink reached through an imported function is still invisible,
+    which is the remaining ceiling — worth stating rather than implying, since the
+    failure mode is the vacuous pass this whole helper exists to close.
+    """
+    candidates = {
+        node.name: node for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and not any(
+            isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Name)
+            and call.func.id == '_validated_form_id'
+            for call in ast.walk(node)
+        )
+    }
+    helpers: set[str] = set()
+    growing = True
+    while growing:
+        growing = False
+        for name, node in candidates.items():
+            if name not in helpers and _sink_calls(node, frozenset(helpers)):
+                helpers.add(name)
+                growing = True
+    return frozenset(helpers)
+
+
+def _sink_calls(
+    function: ast.FunctionDef, helpers: frozenset[str] = frozenset()
+) -> list[tuple[tuple[int, int], frozenset[str]]]:
+    """Every call in `function` that reaches a form id into a sink.
+
+    `(position, the names mentioned in the call's arguments)` per sink — the names
+    because a position alone answers "was something validated before this read",
+    and the claim is that the id THIS read keys on was. See
+    `_validates_its_form_id`.
+
+    A call counts as a sink three ways, and any one is enough:
 
     - its METHOD is one of `_SINK_OPERATIONS`, whatever handle it arrives through.
       That is the one that is closed over spellings; the constant's comment carries
       the argument and the in-repo lines it is derived from.
     - a sink NAME appears anywhere in the callee chain — including a local alias of
       one — which still catches a call whose method that set does not name.
+    - it calls a module-level function that reaches its own argument into a sink
+      (`_sink_bearing_helpers`), so an indirect write is a write.
 
-    Both exist because an earlier version had only the second, spelled as
+    All three exist because an earlier version had only the second, spelled as
     `<sink>.<method>` on the immediate owner, and every shape it could not see
     reported as bounded while reading before validating. The failure mode is
-    SILENCE rather than a wrong answer: no sink found makes `sink_positions` empty,
-    and `all(...)` over an empty list is vacuously True. Each shape below is a
-    control in `TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes`:
+    SILENCE rather than a wrong answer: a sink missing from this list is one
+    `_validates_its_form_id` asks neither of its questions about, so an empty list
+    passes both vacuously. Each shape below is a control in
+    `TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes`:
 
     - `table = aggregates_table` then `table.get_item(...)` — alias tracking.
     - `dynamodb.Table(AGGREGATES_TABLE).get_item(...)` — the sink name sits deeper
@@ -3592,14 +3648,16 @@ def _sink_call_positions(function: ast.FunctionDef) -> list[tuple[int, int]]:
     - `table = get_aggregates_table()` then `table.get_item(...)`, and
       `get_dynamodb_resource().Table(T).get_item(...)` — no sink name anywhere, so
       only the operation match sees them.
+    - `_anchor_form_brand(form_id, ...)` — no attribute callee at all, so only the
+      helper match sees it.
 
     Aliases are collected in source order and from NESTED bodies as well as the top
     level (`try`, `with`, `if`, `for`), because every table read in this handler
     sits inside a `try:` — so the plausible spelling of an alias is an indented
     one, and three of the twelve in-repo `table = get_aggregates_table()` sites are
     themselves inside one. An untracked alias is a FALSE NEGATIVE, not a cautious
-    false positive: the call drops out of `sink_positions` and the shorter list
-    makes the `all()` MORE likely to pass. That is the same vacuous pass the
+    false positive: the call drops out of this list, so nothing is asked about it
+    and the shorter list is MORE likely to pass. That is the same vacuous pass the
     controls exist to prevent, which is why alias collection is generous while the
     REFUSAL's top-level requirement — a separate axis — stays strict.
 
@@ -3651,12 +3709,34 @@ def _sink_call_positions(function: ast.FunctionDef) -> list[tuple[int, int]]:
 
     _collect_aliases(function.body)
 
+    def _is_sink(call: ast.Call) -> bool:
+        if isinstance(call.func, ast.Attribute):
+            return (
+                call.func.attr in _SINK_OPERATIONS or _mentions_a_sink(call.func)
+            )
+        # A module-level helper that writes what it is handed. See
+        # `_sink_bearing_helpers`.
+        return isinstance(call.func, ast.Name) and call.func.id in helpers
+
+    def _names_in_arguments(call: ast.Call) -> frozenset[str]:
+        """Every identifier the call's arguments mention.
+
+        Includes names inside an f-string, since `f'FORM#{form_id}'` is how every
+        key in this module is built — `ast.walk` reaches into `JoinedStr` for free.
+        The callee is deliberately excluded: `table.get_item(...)`'s receiver is not
+        an id that needed validating.
+        """
+        return frozenset(
+            child.id
+            for argument in [*call.args, *(kw.value for kw in call.keywords)]
+            for child in ast.walk(argument)
+            if isinstance(child, ast.Name)
+        )
+
     return [
-        (call.lineno, call.col_offset)
+        ((call.lineno, call.col_offset), _names_in_arguments(call))
         for call in ast.walk(function)
-        if isinstance(call, ast.Call)
-        and isinstance(call.func, ast.Attribute)
-        and (call.func.attr in _SINK_OPERATIONS or _mentions_a_sink(call.func))
+        if isinstance(call, ast.Call) and _is_sink(call)
     ]
 
 
@@ -3783,6 +3863,32 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     `if False:` is just the extreme of that. If a legitimate spelling ever needs to
     nest (validation inside a `with`, say), widen this deliberately and add the
     control alongside the ones below; do not relax it to get green.
+
+    Two questions are asked of every sink, not one:
+
+    - ORDER: no sink may precede the earliest refusal. That is the cost argument —
+      a read paid for before the check is a read the check existed to avoid — and
+      it holds even for a sink that mentions no id at all.
+    - LINKAGE: the id the sink keys on has to be one that WAS bounded. Position
+      alone answered "was something validated first", and a route that validated a
+      DIFFERENT capture satisfied that while keying on a raw one:
+      `validated = _validated_form_id(submission_id)` refused, then
+      `get_item(Key={'sk': f'FORM#{form_id}'})`. Reported bounded, with `form_id`
+      reaching the key unchecked. Not remote — the route selector is deliberately
+      capture-name-agnostic, so a two-capture route like
+      `/feedback-forms/<form_id>/submissions/<submission_id>` is already in the
+      universe, and it could satisfy the derivation by bounding whichever capture
+      was easier (`test_the_derivation_refuses_validating_the_wrong_capture`).
+
+    Linkage is asked of the PARAMETERS, because they are the untrusted values: a
+    parameter is bounded once it has been handed to `_validated_form_id` (or
+    `_load_form_for_query`) in a statement whose refusal precedes the sink, and so
+    is anything the validator handed back. Every other local is judged by what it
+    was built from, so `key = f'FORM#{form_id}'` before the check is a tainted key
+    rather than an unremarkable string. The ceiling: propagation follows `Assign`
+    and `AnnAssign` only, so an id smuggled through a `for` target or a mutated
+    container is not traced — a deliberate stopping point, since the shapes that
+    exist here build keys and filters by assignment.
     """
     tree = ast.parse(source)
     functions = [
@@ -3801,7 +3907,27 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
     def _named(call: ast.Call, name: str) -> bool:
         return isinstance(call.func, ast.Name) and call.func.id == name
 
-    def _walrus_refusal(statement) -> tuple[int, int] | None:
+    def _mentioned(node: ast.AST) -> set[str]:
+        return {
+            child.id for child in ast.walk(node) if isinstance(child, ast.Name)
+        }
+
+    def _target_names(statement) -> set[str]:
+        targets = (
+            statement.targets if isinstance(statement, ast.Assign)
+            else [statement.target] if isinstance(statement, ast.AnnAssign)
+            else []
+        )
+        # A tuple target too: `validated, form = _load_form_for_query(...)` binds
+        # both, and the validated id is the one the caller keys and filters on.
+        return {
+            name.id
+            for target in targets
+            for name in ast.walk(target)
+            if isinstance(name, ast.Name)
+        }
+
+    def _walrus_refusal(statement) -> tuple[tuple[int, int], ast.Call] | None:
         """`if not (<name> := _validated_form_id(...)):` — bind and refuse in one.
 
         The `if`'s own position, because for this spelling the binding and the
@@ -3825,47 +3951,87 @@ def _validates_its_form_id(source: str, function_name: str) -> bool:
             for child in ast.walk(node)
         ):
             return None
-        return (statement.lineno, statement.col_offset)
+        return (statement.lineno, statement.col_offset), bound.value
 
-    validated_at = None
+    # name -> the earliest position from which it is known to be bounded. Both the
+    # id handed TO the validator and the value handed BACK are bounded from the
+    # refusal, since the refusal is what makes the one a well-formed id and the
+    # other not None.
+    bounded_at: dict[str, tuple[int, int]] = {}
+
+    def _bind(names, position: tuple[int, int]) -> None:
+        for name in names:
+            known = bounded_at.get(name)
+            bounded_at[name] = position if known is None else min(known, position)
+
     for statement in function.body:
         walrus = _walrus_refusal(statement)
         if walrus is not None:
-            validated_at = min(validated_at or walrus, walrus)
+            position, call = walrus
+            _bind(_mentioned(call) | _mentioned(statement.test), position)
         for call in _calls(statement):
             if _named(call, '_load_form_for_query'):
                 # This one raises for itself, so the call is the refusal.
                 position = (statement.lineno, statement.col_offset)
-                validated_at = min(validated_at or position, position)
+                _bind(_mentioned(call) | _target_names(statement), position)
             if not _named(call, '_validated_form_id'):
                 continue
             # The result has to be BOUND and then refused. An `Expr` statement, or
             # an assignment to a name nothing tests, is the shape that has no bound.
-            targets = (
-                statement.targets if isinstance(statement, ast.Assign)
-                else [statement.target] if isinstance(statement, ast.AnnAssign)
-                else []
-            )
+            targets = _target_names(statement)
             # The REFUSAL's position, not the assignment's: binding None is free,
-            # and anything between the two runs with it. Taking the earliest over
-            # the targets keeps `min` below meaningful when a function validates
-            # more than one id.
-            refusals = [
-                refused[target.id] for target in targets
-                if isinstance(target, ast.Name) and target.id in refused
-            ]
+            # and anything between the two runs with it.
+            refusals = [refused[target] for target in targets if target in refused]
             if refusals:
-                position = min(refusals)
-                validated_at = min(validated_at or position, position)
+                _bind(targets | _mentioned(call), min(refusals))
 
-    if validated_at is None:
+    if not bounded_at:
         return False
+    validated_at = min(bounded_at.values())
 
-    sink_positions = _sink_call_positions(function)
+    sinks = _sink_calls(function, _sink_bearing_helpers(tree))
     # No sink is not a pass by default: #379 was a route that touched no AWS
     # service at all and still put the id in its response, so a route that keys on
     # nothing yet takes an id out of the URL still has to establish the bound.
-    return all(validated_at < sink for sink in sink_positions)
+    if any(position <= validated_at for position, _ in sinks):
+        return False
+
+    parameters = {
+        argument.arg for argument in (
+            *function.args.posonlyargs, *function.args.args,
+            *function.args.kwonlyargs,
+        )
+    }
+    assignments = [
+        ((node.lineno, node.col_offset), _target_names(node), _mentioned(node.value))
+        for node in ast.walk(function)
+        if isinstance(node, (ast.Assign, ast.AnnAssign)) and node.value is not None
+    ]
+
+    def _unbounded_at(position: tuple[int, int]) -> set[str]:
+        """Names holding a value no refusal before `position` has vouched for."""
+        tainted = {
+            name for name in parameters
+            if name not in bounded_at or bounded_at[name] >= position
+        }
+        growing = True
+        while growing:
+            growing = False
+            for at, targets, mentioned in assignments:
+                if at >= position or not (mentioned & tainted):
+                    continue
+                spreading = {
+                    target for target in targets - tainted
+                    if bounded_at.get(target, position) >= position
+                }
+                if spreading:
+                    tainted |= spreading
+                    growing = True
+        return tainted
+
+    return not any(
+        mentioned & _unbounded_at(position) for position, mentioned in sinks
+    )
 
 
 class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
@@ -3909,9 +4075,12 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
             'validator call at all; a result that is never refused, or refused by '
             'something that is not a NEGATIVE test of it — a success-path or '
             'cache-hit `return` is not a refusal (see `_refused_names`); a refusal '
-            'that is nested, so it runs on some paths only; or a REFUSAL that comes '
-            'after the table or the queue is touched. Add the check rather than '
-            'narrowing the claim: the value of a universal bound is that a reader '
+            'that is nested, so it runs on some paths only; a REFUSAL that comes '
+            'after the table or the queue is touched; or a bound established on a '
+            'DIFFERENT value than the one the read keys on — validating '
+            '`submission_id` and keying on a raw `form_id` reports here, as does a '
+            'key built from the raw id before the refusal. Add the check rather '
+            'than narrowing the claim: the value of a universal bound is that a reader '
             'does not have to hold the exceptions. And if the route is genuinely '
             'bounded in a spelling this derivation does not know, widen the '
             'derivation and add a control for it — '
@@ -3966,12 +4135,15 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
 
         So the count is pinned per route, against what each one actually does. The
         numbers are small enough to read: one read each, `submit_form_feedback`
-        alone having a read AND the send that makes its cost argument different.
+        alone having a read AND the send that makes its cost argument different —
+        plus the `_anchor_form_brand` call, which is a sink because that helper
+        writes what it is handed (`_sink_bearing_helpers`).
         """
         source = Path(inspect.getsourcefile(feedback_form_handler)).read_text(
             encoding='utf-8'
         )
         tree = ast.parse(source)
+        helpers = _sink_bearing_helpers(tree)
 
         counted = {}
         for route, function_name in _routes_keying_on_a_form_id(source).items():
@@ -3979,15 +4151,18 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
                 node for node in ast.walk(tree)
                 if isinstance(node, ast.FunctionDef) and node.name == function_name
             )
-            counted[route] = len(_sink_call_positions(function))
+            counted[route] = len(_sink_calls(function, helpers))
 
         assert counted == {
             'GET /feedback-forms/<form_id>': 1,
             'PUT /feedback-forms/<form_id>': 1,
             'DELETE /feedback-forms/<form_id>': 1,
             'GET /feedback-forms/<form_id>/config': 1,
-            # The read for the enabled check, and the enqueue.
-            'POST /feedback-forms/<form_id>/submit': 2,
+            # The read for the enabled check, the enqueue, and the
+            # `_anchor_form_brand` call — that helper's own `update_item` writes a
+            # key built from the id it is handed, so the call site is a write
+            # whatever it is spelled like.
+            'POST /feedback-forms/<form_id>/submit': 3,
             # The existence gate is inside `_load_form_for_query`, so this route
             # touches no sink of its own — which is why "no sink" is deliberately
             # not a pass by default in `_validates_its_form_id`.
@@ -3997,9 +4172,13 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
         }, (
             f'{counted} — a route gained or lost a read, or the derivation started '
             'counting something that is not one. If a count went UP without the '
-            'route changing, suspect `aliases`: binding the RESULT of a read makes '
-            'every subsequent `.get(...)` on it look like a sink, and the earliest '
-            'of those decides the verdict.'
+            'route changing, suspect two things: `aliases`, since binding the '
+            'RESULT of a read makes every subsequent `.get(...)` on it look like a '
+            'sink; and `_sink_bearing_helpers`, since a module-level function that '
+            'starts writing makes every call to it a sink. Both are the right '
+            'answer when the call really does reach an id into a table, and both '
+            'are a false positive otherwise — the earliest sink is what decides '
+            'the verdict, so one spurious early entry accuses a correct route.'
         )
 
     def test_the_derivation_can_fail(self):
@@ -4151,8 +4330,8 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
         selector matching only `<sink>.<method>` stops recognising it.
 
         The failure mode is what makes this worth a case rather than a note — it is
-        SILENCE, not a wrong answer. `sink_positions` comes back empty, and
-        `all(validated_at < sink for sink in [])` is vacuously True, so a route
+        SILENCE, not a wrong answer. `_sink_calls` comes back empty, so neither the
+        order question nor the linkage one is asked of anything, and a route
         reading before validating is reported as bounded. A derivation that reports
         "fine" when it understood nothing is worse than no derivation, because the
         docstring above it is then trusted.
@@ -4183,8 +4362,8 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
 
         `dynamodb.Table(AGGREGATES_TABLE).get_item(...)` puts the sink name deeper
         in the callee chain than `call.func.value`, so a selector looking only at
-        the attribute's immediate owner sees no sink and `sink_positions` is empty —
-        vacuously True again.
+        the attribute's immediate owner sees no sink and `_sink_calls` is empty —
+        nothing to ask a question about, vacuously bounded again.
 
         This is the more plausible of the two shapes, and that is the whole argument
         for the case: the module binds its tables exactly this way at module scope,
@@ -4225,8 +4404,8 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
 
         So the single most likely way the NEXT form-id route gets written in this
         repo was the one shape a receiver-name allowlist could not see: no sink name
-        appears anywhere in the callee chain, `sink_positions` comes back empty, and
-        `all(...)` over an empty list is vacuously True. Matching the OPERATION
+        appears anywhere in the callee chain, `_sink_calls` comes back empty, and a
+        read nothing was asked about is a read that passed. Matching the OPERATION
         (`_SINK_OPERATIONS`) rather than the receiver is what closes the class
         instead of one more spelling — the method is what makes a call a read.
         """
@@ -4273,6 +4452,169 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
             'chain is a sink and the verdict came from an EMPTY sink list'
         )
 
+    def test_the_derivation_refuses_a_write_through_an_in_module_helper(self):
+        """The sink-side gap that is not about the RECEIVER but about the call SHAPE.
+
+        Every control above spells the sink as a method on something. This one has
+        no attribute callee at all: `_anchor_form_brand(form_id, ...)` is a plain
+        call, and the `update_item` is inside the helper — on a key built from the
+        id it was handed (`feedback_form_handler.py:269`). So a route can write an
+        unvalidated id to the table with no sink call anywhere in its own body.
+
+        Not a spelling nobody would reach for: `submit_form_feedback` already calls
+        that helper, so it is the in-module example of writing through a function.
+        And it is the same silence as the receiver cases — matching only
+        `ast.Attribute` callees left the list EMPTY, and `all(...)` over an empty
+        list is vacuously True, so the instrument answered "bounded" having seen
+        nothing.
+
+        `_sink_bearing_helpers` derives the set of such helpers from the module
+        rather than naming them, and excludes any that validates for itself — which
+        is what keeps `_load_form_for_query` a refusal rather than an unguarded
+        sink.
+        """
+        source = textwrap.dedent(
+            '''
+            def _anchor_form_brand(form_id, effective_brand):
+                aggregates_table.update_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'},
+                    UpdateExpression='SET brand_name = :brand',
+                )
+
+            @app.post("/feedback-forms/<form_id>/helper-write")
+            def post_helper_write(form_id: str):
+                _anchor_form_brand(form_id, 'Acme')
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'post_helper_write'), (
+            'a write reached through an in-module helper was not recognised as a '
+            'write — the helper call has no attribute callee, so the sink list came '
+            'back EMPTY and the route was reported bounded vacuously'
+        )
+
+        # The accepting side, because a helper call must not become a blanket
+        # accusation: the same helper AFTER the refusal is what `submit_form_feedback`
+        # does, and it has to stay green.
+        after = textwrap.dedent(
+            '''
+            def _anchor_form_brand(form_id, effective_brand):
+                aggregates_table.update_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'},
+                    UpdateExpression='SET brand_name = :brand',
+                )
+
+            @app.post("/feedback-forms/<form_id>/helper-write")
+            def post_helper_write(form_id: str):
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                _anchor_form_brand(validated, 'Acme')
+            '''
+        )
+
+        assert _validates_its_form_id(after, 'post_helper_write'), (
+            'a helper write AFTER the refusal was reported as unbounded — the '
+            'helper match is meant to see an indirect write, not to accuse every '
+            'route that delegates one'
+        )
+
+    def test_the_derivation_refuses_validating_the_wrong_capture(self):
+        """Validating SOMETHING is not validating the id the read keys on.
+
+        The derivation used to compare positions only, which answers "was a refusal
+        reached before the first sink" — not "was the value this sink keys on the
+        one that was refused". So a route could bound one capture and key on
+        another: `_validated_form_id(submission_id)` refused, then
+        `Key={'sk': f'FORM#{form_id}'}` with `form_id` never checked at all.
+
+        This is the residual half of making the route selector capture-name-agnostic
+        rather than a hypothetical: a two-capture route under this prefix is already
+        in the derived universe, and
+        `/feedback-forms/<form_id>/submissions/<submission_id>` is the natural next
+        one for this module. Bounding whichever capture is easier would satisfy the
+        old check while the other one — the one that becomes the key — arrived raw.
+
+        Both directions, because only the pair means anything: validating the KEYED
+        capture passes, validating the other does not. Without the accepting case a
+        derivation that simply rejected every two-capture route would look correct
+        here.
+        """
+        wrong = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/submissions/<submission_id>")
+            def get_one_wrong(form_id: str, submission_id: str):
+                validated = _validated_form_id(submission_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+            '''
+        )
+
+        assert not _validates_its_form_id(wrong, 'get_one_wrong'), (
+            'a route that validated one capture and keyed on another was reported '
+            'as bounded — the position of a refusal says nothing about WHICH value '
+            'it vouched for, and the raw one is what reached the key'
+        )
+
+        right = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/submissions/<submission_id>")
+            def get_one_right(form_id: str, submission_id: str):
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{validated}'}
+                )
+            '''
+        )
+
+        assert _validates_its_form_id(right, 'get_one_right'), (
+            'a two-capture route that validated the id it keys on was reported as '
+            'unbounded — the linkage check must judge WHICH value was bounded, not '
+            'refuse every route with more than one capture'
+        )
+
+    def test_the_derivation_refuses_a_key_built_before_the_check(self):
+        """The linkage check has to follow the value, not just the parameter name.
+
+        A route can put the raw id into a local first and hand THAT to the read:
+        `key = {'sk': f'FORM#{form_id}'}` above the refusal, `get_item(Key=key)`
+        below it. The sink then mentions no parameter at all, so a linkage check
+        that looked only for parameter names in the arguments would see nothing to
+        object to — while the key it reads was built from a value nothing had
+        vouched for at the time.
+
+        Ordering is what makes this the interesting case rather than a duplicate of
+        the read-before-check control: the READ is correctly placed after the
+        refusal. It is the key's CONSTRUCTION that is not, and the string does not
+        become well-formed later because the id it was built from was checked
+        afterwards.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/prebuilt-key")
+            def get_prebuilt_key(form_id: str, raw: str):
+                key = {'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{raw}'}
+                validated = _validated_form_id(form_id)
+                if not validated:
+                    raise NotFoundError('Form not found')
+                return aggregates_table.get_item(Key=key)
+            '''
+        )
+
+        assert not _validates_its_form_id(source, 'get_prebuilt_key'), (
+            'a key built from an unvalidated value before the refusal was reported '
+            'as bounded — the read mentions only the local, so the derivation has '
+            'to follow what that local was built from'
+        )
+
     def test_the_derivation_refuses_a_read_through_an_alias_bound_in_a_try(self):
         """The alias one indentation level in, which is where the real ones are.
 
@@ -4285,9 +4627,9 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
 
         Worth being precise about the direction, because the helper's own docstring
         used to have it backwards: an untracked alias is a FALSE NEGATIVE. The call
-        drops out of `sink_positions`, and `all(...)` over the shorter list is MORE
-        likely to pass — so the read is not reported at all. That is the vacuous
-        pass these controls exist for, not a cautious over-report.
+        drops out of `_sink_calls`, so neither question is asked of it and the
+        shorter list is MORE likely to pass — the read is not reported at all. That
+        is the vacuous pass these controls exist for, not a cautious over-report.
         """
         source = textwrap.dedent(
             '''

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -5677,18 +5677,26 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         an operator to rename a row that was never served.
 
         The `\\w` boundary is sampled across CATEGORIES rather than at the ASCII
-        line, and that is the point of `'hawaiʼi-form'` and `'surface-m²'` being in
-        the reachable loop next to `'café'`. `\\w` spans every `L*` and `N*`
-        category — `Ll`, `Lm`, `Lo`, `Lt`, `Lu`, `Nd`, `Nl`, `No` — so a modifier
-        letter (U+02BC, the correct ʻokina, which looks like an apostrophe) and a
-        superscript or fraction are routable while reading to a human as
-        punctuation. A note glossing `\\w` as "a letter or a digit" puts those in the
-        SAME sentence as `€` and `—`, and that error runs in the expensive
-        direction: an operator sees `hawaiʼi-form` printed by the scan, classifies
-        it out of scope, skips the rename, and the row 404s in production. Every
-        other imprecision in this note over-reports; this one loses a reachable row,
-        which is why the loop samples `Lm` and `No` rather than trusting `Ll` and
-        `Lo` to stand for all eight.
+        line, and EVERY category is sampled on both sides rather than a
+        representative few. `\\w` is exactly `L* | N* | {'_'}` — verified by
+        enumerating all 0x110000 codepoints — so the reachable loop carries one id
+        per `\\w` category (`Ll` `'café'`, `Lm` `'hawaiʼi-form'`, `Lo` `'表単'`,
+        `Lt` `'ǅigit'`, `Lu` `'ÉCOLE'`, `Nd` `'form٠a'`, `Nl` `'section-Ⅷ'`, `No`
+        `'surface-m²'`) and the unreachable loop one per class `\\w` excludes
+        (`Mn`, `Mc`, `Me`, `Sc`, `Zs`, `Cf`, `Pc`).
+
+        Exhaustively rather than representatively, because a partial sample is what
+        let the prose go wrong twice. `Lm` and `No` read to a human as punctuation,
+        so a note glossing `\\w` as "a letter or a digit" put them in the SAME
+        sentence as `€` and `—` — and that error runs in the expensive direction:
+        an operator sees `hawaiʼi-form` printed by the scan, classifies it out of
+        scope, skips the rename, and the row 404s in production. Every other
+        imprecision in this note over-reports; that one loses a reachable row. The
+        converse is cheaper but also live: `Mc`/`Mn` read as LETTERS, so a
+        Devanagari or Thai id looks in scope while never having matched a route.
+        Both documents cite this test as asserting "the whole split", so a category
+        named in either of them and absent here would make that citation false —
+        which is the state a four-of-eight sample was in.
 
         That is the SAME distinction the whole upgrade note turns on, applied one
         level down: ` abc123` is exempt because it never resolved, and `abc<TAB>def`
@@ -5709,8 +5717,13 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         path that matches NOTHING — which would report every character as excluded
         and pass an assertion set made only of exclusions.
         """
-        for reachable in ('my form', '   ', 'a:b', 'café', '表単',
-                          'hawaiʼi-form', 'surface-m²'):
+        # After the three ASCII cases, one id per `\w` category, so no category
+        # stands in for another: `Ll` `café`, `Lm` `hawaiʼi-form` (U+02BC, an
+        # apostrophe to the eye), `Lo` `表単`, `Lt` `ǅigit`, `Lu` `ÉCOLE`, `Nd`
+        # `form٠a` (ARABIC-INDIC DIGIT ZERO), `Nl` `section-Ⅷ`, `No` `surface-m²`.
+        for reachable in ('my form', '   ', 'a:b', 'café', 'hawaiʼi-form', '表単',
+                          'ǅigit', 'ÉCOLE', 'form٠a', 'section-Ⅷ',
+                          'surface-m²'):
             admitting = [
                 f'{method} {path}'
                 for method, path, rule in _form_id_route_paths(
@@ -5730,15 +5743,36 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
                 'not belong in the scan at all'
             )
 
-        # The last entry is the DECOMPOSED spelling of `caf\u00e9`, written with an
-        # escape because it is visually identical to the composed `caf\u00e9` in
-        # the loop above, and the whole point is that the two are different strings
-        # with different verdicts: a combining accent is a MARK, which `\w` does
-        # not match, so the decomposed form never reached a route while the composed
-        # one did. Both documents name `caf\u00e9` in scope without saying which of
-        # the two spellings they mean.
+        # One id per class `\w` EXCLUDES, mirroring the per-category loop above so
+        # that neither side of the boundary rests on a representative sample:
+        # `form€a` is `Sc`, `form\xa0a` is `Zs`, `cafe\u0301` is `Mn`, the Devanagari
+        # id is `Mc`, `form\u0488a` is `Me`, `form\u200da` is `Cf` (a zero-width
+        # joiner) and `form\uff3fa` is `Pc`.
+        #
+        # `Pc` earns its line because it is the NEAR MISS: `_` is the one `\w`
+        # member outside `L*`/`N*`, and `_` is `Pc` — but the REST of `Pc` (U+FF3F
+        # here, also U+2040 and U+203F) is excluded like any other punctuation. So
+        # "connector punctuation" is not a shorthand for the exception; `_` alone is,
+        # and `_` is inside the validator's OWN class, so an id holding one is
+        # accepted rather than refused and belongs to neither of the scan's lists.
+        #
+        # The Devanagari id is Hindi for "form": `Lo` base letters carrying a matra,
+        # which is `Mc`. It is here as the OPPOSITE misfiling to `hawai\u02bci-form`
+        # in the loop above — this one reads as letters and never reached a route,
+        # that one reads as punctuation and resolved. Getting them from one fact
+        # (`\w` is `L*`/`N*`) is why both documents state the categories now.
+        #
+        # The confusable and invisible entries are spelled as escapes on purpose.
+        # `cafe\u0301` is the DECOMPOSED spelling of `caf\u00e9`, visually identical to
+        # the composed `caf\u00e9` in the loop above, and the whole point is that the
+        # two are different strings with OPPOSITE verdicts: a combining accent is a
+        # MARK, so the decomposed form never reached a route while the composed one
+        # did. Both documents name `caf\u00e9` in scope without saying which of the
+        # two spellings they mean. `\u200d` and `\u0488` would be invisible, or would
+        # stack onto the preceding character, in an editor.
         for unreachable in ('abc\tdef', 'abc\ndef', 'form€a', 'form\xa0a',
-                            'cafe\u0301'):
+                            'cafe\u0301', 'फॉर्म', 'form\u0488a',
+                            'form\u200da', 'form\uff3fa'):
             admitting = [
                 f'{method} {path}'
                 for method, path, rule in _form_id_route_paths(

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -5661,12 +5661,20 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         """The scan's REACH, which is a different claim from its accuracy.
 
         `CHANGELOG.md` tells an operator that the ids it names went from resolving
-        to answering 404, and that a literal tab or newline is NOT something the
-        scan has to find. Both halves rest on one fact about a file this one does
-        not own: powertools' capture group admits a space but excludes a tab and a
-        newline, so an id containing either never matched a route and answered 404
-        before this change as well as after — unreachable rather than
+        to answering 404, and that a literal tab or newline — and a non-ASCII symbol
+        or space — is NOT something the scan has to find. Both halves rest on one
+        fact about a file this one does not own: powertools' capture group lists a
+        literal space but no other whitespace, and reaches past ASCII only through
+        `\\w`, which is Unicode-aware for LETTERS AND DIGITS alone. So an id holding
+        a tab, a newline, or a non-ASCII symbol never matched a route and answered
+        404 before this change as well as after — unreachable rather than
         reachable-then-orphaned.
+
+        The `\\w` half is asserted rather than the ASCII boundary, because that is
+        where the line actually falls and the two are easy to conflate: `'café'` and
+        `'表単'` are both non-ASCII and both resolved, while `'form€a'` is non-ASCII
+        and never did. An upgrade note that said "any non-ASCII character" would send
+        an operator to rename a row that was never served.
 
         That is the SAME distinction the whole upgrade note turns on, applied one
         level down: ` abc123` is exempt because it never resolved, and `abc<TAB>def`
@@ -5687,7 +5695,7 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         path that matches NOTHING — which would report every character as excluded
         and pass an assertion set made only of exclusions.
         """
-        for reachable in ('my form', '   ', 'a:b', 'café'):
+        for reachable in ('my form', '   ', 'a:b', 'café', '表単'):
             admitting = [
                 f'{method} {path}'
                 for method, path, rule in _form_id_route_paths(
@@ -5707,7 +5715,7 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
                 'not belong in the scan at all'
             )
 
-        for unreachable in ('abc\tdef', 'abc\ndef'):
+        for unreachable in ('abc\tdef', 'abc\ndef', 'form€a', 'form\xa0a'):
             admitting = [
                 f'{method} {path}'
                 for method, path, rule in _form_id_route_paths(
@@ -5717,11 +5725,12 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
             ]
             assert not admitting, (
                 f'{unreachable!r} is now admitted by {admitting} — powertools has '
-                'widened its capture group, so an id containing a tab or a newline '
-                'CAN reach a handler and is reachable-then-orphaned after all. '
-                "CHANGELOG.md's paragraph saying the scan need not find one is now "
-                'wrong, and the scan itself cannot find one through a line-oriented '
-                'pipeline'
+                'widened its capture group, so this id CAN reach a handler and is '
+                'reachable-then-orphaned after all. '
+                "CHANGELOG.md's paragraph saying the scan need not find it is now "
+                'wrong, in the under-reporting direction: an operator is told the '
+                'row was never served when it was. (For a tab or a newline the '
+                'scan could not find one anyway, through a line-oriented pipeline.)'
             )
 
     def test_a_trailing_newline_is_not_a_valid_form_id(

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -2163,11 +2163,16 @@ class TestTheAnchorCanOnlyEverUpdateAFormThatExists:
 # interpolated the caller-supplied path segment straight into a `<script>` block
 # inside handwritten quotes, and returned 200 without reading the table at all — so
 # an id the route's own pattern accepts could close those quotes and be executed as
-# script. `a',x:alert(1),y:'` is the shortest one that does through this exact
-# template (verified by rendering the merge-base f-string and running it); the
-# issue's own `a');alert(document.domain);x=('` was written for a bare-argument call
-# and leaves the object literal unparseable, which is why the constant below carries
-# that distinction rather than the tests resting on the sample's remainder.
+# script. `a',x:alert(1),y:'` is one that does through this exact template
+# (verified by rendering the merge-base f-string and running it), and it is not the
+# only shape or the shortest: `'+alert()+'` closes the same quote and concatenates
+# instead of supplying further keys, needing 11 characters to its 17, and all eight
+# routes admit it too. That the position was reachable by more than one shape is
+# why the fix is a serializer rather than a blocklist, so no length or spelling
+# here is load-bearing. The issue's own `a');alert(document.domain);x=('` was
+# written for a bare-argument call and leaves the object literal unparseable, which
+# is why the constant below carries that distinction rather than the tests resting
+# on the sample's remainder.
 
 # The payload from the issue, kept as one constant because three separate tests
 # assert three different things about the same string: that the ROUTE admits it,
@@ -5947,12 +5952,18 @@ class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
         # character would pin the note's list rather than the class the classifier
         # actually tests.
         #
+        # `'+alert()+'` is here for the claim the header comment makes about it: the
+        # position was reachable by more than one payload shape, so the concatenation
+        # spelling is route-admitted exactly as `_EXECUTING_PAYLOAD`'s object-key
+        # spelling is. Asserted rather than stated, because a header comment naming a
+        # second shape is worth nothing if the routes stopped admitting it.
+        #
         # Then one id per `\w` category, so no category stands in for another: `Ll`
         # `café`, `Lm` `hawaiʼi-form` (U+02BC, an apostrophe to the eye), `Lo`
         # `表単`, `Lt` `ǅigit`, `Lu` `ÉCOLE`, `Nd` `form٠a` (ARABIC-INDIC DIGIT
         # ZERO), `Nl` `section-Ⅷ`, `No` `surface-m²`.
-        for reachable in ('my form', '   ', 'a:b', 'form(1)', 'a;b', 'café',
-                          'hawaiʼi-form', '表単', 'ǅigit', 'ÉCOLE',
+        for reachable in ('my form', '   ', 'a:b', 'form(1)', 'a;b', "'+alert()+'",
+                          'café', 'hawaiʼi-form', '表単', 'ǅigit', 'ÉCOLE',
                           'form٠a', 'section-Ⅷ', 'surface-m²'):
             admitting = [
                 f'{method} {path}'

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import boto3
 import pytest
+from botocore.exceptions import ClientError
 from moto import mock_aws
 
 WIDGET_SOURCE = Path(__file__).resolve().parents[1] / 'static' / 'feedback-widget.js'
@@ -2916,6 +2917,14 @@ class TestEveryRouteThatKeysOnAFormIdChecksItsFormatFirst:
     `ballots_handler` applies its equivalent at all five of its routes; this
     mirrors that.
 
+    These four are the routes an UNAUTHENTICATED caller can reach plus the two
+    authenticated reads. The authenticated CRUD trio is covered separately, by
+    `TestTheAuthenticatedCrudRoutesAreBoundedToo`, because what is at stake there
+    is a write rather than a read cost — and the whole set is derived from the
+    module's routing table by
+    `test_no_route_keys_on_a_form_id_without_validating_it_first`, so neither class
+    is the list of record.
+
     Asserted as "no read happened", route by route, because that is the property
     the comment claims and the only one a 404 alone would not distinguish from a
     lookup that merely found nothing.
@@ -3043,5 +3052,540 @@ class TestEveryRouteThatKeysOnAFormIdChecksItsFormatFirst:
         response = feedback_form_handler.lambda_handler(event, lambda_context)
 
         assert response['statusCode'] == 404
+        mock_table.get_item.assert_not_called()
+        mock_sqs.send_message.assert_not_called()
+
+
+class TestTheAuthenticatedCrudRoutesAreBoundedToo:
+    """`GET`/`PUT`/`DELETE /feedback-forms/<form_id>`, and the write PUT used to do.
+
+    These three are behind Cognito (`authMethodOptions` in
+    `lib/stacks/api-stack.ts`), so none of this is the #379 vulnerability and the
+    cost argument for a public probe does not apply. Two other things do:
+
+    - `_validated_form_id`'s docstring claims the check is at EVERY route that
+      turns a URL segment into a key. These were the three that disproved it.
+    - `update_form` called `update_item` with no condition, and UpdateItem is an
+      UPSERT. A `PUT` to an id the table did not hold therefore CREATED a row,
+      keyed on whatever the caller put in the path.
+    """
+
+    # The three shapes, and what each must not do. Kept as data so a route added
+    # to the trio is a one-line addition rather than a fourth near-copy.
+    MALFORMED_BODY = {'name': 'pwn'}
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_no_crud_route_turns_a_malformed_id_into_a_key(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The claim, checked at the three routes that used to break it.
+
+        `get_item`, `update_item` and `delete_item` alike: a segment the pattern
+        refuses must not reach the table at all, so the refusal cannot be confused
+        with a lookup that found nothing (`GET`) or a write that happened to be
+        harmless (`DELETE`).
+        """
+        for method, body in (
+            ('GET', None),
+            ('PUT', self.MALFORMED_BODY),
+            ('DELETE', None),
+        ):
+            for malformed in (
+                _INJECTION_PAYLOAD,
+                'a' * (feedback_form_handler.FORM_ID_MAX_LENGTH + 1),
+            ):
+                mock_table.reset_mock()
+                event = api_gateway_event(
+                    method=method,
+                    path=f'/feedback-forms/{malformed}',
+                    path_params={'form_id': malformed},
+                    body=body,
+                    resource='/feedback-forms/{form_id}',
+                )
+
+                response = feedback_form_handler.lambda_handler(
+                    event, lambda_context
+                )
+
+                assert response['statusCode'] == 404, (
+                    f'{method} /feedback-forms/<malformed> answered '
+                    f'{response["statusCode"]}, not the 404 every other route '
+                    'gives for an id that cannot be one of ours'
+                )
+                mock_table.get_item.assert_not_called()
+                mock_table.update_item.assert_not_called()
+                mock_table.delete_item.assert_not_called()
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_put_to_a_malformed_id_does_not_mint_a_phantom_form(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The write, which is what made this more than a docstring problem.
+
+        Before the fix this answered **200** and called `update_item` with
+        `sk='FORM#a\\');alert(document.domain);x=(\\''`. UpdateItem being an upsert,
+        that CREATED the row — and since UPDATABLE_FIELDS does not include
+        `form_id`, the row it created had none, so `item_to_form` read it back as
+        `form_id: ''`: a nameless entry in `list_forms` that no route could then
+        address or delete by id.
+
+        The response body is asserted as well as the call, because the empty
+        `form_id` coming back to the caller is the visible half of the same defect.
+        """
+        event = api_gateway_event(
+            method='PUT',
+            path=f'/feedback-forms/{_INJECTION_PAYLOAD}',
+            path_params={'form_id': _INJECTION_PAYLOAD},
+            body=self.MALFORMED_BODY,
+            resource='/feedback-forms/{form_id}',
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 404
+        mock_table.update_item.assert_not_called()
+        assert '"form_id":""' not in response['body'].replace(' ', '')
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_put_to_a_well_formed_absent_id_is_refused_by_the_table(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The other half, and the reason a format check alone was not the fix.
+
+        `deadbeef` is a perfectly well-formed id, so the validator passes it and
+        the upsert would still have created a row for a form that does not exist.
+        `attribute_exists(sk)` is what refuses it, and the route must report that
+        as the same 404 `GET` gives rather than as a 500 — a condition failing is
+        the table answering the question, not an error.
+        """
+        mock_table.update_item.side_effect = ClientError(
+            {'Error': {'Code': 'ConditionalCheckFailedException',
+                       'Message': 'The conditional request failed'}},
+            'UpdateItem',
+        )
+
+        event = api_gateway_event(
+            method='PUT',
+            path='/feedback-forms/deadbeef',
+            path_params={'form_id': 'deadbeef'},
+            body={'name': 'a rename of a form that is not there'},
+            resource='/feedback-forms/{form_id}',
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 404
+        assert 'Form not found' in response['body']
+        # The condition is on the request, not just in the docstring: without it
+        # the write above would have succeeded and this test would need the mock
+        # to fail for a different reason.
+        assert (
+            mock_table.update_item.call_args.kwargs['ConditionExpression']
+            == 'attribute_exists(sk)'
+        )
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_put_to_a_form_that_exists_still_updates_it(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """The contract the two guards must not have broken.
+
+        A real form still updates and still answers with the new record — so the
+        404s above are the id or the condition refusing, not the route having
+        stopped working.
+        """
+        mock_table.update_item.return_value = {
+            'Attributes': {'form_id': 'deadbeef', 'name': 'Updated', 'enabled': True}
+        }
+
+        event = api_gateway_event(
+            method='PUT',
+            path='/feedback-forms/deadbeef',
+            path_params={'form_id': 'deadbeef'},
+            body={'name': 'Updated'},
+            resource='/feedback-forms/{form_id}',
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        assert json.loads(response['body'])['form']['name'] == 'Updated'
+        assert (
+            mock_table.update_item.call_args.kwargs['Key']['sk'] == 'FORM#deadbeef'
+        )
+
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_delete_of_an_absent_form_stays_idempotent(
+        self, mock_table, api_gateway_event, lambda_context, feedback_form_handler
+    ):
+        """`delete_form` deliberately gets NO existence condition, unlike `PUT`.
+
+        DeleteItem on a missing key writes nothing, so there is no phantom row to
+        prevent and the idempotent 200 is the honest answer — a caller retrying a
+        delete should not get a 404 for having succeeded the first time. Pinned so
+        the asymmetry with `update_form` reads as a decision rather than as the
+        condition having been forgotten on one of the two writes.
+        """
+        event = api_gateway_event(
+            method='DELETE',
+            path='/feedback-forms/deadbeef',
+            path_params={'form_id': 'deadbeef'},
+            resource='/feedback-forms/{form_id}',
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        assert mock_table.delete_item.call_args.kwargs['Key']['sk'] == (
+            'FORM#deadbeef'
+        )
+        assert 'ConditionExpression' not in mock_table.delete_item.call_args.kwargs
+
+
+def _routes_keying_on_a_form_id(source: str) -> dict[str, str]:
+    """Every `@app.<method>` route whose path captures `<form_id>`, from source.
+
+    Returns route path -> handler function name, read off the module with `ast`
+    rather than listed here. The two classes above name their routes explicitly,
+    which is what makes their failures legible; this exists so neither of those
+    lists is what the module is measured against. A route added later appears here
+    for free, and if it does not validate its id the test below fails naming it.
+
+    Only `<form_id>` counts: `/feedback-forms` and `POST /feedback-forms` take no
+    id out of the URL and have nothing to check.
+    """
+    tree = ast.parse(source)
+    routes = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        for decorator in node.decorator_list:
+            if not isinstance(decorator, ast.Call):
+                continue
+            target = decorator.func
+            # `@app.get(...)`, `@app.put(...)` and so on — the attribute is the
+            # HTTP method and the object has to be `app`, so `@tracer.capture_method`
+            # (not a Call with a string argument) and any other decorator are out.
+            if not isinstance(target, ast.Attribute):
+                continue
+            if not (isinstance(target.value, ast.Name) and target.value.id == 'app'):
+                continue
+            if not decorator.args:
+                continue
+            path = decorator.args[0]
+            if not (isinstance(path, ast.Constant) and isinstance(path.value, str)):
+                continue
+            if '<form_id>' in path.value:
+                routes[f'{target.attr.upper()} {path.value}'] = node.name
+    assert routes, (
+        'no @app route capturing <form_id> was found in the handler source — the '
+        'derivation found nothing to judge, so a green result below would be '
+        'meaningless. If the routes moved or the decorator spelling changed, fix '
+        'this helper; do not delete the assertion.'
+    )
+    return routes
+
+
+def _validates_its_form_id(source: str, function_name: str) -> bool:
+    """Does `function_name` reach `_validated_form_id` before it keys on anything?
+
+    True if the function calls it directly, or calls `_load_form_for_query` — the
+    one read `/stats` and `/submissions` make, which validates on their behalf.
+    Following the delegation rather than requiring the direct call is the point:
+    the alternative is a test that demands a particular spelling and fails on a
+    legitimate refactor.
+    """
+    tree = ast.parse(source)
+    functions = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == function_name
+    ]
+    assert len(functions) == 1, (
+        f'expected exactly one def {function_name}, found {len(functions)}'
+    )
+    called = {
+        node.func.id
+        for node in ast.walk(functions[0])
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    return bool(called & {'_validated_form_id', '_load_form_for_query'})
+
+
+class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
+    """`_validated_form_id`'s docstring says EVERY route; this is what checks it.
+
+    That claim was false when it was written — `/config`, `/submit`, `/iframe`,
+    `/stats` and `/submissions` were covered and the authenticated CRUD trio was
+    not, while the docstring enumerated five routes as if they were all of them.
+    A prose list is the wrong instrument for a universal claim: it goes stale
+    silently, and the reader who trusts it assumes a protection that is not there.
+
+    So the universe is derived from the module's own routing table instead.
+    """
+
+    def test_no_route_keys_on_a_form_id_without_validating_it_first(
+        self, feedback_form_handler
+    ):
+        """Every `<form_id>` route validates, or the failure names the ones that do
+        not.
+
+        This is the test that makes the docstring's "EVERY" audit itself. A route
+        added later is included automatically, so the next person to write
+        `@app.get("/feedback-forms/<form_id>/something")` finds out here rather
+        than in a review.
+        """
+        source = Path(inspect.getsourcefile(feedback_form_handler)).read_text(
+            encoding='utf-8'
+        )
+        routes = _routes_keying_on_a_form_id(source)
+
+        unbounded = sorted(
+            f'{route} ({function})'
+            for route, function in routes.items()
+            if not _validates_its_form_id(source, function)
+        )
+
+        assert unbounded == [], (
+            f'{unbounded} take a form id out of the URL without reaching '
+            '_validated_form_id (directly or through _load_form_for_query), so '
+            "that function's docstring no longer describes the module. Add the "
+            'check rather than narrowing the claim: the value of a universal '
+            'bound is that a reader does not have to hold the exceptions.'
+        )
+
+    def test_the_derivation_sees_the_routes_this_module_actually_has(
+        self, feedback_form_handler
+    ):
+        """The positive control: the walk finds the whole surface, not a subset.
+
+        Without this, `_routes_keying_on_a_form_id` returning only the routes that
+        happen to pass would make the test above vacuous in the most convincing
+        way possible — a green run over an empty-ish universe. The eight are named
+        here because THIS is the assertion that is supposed to fail when the
+        surface changes, prompting a decision about the new route.
+        """
+        source = Path(inspect.getsourcefile(feedback_form_handler)).read_text(
+            encoding='utf-8'
+        )
+
+        assert set(_routes_keying_on_a_form_id(source)) == {
+            'GET /feedback-forms/<form_id>',
+            'PUT /feedback-forms/<form_id>',
+            'DELETE /feedback-forms/<form_id>',
+            'GET /feedback-forms/<form_id>/config',
+            'POST /feedback-forms/<form_id>/submit',
+            'GET /feedback-forms/<form_id>/iframe',
+            'GET /feedback-forms/<form_id>/submissions',
+            'GET /feedback-forms/<form_id>/stats',
+        }
+
+    def test_the_derivation_can_fail(self):
+        """A route that keys on an id and does not check it must be REPORTED.
+
+        The control for the check itself: fed a module with one unvalidated route,
+        `_validates_its_form_id` has to say so. Otherwise the test above passes
+        because the derivation always returns True, which is indistinguishable
+        from a module that is correct.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/new-thing")
+            def get_new_thing(form_id: str):
+                return aggregates_table.get_item(
+                    Key={'pk': 'FEEDBACK_FORM', 'sk': f'FORM#{form_id}'}
+                )
+
+            @app.get("/feedback-forms/<form_id>/checked")
+            def get_checked(form_id: str):
+                validated = _validated_form_id(form_id)
+                return validated
+            '''
+        )
+
+        routes = _routes_keying_on_a_form_id(source)
+        assert routes == {
+            'GET /feedback-forms/<form_id>/new-thing': 'get_new_thing',
+            'GET /feedback-forms/<form_id>/checked': 'get_checked',
+        }
+        assert not _validates_its_form_id(source, 'get_new_thing')
+        # And the delegating spelling is accepted, so the check is about reaching
+        # the validator rather than about naming it.
+        assert _validates_its_form_id(source, 'get_checked')
+
+    def test_the_derivation_accepts_the_delegating_spelling(self):
+        """`/stats` and `/submissions` validate through `_load_form_for_query`.
+
+        Pinned separately from the direct call because it is the one that would be
+        lost first: a stricter derivation that demanded `_validated_form_id` by
+        name would report those two as unbounded, and the tempting fix would be to
+        add a redundant second call to each rather than to fix the test.
+        """
+        source = textwrap.dedent(
+            '''
+            @app.get("/feedback-forms/<form_id>/stats")
+            def get_form_stats(form_id: str):
+                form = _load_form_for_query(form_id, 'Failed')
+                return form
+            '''
+        )
+
+        assert _validates_its_form_id(source, 'get_form_stats')
+
+
+class TestTheValidatorIsExactSoNoRouteCanDisagreeWithAnother:
+    """`_validated_form_id` returns what it was given, and that is load-bearing.
+
+    Callers use their own `form_id` for things that are not the key —
+    `source_channel` in `/submissions`, the id echoed in a response — so the
+    validated value and the parameter have to be the same string. `.strip()` was
+    removed for a related reason, but exactness is the broader property and it was
+    carried entirely by a sentence in a docstring.
+    """
+
+    def test_the_validator_returns_its_input_unchanged(self, feedback_form_handler):
+        """Identity, not merely truthiness.
+
+        A normalizing validator — lower-casing, say, for a plausible "form ids are
+        case-insensitive" change — would pass every existing test while splitting
+        the module: `/stats` would read the record its key names and then filter
+        submissions on a `source_channel` its CALLER built from the raw id, which
+        no write ever used. Zero submissions for a form that has them, which is
+        the false zero `_load_form_for_query` exists to prevent (#312).
+
+        So the invariant gets a test instead of a sentence. If ids ever should be
+        case-insensitive, the normalization belongs at the mint and at every read
+        alike, and this test is the place to come and argue with.
+        """
+        for valid in (
+            'deadbeef',
+            'DEADBEEF',
+            'website-form_2',
+            'a',
+            'a' * feedback_form_handler.FORM_ID_MAX_LENGTH,
+            feedback_form_handler._minted_form_id(),
+        ):
+            assert feedback_form_handler._validated_form_id(valid) == valid, (
+                f'{valid!r} came back as '
+                f'{feedback_form_handler._validated_form_id(valid)!r} — a '
+                'normalized return splits the key a route reads from the '
+                'source_channel it filters on'
+            )
+
+    @patch('feedback_form_handler.feedback_table')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_the_key_a_query_route_reads_is_the_id_in_its_url(
+        self,
+        mock_table,
+        mock_feedback_table,
+        api_gateway_event,
+        lambda_context,
+        feedback_form_handler,
+    ):
+        """The consequence, end to end on the route where it would surface.
+
+        `_load_form_for_query` keys on the VALIDATED value while its callers build
+        `source_channel` from the parameter. Both are asserted here against the id
+        in the URL, so the two halves cannot drift apart without a failure — which
+        is the only way this defect would ever have been noticed, since it produces
+        a plausible-looking zero rather than an error.
+        """
+        mock_table.get_item.return_value = {
+            'Item': {'form_id': 'DeadBeef', 'brand_name': 'acme'}
+        }
+        mock_feedback_table.query.return_value = {'Items': []}
+
+        event = api_gateway_event(
+            method='GET',
+            path='/feedback-forms/DeadBeef/submissions',
+            path_params={'form_id': 'DeadBeef'},
+            resource='/feedback-forms/{form_id}/submissions',
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 200
+        assert mock_table.get_item.call_args.kwargs['Key']['sk'] == 'FORM#DeadBeef'
+        assert (
+            mock_feedback_table.query.call_args.kwargs[
+                'ExpressionAttributeValues'
+            ][':sc']
+            == 'form_DeadBeef'
+        )
+
+
+class TestTheSubmitRouteChecksTheIdBeforeTheBody:
+    """The one input shape whose ERROR CLASS changed, pinned as a decision.
+
+    Putting the format check above `app.current_event.json_body` is deliberate —
+    `/submit` is the only public route that enqueues, so an id that cannot be one
+    of ours must reach neither the table nor the queue, whatever the body says.
+
+    The side effect is a contract change: a request carrying BOTH a malformed id
+    and an invalid body used to be told about the body (400) and is now told about
+    the id (404). That is the better answer — the id is wrong regardless of what
+    the body contains — but it is observable to an integrator whose client
+    distinguishes "fix your input" from "this form is gone", so it is recorded in
+    `docs/feedback-forms.md` as well as here, and pinned so the ordering is a
+    decision rather than an artefact of statement order.
+    """
+
+    @patch('feedback_form_handler.sqs')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_malformed_id_with_an_invalid_body_reports_the_id(
+        self,
+        mock_table,
+        mock_sqs,
+        api_gateway_event,
+        lambda_context,
+        feedback_form_handler,
+    ):
+        """404 for the id, not 400 for the empty text — and no read, no send."""
+        event = api_gateway_event(
+            method='POST',
+            path=f'/feedback-forms/{_INJECTION_PAYLOAD}/submit',
+            path_params={'form_id': _INJECTION_PAYLOAD},
+            body={'text': ''},
+            resource='/feedback-forms/{form_id}/submit',
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 404
+        assert 'Form not found' in response['body']
+        assert 'Feedback text is required' not in response['body']
+        mock_table.get_item.assert_not_called()
+        mock_sqs.send_message.assert_not_called()
+
+    @patch('feedback_form_handler.sqs')
+    @patch('feedback_form_handler.aggregates_table')
+    def test_a_well_formed_id_with_an_invalid_body_still_reports_the_body(
+        self,
+        mock_table,
+        mock_sqs,
+        api_gateway_event,
+        lambda_context,
+        feedback_form_handler,
+    ):
+        """The other side of the precedence, which is what makes it a precedence.
+
+        With an id that could be ours, the empty `text` is still a 400 — so the
+        404 above is the id being refused first, not the route having lost its body
+        validation. Without this case, deleting the text check would leave the case
+        above green.
+        """
+        event = api_gateway_event(
+            method='POST',
+            path='/feedback-forms/deadbeef/submit',
+            path_params={'form_id': 'deadbeef'},
+            body={'text': ''},
+            resource='/feedback-forms/{form_id}/submit',
+        )
+
+        response = feedback_form_handler.lambda_handler(event, lambda_context)
+
+        assert response['statusCode'] == 400
+        assert 'Feedback text is required' in response['body']
+        # Still before any read: the body is refused on its own terms, and the
+        # form's existence was never the question.
         mock_table.get_item.assert_not_called()
         mock_sqs.send_message.assert_not_called()

--- a/voc-datalake/lambda/api/test/test_feedback_form_handler.py
+++ b/voc-datalake/lambda/api/test/test_feedback_form_handler.py
@@ -3602,6 +3602,16 @@ def _sink_call_positions(function: ast.FunctionDef) -> list[tuple[int, int]]:
     makes the `all()` MORE likely to pass. That is the same vacuous pass the
     controls exist to prevent, which is why alias collection is generous while the
     REFUSAL's top-level requirement — a separate axis — stays strict.
+
+    An alias is a HANDLE, though, not a RESULT: `response = aggregates_table.
+    get_item(...)` mentions a sink and binds a dict, so counting it would make
+    every subsequent `response.get(...)` and `form.get(...)` a sink. That is not
+    merely noise — the whole point of the position comparison is which call comes
+    FIRST, so a spurious early "sink" on a line above the refusal would report a
+    correctly guarded route as unbounded. Hence an assignment whose value is itself
+    a call to a sink OPERATION binds nothing:
+    `test_the_derivation_names_only_the_real_sinks_in_the_module` pins the count on
+    the live routes, so this stays honest in both directions.
     """
     aliases: set[str] = set()
 
@@ -3612,10 +3622,20 @@ def _sink_call_positions(function: ast.FunctionDef) -> list[tuple[int, int]]:
             for child in ast.walk(node)
         )
 
+    def _is_operation_result(value: ast.expr) -> bool:
+        return (
+            isinstance(value, ast.Call)
+            and isinstance(value.func, ast.Attribute)
+            and value.func.attr in _SINK_OPERATIONS
+        )
+
     def _collect_aliases(body: list[ast.stmt]) -> None:
         for statement in body:
-            if isinstance(statement, ast.Assign) and _mentions_a_sink(
-                statement.value
+            if (
+                isinstance(statement, ast.Assign)
+                and _mentions_a_sink(statement.value)
+                # A handle, not what a read returned. See the docstring.
+                and not _is_operation_result(statement.value)
             ):
                 aliases.update(
                     target.id for target in statement.targets
@@ -3923,6 +3943,64 @@ class TestTheFormIdBoundIsUniversalRatherThanAListOfRoutes:
             'GET /feedback-forms/<form_id>/submissions',
             'GET /feedback-forms/<form_id>/stats',
         }
+
+    def test_the_derivation_names_only_the_real_sinks_in_the_module(
+        self, feedback_form_handler
+    ):
+        """The other half of non-vacuity: the sink count is right, not merely
+        non-zero.
+
+        The controls in this class all check that a read is not MISSED, because a
+        missed read makes `all(...)` vacuously true. This checks the opposite
+        direction, which matching on the operation name made possible: a call that
+        is not a read must not be counted either. `form.get('name')` and
+        `response.get('Item')` are dict access, and they were being counted while
+        `aliases` tracked the RESULT of a read as though it were a table handle —
+        twelve "sinks" in `submit_form_feedback`, ten of them dict lookups.
+
+        That is not cosmetic. The whole comparison is which call comes FIRST, so a
+        spurious sink on a line above the refusal reports a correctly guarded route
+        as unbounded — and the failure would arrive as this class's own universal
+        test accusing a route that is fine, which is the least useful failure it
+        could produce.
+
+        So the count is pinned per route, against what each one actually does. The
+        numbers are small enough to read: one read each, `submit_form_feedback`
+        alone having a read AND the send that makes its cost argument different.
+        """
+        source = Path(inspect.getsourcefile(feedback_form_handler)).read_text(
+            encoding='utf-8'
+        )
+        tree = ast.parse(source)
+
+        counted = {}
+        for route, function_name in _routes_keying_on_a_form_id(source).items():
+            function = next(
+                node for node in ast.walk(tree)
+                if isinstance(node, ast.FunctionDef) and node.name == function_name
+            )
+            counted[route] = len(_sink_call_positions(function))
+
+        assert counted == {
+            'GET /feedback-forms/<form_id>': 1,
+            'PUT /feedback-forms/<form_id>': 1,
+            'DELETE /feedback-forms/<form_id>': 1,
+            'GET /feedback-forms/<form_id>/config': 1,
+            # The read for the enabled check, and the enqueue.
+            'POST /feedback-forms/<form_id>/submit': 2,
+            # The existence gate is inside `_load_form_for_query`, so this route
+            # touches no sink of its own — which is why "no sink" is deliberately
+            # not a pass by default in `_validates_its_form_id`.
+            'GET /feedback-forms/<form_id>/iframe': 0,
+            'GET /feedback-forms/<form_id>/submissions': 1,
+            'GET /feedback-forms/<form_id>/stats': 1,
+        }, (
+            f'{counted} — a route gained or lost a read, or the derivation started '
+            'counting something that is not one. If a count went UP without the '
+            'route changing, suspect `aliases`: binding the RESULT of a read makes '
+            'every subsequent `.get(...)` on it look like a sink, and the earliest '
+            'of those decides the verdict.'
+        )
 
     def test_the_derivation_can_fail(self):
         """A route that keys on an id and does not check it must be REPORTED.

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -1167,9 +1167,10 @@ export class VocApiStack extends VocStack {
      *  decision to tighten the stage-wide default cannot silently squeeze a
      *  customer's page.
      *
-     *  Cost is the reason this can be the generous side of the pair: `config` is
-     *  one get_item, and `iframe` touches no AWS service at all — it interpolates
-     *  form_id into a static HTML shell around a module-cached widget script.
+     *  Cost is the reason this can be the generous side of the pair: both reads
+     *  are one get_item. `config` returns its projection; `iframe` reads the same
+     *  record only to confirm the form EXISTS (#379) and then renders a static
+     *  HTML shell around a module-cached widget script.
      *
      *  CACHING, not a throttle, is the right primary control for `iframe`: the
      *  response is a pure function of form_id and host. It is not adopted here
@@ -1178,15 +1179,16 @@ export class VocApiStack extends VocStack {
      *  feedback_form_handler.py change. Recorded so nobody reads the throttle as
      *  evidence that the route is uncacheable.
      *
-     *  DO NOT CACHE `iframe` BEFORE ESCAPING ITS INPUT — issue #379. That route
-     *  reflects caller-supplied input into its response unescaped, so caching
-     *  would turn a reflected flaw into a stored one served to every subsequent
-     *  visitor. The escaping is therefore a PRECONDITION of the caching follow-up,
-     *  not a parallel cleanup. Pre-existing and out of scope for a CDK-only
-     *  change; the constraint is recorded HERE because this is where the next
-     *  reader decides to implement the caching, and the mechanism and fix are in
-     *  #379 rather than restated here — one description to keep correct, and it
-     *  stops this comment asserting a live vulnerability after #379 is closed.
+     *  The PRECONDITION that used to be recorded here — do not cache `iframe`
+     *  while it reflects caller input unescaped (#379) — is MET: the handler now
+     *  refuses a form id that is not one of ours, 404s an id the table does not
+     *  hold, and emits every JavaScript value through `json.dumps`, so the
+     *  response no longer carries anything a cache could store on the caller's
+     *  behalf. Kept as a note rather than deleted because this is where the next
+     *  reader decides to implement the caching, and "was this ever checked?" is
+     *  the question they will have. Caching also freezes the existence check for
+     *  the TTL, which is a decision for that follow-up: a deleted form would keep
+     *  serving its page until the entry expires.
      *
      *  NOTHING OBSERVES THIS CEILING EITHER — see the note on `methodOptions`
      *  below, where both pairs are applied. */

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -1198,6 +1198,21 @@ export class VocApiStack extends VocStack {
      *  the TTL, which is a decision for that follow-up: a deleted form would keep
      *  serving its page until the entry expires.
      *
+     *  That staleness is a FRESHNESS question and not a security one, which is the
+     *  part worth stating rather than re-deriving: A 404 IS NEVER THE CACHED
+     *  RESPONSE. The only cacheable response this route produces is the 200 for a
+     *  form that existed at render time, so the ids a cache can hold an entry for
+     *  are exactly the ids the gate already admitted. An id that was never minted
+     *  never produces a 200, so a caller cannot prime the cache with one — the
+     *  gate's guarantee weakening from "exists" to "existed within the TTL"
+     *  therefore costs a deleted form's page outliving it, and nothing more. So
+     *  the follow-up needs NO cache-invalidation-on-delete step for correctness;
+     *  it needs a TTL short enough that the stale window is acceptable, and if a
+     *  deleted form's page must disappear promptly then that is a product
+     *  requirement to decide, not a hole to close. The one constraint this does
+     *  impose: whatever form the caching takes must not become negative caching,
+     *  because a cached 404 WOULD be keyed on an id an anonymous caller chose.
+     *
      *  NOTHING OBSERVES THIS CEILING EITHER — see the note on `methodOptions`
      *  below, where both pairs are applied. */
     const publicWidgetReadThrottle: apigateway.MethodDeploymentOptions = {

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -1172,6 +1172,14 @@ export class VocApiStack extends VocStack {
      *  record only to confirm the form EXISTS (#379) and then renders a static
      *  HTML shell around a module-cached widget script.
      *
+     *  And ZERO get_item for a form id that cannot be one of ours: all three
+     *  public routes format-check the path segment before they read
+     *  (`_validated_form_id`), so a probe for `/feedback-forms/admin` or a
+     *  megabyte of path segment costs a 404 and no table call on any of them.
+     *  That is what makes the cost figure above a bound on what a caller can
+     *  spend rather than a description of the happy path — which matters here,
+     *  because this ceiling is shared across every form and every caller.
+     *
      *  CACHING, not a throttle, is the right primary control for `iframe`: the
      *  response is a pure function of form_id and host. It is not adopted here
      *  because both available forms are out of a CDK-only change — an API Gateway


### PR DESCRIPTION
Clean review-context successor to #392.

The code is unchanged from #392 at creation (`a403df8d2bcec2f7d4189efceea7dd067d38c67d`). This pull request keeps the same focused feedback-form iframe security change while allowing review to continue without the accumulated discussion history on the original pull request.

Original context and prior reviews remain available on #392. The original pull request is intentionally left open until this successor is validated.
