### PR TITLE
test(plugins): pin the plugin-secret identity guard by failure mode (#398)

### DIFF
--- a/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
+++ b/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
@@ -29,6 +29,18 @@ REVERT MAP — each assertion below names the mutation it catches:
       which since #251 is the whole isolation boundary — pinned as raise-vs-return,
       so no rewording of either message can defeat it (issue #398 A.1).
 
+    — also reclassifies the identity branch to `SecretUnreadableError`. That is the
+      one mutation `pytest.raises(ConfigurationError)` cannot see, the narrower type
+      being a SUBCLASS, and it is the availability classification this file spends a
+      whole class on: `BaseIngestor._report_construction_failure` reads
+      `unreadable = isinstance(error, SecretUnreadableError)` and skips
+      `record_failure` for it, so a malformed `SOURCE_PLATFORM` — a human mistake
+      that never self-heals — would be exempt from the breaker and retried on every
+      schedule tick forever. The counted class's other two branches each already
+      carry this assertion (test_a_namespace_miss_is_not_the_unreadable_type,
+      test_a_non_object_payload_is_not_the_unreadable_type); the identity branch was
+      the only one of the three without it.
+
   test_a_missing_or_malformed_identity_raises
     — the same deletion, caught by MESSAGE, over the seven malformed shapes the
       character class rejects. Every one of those ids also misses the namespace, so
@@ -48,11 +60,33 @@ REVERT MAP — each assertion below names the mutation it catches:
       truncation. Mirrors `integrations_handler._validate_source`'s
       `repr(source[:40])`, for the same reason on the write side.
 
-    — and empties `PLUGIN_IDENTIFIER_RULES`, the precondition both of that test's
-      message assertions rest on: `'' in message` is always true, so the pin would
-      go vacuous while its control failed as though the two messages had converged.
+    — and widens the IDENTITY message to name the payload's keys. Held to the same
+      four-part property as the miss message below (both key names and both values),
+      because the two branches' messages are read as a pair and a reader comparing
+      them will assume parity. The keys are the reconnaissance half: answering "your
+      plugin id is malformed" with a list of the other plugins' key names is the
+      mutation the miss-branch entry further down describes, and it survived here
+      while only values were asserted.
+
+  test_the_identity_log_carries_only_the_truncated_preview
+    — attaches the payload to the identity branch's `logger.error(extra=...)`, or
+      logs the raw `plugin_id` in place of the truncated `preview`. The message and
+      the log are separate surfaces: every message assertion above passes while the
+      `extra` grows a copy of the secret, which the miss branch's log test calls the
+      more likely way this regresses. Asserting `extra` by EQUALITY is what makes
+      that so — an added key fails it — and the expected preview is spelled as
+      `repr('a' * 40)` so the 40-char bound is pinned on this surface too.
+
+  test_the_precondition_the_rules_constant_is_not_empty
+    — empties `PLUGIN_IDENTIFIER_RULES`, the precondition the two message
+      assertions above rest on: `'' in message` is always true, so the pin would go
+      vacuous while its control failed as though the two messages had converged.
+      Its own test rather than a line inside the parametrised body, since it is a
+      module-level invariant and does not vary with the seven fixtures.
       `test_the_identity_rule_is_the_one_the_write_path_enforces` pins the REGEX is
-      shared; nothing pinned the prose constant.
+      shared; nothing pinned the prose constant. Note the limit: this makes the
+      vacuity LOUD, it does not repair the pin — what survives an emptied constant
+      is the outcome test above, which reads neither message.
 
   test_a_key_outside_every_plugin_namespace_is_not_returned
     — restores BaseIngestor's "no KNOWN prefix means shared/legacy" branch and
@@ -238,10 +272,17 @@ FOREIGN_ONLY_SECRET = {
 # LOCALS in a traceback (`--tb=long -l`), so a payload built inside a test body
 # would print its values on any failure in that test. This file's discipline is
 # that a refusal's output names the failure mode and nothing else.
+#
+# The prefixed key is spelled out here rather than built with
+# `plugin_secret_prefix(MALFORMED_ID)`: calling the production helper on a
+# deliberately INVALID id at module scope would make the whole file fail at
+# COLLECTION if that helper ever started validating — a plausible hardening of the
+# very boundary this test defends, and a collection error takes every test in this
+# file with it rather than failing one. The test asserts the hand-spelled key really
+# does match the prefix the helper derives, so the two cannot drift.
 MALFORMED_ID = PLUGIN_ID.upper()
-MALFORMED_ID_PREFIX = plugin_secret_prefix(MALFORMED_ID)
 MALFORMED_ID_MATCHING_SECRET = {
-    f'{MALFORMED_ID_PREFIX}api_key': 'mine-key',
+    f'{MALFORMED_ID}_api_key': 'mine-key',
     **FOREIGN_ONLY_SECRET,
 }
 
@@ -344,6 +385,10 @@ class TestANamespaceMissFailsClosed:
         becoming a Secrets Manager key prefix. `'TEST_SOURCE'` is refused by the
         character class, yet `TEST_SOURCE_api_key` is a key a write path that did
         not share that class could have stored.
+
+        The exception CLASS is pinned too, for the reason
+        `test_a_namespace_miss_is_not_the_unreadable_type` gives: `pytest.raises`
+        alone cannot see a reclassification to the narrower subclass.
         """
         # Both halves of the fixture's premise, asserted rather than assumed — with
         # either one broken by a later edit this silently becomes a second
@@ -352,14 +397,29 @@ class TestANamespaceMissFailsClosed:
             f'{MALFORMED_ID!r} must be malformed for this to test the identity guard'
         )
         # The scan's own condition, so "the payload matches" means what the code
-        # means by it.
+        # means by it — and against the prefix the production helper really derives,
+        # which is what keeps the hand-spelled fixture key honest.
+        malformed_prefix = plugin_secret_prefix(MALFORMED_ID)
         assert any(
-            key.startswith(MALFORMED_ID_PREFIX) and len(key) > len(MALFORMED_ID_PREFIX)
+            key.startswith(malformed_prefix) and len(key) > len(malformed_prefix)
             for key in MALFORMED_ID_MATCHING_SECRET
         ), 'the payload must match the malformed prefix, or the miss branch raises instead'
 
-        with pytest.raises(ConfigurationError):
+        with pytest.raises(ConfigurationError) as excinfo:
             filter_plugin_secrets(MALFORMED_ID, MALFORMED_ID_MATCHING_SECRET)
+
+        # A malformed identity comes from SOURCE_PLATFORM: a human wrote it wrong and
+        # it will never self-heal, so it belongs to the COUNTED class.
+        # `_report_construction_failure` skips `record_failure` for the unreadable
+        # type, so classifying this branch as unreadable would exempt a permanent
+        # misconfiguration from the breaker and retry it on every schedule tick
+        # forever. Same argument, and same assertion, as the other two counted
+        # branches.
+        assert not isinstance(excinfo.value, SecretUnreadableError), (
+            'a malformed identity is a permanent misconfiguration, not an unreadable '
+            'secret; the narrower type is exempt from the circuit breaker, so this '
+            'would be retried every tick forever'
+        )
 
     @pytest.mark.parametrize(
         'identity',
@@ -387,12 +447,6 @@ class TestANamespaceMissFailsClosed:
 
         message = str(excinfo.value)
 
-        # The precondition both message assertions rest on, since `'' in anything`
-        # is True and `'' not in anything` is False: an emptied constant would make
-        # the check below pass on all seven fixtures with the guard deleted, and
-        # break the control in a way that reads as "the messages converged".
-        assert PLUGIN_IDENTIFIER_RULES, 'the rules constant must state the rules'
-
         assert PLUGIN_IDENTIFIER_RULES in message, (
             'the refusal must identify a missing or malformed plugin identity and '
             'state the rule it broke; a message that instead reports a missing '
@@ -405,12 +459,37 @@ class TestANamespaceMissFailsClosed:
         # never reaches this branch. And this is the branch that matters most for
         # leakage, being the only refusal that echoes caller-controlled input back
         # into the string.
+        #
+        # All four parts of the property, matching what that class asserts about the
+        # miss message: the KEY NAMES as well as the values. The two messages are
+        # read as a pair, so holding them to different properties invites a reader to
+        # assume parity that is not there — and the key names are the half that turns
+        # a misconfiguration into reconnaissance.
+        assert OTHER_PLUGIN_KEY not in message
         assert OTHER_PLUGIN_VALUE not in message
+        assert UNPREFIXED_KEY not in message
         assert UNPREFIXED_VALUE not in message
         # Reflected input is BOUNDED at 40 characters, mirroring
-        # `integrations_handler._validate_source`'s `repr(source[:40])`. The
-        # `too_long` fixture is 65 `a`s, so a 41st means the truncation went.
+        # `integrations_handler._validate_source`'s `repr(source[:40])`. Meaningful
+        # for the `too_long` fixture (65 `a`s, so a 41st means the truncation went)
+        # and trivially true for the other six, which are all shorter than the bound.
         assert 'a' * 41 not in message
+
+    def test_the_precondition_the_rules_constant_is_not_empty(self):
+        """The constant both message assertions above rest on, since `'' in anything`
+        is True and `'' not in anything` is False. Emptied, the check above would
+        pass on all seven fixtures with the guard deleted, and the control below
+        would fail as though the two messages had converged — so the diagnosis would
+        point at the wrong thing.
+
+        Its own test rather than a line in the parametrised body: it is a
+        module-level invariant that does not vary with the fixtures, and asserting it
+        seven times says nothing more than asserting it once. Note the ceiling — this
+        makes the vacuity LOUD, it does not repair the pin. What survives an emptied
+        constant is `test_a_malformed_identity_is_refused_even_when_its_prefix_would_match`,
+        which reads neither message.
+        """
+        assert PLUGIN_IDENTIFIER_RULES, 'the rules constant must state the rules'
 
     def test_the_control_a_namespace_miss_is_not_reported_as_a_malformed_identity(self):
         """Non-vacuity for the assertion above: it separates the two refusals only
@@ -478,6 +557,31 @@ class TestErrorsRevealTheMisconfigurationAndNothingElse:
         assert OTHER_PLUGIN_KEY not in rendered
         assert OTHER_PLUGIN_VALUE not in rendered
         assert UNPREFIXED_VALUE not in rendered
+
+    def test_the_identity_log_carries_only_the_truncated_preview(self):
+        """The identity branch's log held to the same property as the miss branch's
+        above, on the surface the message assertions cannot see.
+
+        Every assertion in `test_a_missing_or_malformed_identity_raises` reads
+        `str(excinfo.value)`, so an `extra` that grew a copy of the payload would pass
+        all of them — and the sibling test above calls that the more likely way this
+        regresses. Asserted by EQUALITY for that reason: an ADDED key fails it, which
+        a set of `not in` checks against today's fixture values would not.
+
+        The id is the `too_long` fixture, so the expected value spells the 40-char
+        bound out (`repr('a' * 40)`): this pins that the log gets the truncated
+        preview and not the raw identity, which the message test pins separately for
+        its own surface.
+        """
+        with patch('_shared.plugin_secrets.logger') as mock_logger, \
+                pytest.raises(ConfigurationError):
+            filter_plugin_secrets('a' * 65, MIXED_SECRET)
+
+        assert mock_logger.error.call_args_list, (
+            'a malformed identity must be logged, not only raised'
+        )
+        call = mock_logger.error.call_args
+        assert call.kwargs['extra'] == {'plugin_id': repr('a' * 40)}
 
     def test_the_log_control_a_successful_load_logs_nothing(self):
         """Non-vacuity for the assertion above: without this, a refusal logged

--- a/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
+++ b/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
@@ -20,6 +20,17 @@ REVERT MAP — each assertion below names the mutation it catches:
       swallows), so a plugin would run credential-less believing it was
       configured.
 
+  test_a_missing_or_malformed_identity_raises
+    — deletes `if not is_valid_plugin_identifier(plugin_id)` from
+      `filter_plugin_secrets`. The mutation used to survive: the namespace-miss
+      branch below raises the SAME `ConfigurationError` for every malformed id, so
+      a class-only assertion stayed green while the identity was no longer checked
+      at all — and an unvalidated id becomes a key prefix, which is the whole
+      isolation boundary (issue #398 A.1). The assertion now names the rule the
+      identity broke, which only that branch states; its control
+      (test_the_control_a_namespace_miss_is_not_reported_as_a_malformed_identity)
+      pins that the miss branch does not start stating it too.
+
   test_a_key_outside_every_plugin_namespace_is_not_returned
     — restores BaseIngestor's "no KNOWN prefix means shared/legacy" branch and
       the hand-maintained plugin-id list it needed. Under that branch a plugin id
@@ -158,7 +169,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import shared.aws as shared_aws
 from shared.exceptions import ConfigurationError, SecretUnreadableError
-from shared.plugin_identity import is_valid_plugin_identifier
+from shared.plugin_identity import PLUGIN_IDENTIFIER_RULES, is_valid_plugin_identifier
 
 from _shared import base_ingestor, base_webhook
 from _shared.plugin_secrets import filter_plugin_secrets, plugin_secret_prefix
@@ -285,9 +296,43 @@ class TestANamespaceMissFailsClosed:
         """A plugin id becomes a key prefix, so it is validated on the same
         character class the write path enforces on `source`. An empty identity is
         the one that matters most: `prefix = '_'` would otherwise match nothing
-        and, under the old fallback, return everything."""
-        with pytest.raises(ConfigurationError):
+        and, under the old fallback, return everything.
+
+        `pytest.raises(ConfigurationError)` ALONE does not pin the identity guard,
+        and that is not theoretical: delete `if not is_valid_plugin_identifier` and
+        every fixture here still raises `ConfigurationError`, from the namespace-miss
+        branch three checks below — none of these malformed ids has a matching key
+        in `MIXED_SECRET`, by construction. The class is the same, so the MESSAGE is
+        the only evidence of which branch ran (issue #398 A.1).
+
+        Asserted against the imported `PLUGIN_IDENTIFIER_RULES` rather than a
+        quoted phrase: it is the actionable half of the identity message, only that
+        branch states it, and a test carrying its own copy of the wording would
+        fail on a rewording that broke nothing. The paired control below pins that
+        the two branches remain distinguishable this way.
+        """
+        with pytest.raises(ConfigurationError) as excinfo:
             filter_plugin_secrets(identity, MIXED_SECRET)
+
+        # Only the failure mode is named, never the payload: this message must stay
+        # free of secret values and of another plugin's key names, so the assertion
+        # output does too (TestErrorsRevealTheMisconfigurationAndNothingElse pins
+        # the message itself).
+        assert PLUGIN_IDENTIFIER_RULES in str(excinfo.value), (
+            'the refusal must identify a missing or malformed plugin identity and '
+            'state the rule it broke; a message that instead reports a missing '
+            'secret namespace means the identity guard did not run'
+        )
+
+    def test_the_control_a_namespace_miss_is_not_reported_as_a_malformed_identity(self):
+        """Non-vacuity for the assertion above: it separates the two refusals only
+        while their messages differ. A namespace miss carries a VALID identity, so
+        restating the identity rules there would silently make that assertion pass
+        with the guard deleted."""
+        with pytest.raises(ConfigurationError) as excinfo:
+            filter_plugin_secrets(PLUGIN_ID, FOREIGN_ONLY_SECRET)
+
+        assert PLUGIN_IDENTIFIER_RULES not in str(excinfo.value)
 
 
 class TestErrorsRevealTheMisconfigurationAndNothingElse:

--- a/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
+++ b/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
@@ -77,6 +77,15 @@ REVERT MAP — each assertion below names the mutation it catches:
       that so — an added key fails it — and the expected preview is spelled as
       `repr('a' * 40)` so the 40-char bound is pinned on this surface too.
 
+    — and, a DISTINCT mutation, leaks the payload through that call's MESSAGE
+      argument instead of its `extra`: `logger.error(f'... {sorted(all_secrets)}')`
+      leaves the `extra` equality above untouched and passed the whole tree. So the
+      whole call is rendered and checked, exactly as the miss branch's log test does
+      for the same reason — the two log surfaces of one branch have to be covered
+      together or the uncovered one is where a leak lands. The identity branch is the
+      one reflecting caller-controlled input, so it is the last place to hold to a
+      weaker property than its sibling.
+
   test_the_precondition_the_rules_constant_is_not_empty
     — empties `PLUGIN_IDENTIFIER_RULES`, the precondition the two message
       assertions above rest on: `'' in message` is always true, so the pin would go
@@ -492,10 +501,12 @@ class TestANamespaceMissFailsClosed:
         assert PLUGIN_IDENTIFIER_RULES, 'the rules constant must state the rules'
 
     def test_the_control_a_namespace_miss_is_not_reported_as_a_malformed_identity(self):
-        """Non-vacuity for the assertion above: it separates the two refusals only
-        while their messages differ. A namespace miss carries a VALID identity, so
-        restating the identity rules there would silently make that assertion pass
-        with the guard deleted.
+        """Non-vacuity for `test_a_missing_or_malformed_identity_raises`'s
+        `PLUGIN_IDENTIFIER_RULES` assertion — named rather than "above", since the
+        rules-constant precondition now sits between the two. That assertion separates
+        the two refusals only while their messages differ: a namespace miss carries a
+        VALID identity, so restating the identity rules there would silently make it
+        pass with the guard deleted.
 
         Deliberately negative only. The POSITIVE half of this message — that it
         names the identity and the expected prefix and nothing else — is asserted by
@@ -572,16 +583,34 @@ class TestErrorsRevealTheMisconfigurationAndNothingElse:
         bound out (`repr('a' * 40)`): this pins that the log gets the truncated
         preview and not the raw identity, which the message test pins separately for
         its own surface.
+
+        `extra` and the MESSAGE argument are two surfaces, so both are checked: the
+        equality covers an added `extra` key, and the rendered whole call covers a
+        message that interpolated the payload — which leaves `extra` untouched and so
+        passes the equality on its own.
         """
         with patch('_shared.plugin_secrets.logger') as mock_logger, \
                 pytest.raises(ConfigurationError):
             filter_plugin_secrets('a' * 65, MIXED_SECRET)
 
-        assert mock_logger.error.call_args_list, (
-            'a malformed identity must be logged, not only raised'
+        assert mock_logger.error.call_count == 1, (
+            'a malformed identity must be logged exactly once: with two calls the '
+            'assertions below would silently move to whichever came last'
         )
         call = mock_logger.error.call_args
-        assert call.kwargs['extra'] == {'plugin_id': repr('a' * 40)}
+        assert call.kwargs['extra'] == {'plugin_id': repr('a' * 40)}, (
+            "the log's structured fields must carry the truncated identity preview "
+            'and nothing else — no copy of the payload, and not the raw identity'
+        )
+        # The message argument, which the equality above cannot see. Same four-part
+        # property, and the same `repr(call)` mechanism, as the miss branch's log test:
+        # interpolating the payload into the message leaves `extra` correct.
+        rendered = repr(call)
+        for leaked in (OTHER_PLUGIN_KEY, OTHER_PLUGIN_VALUE, UNPREFIXED_KEY, UNPREFIXED_VALUE):
+            assert leaked not in rendered, (
+                f'{leaked!r} reached the identity refusal log; the message argument and '
+                '`extra` are separate surfaces and neither may carry secret material'
+            )
 
     def test_the_log_control_a_successful_load_logs_nothing(self):
         """Non-vacuity for the assertion above: without this, a refusal logged

--- a/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
+++ b/voc-datalake/plugins/_shared/test/test_plugin_secret_isolation.py
@@ -20,16 +20,39 @@ REVERT MAP — each assertion below names the mutation it catches:
       swallows), so a plugin would run credential-less believing it was
       configured.
 
-  test_a_missing_or_malformed_identity_raises
+  test_a_malformed_identity_is_refused_even_when_its_prefix_would_match
     — deletes `if not is_valid_plugin_identifier(plugin_id)` from
-      `filter_plugin_secrets`. The mutation used to survive: the namespace-miss
-      branch below raises the SAME `ConfigurationError` for every malformed id, so
-      a class-only assertion stayed green while the identity was no longer checked
-      at all — and an unvalidated id becomes a key prefix, which is the whole
-      isolation boundary (issue #398 A.1). The assertion now names the rule the
-      identity broke, which only that branch states; its control
+      `filter_plugin_secrets`, caught by OUTCOME: with the guard gone the call
+      RETURNS `{'api_key': ...}` instead of raising, because this one fixture's
+      malformed id has matching keys in the payload. That is the production hazard
+      itself — an unvalidated identity turned into a Secrets Manager key prefix,
+      which since #251 is the whole isolation boundary — pinned as raise-vs-return,
+      so no rewording of either message can defeat it (issue #398 A.1).
+
+  test_a_missing_or_malformed_identity_raises
+    — the same deletion, caught by MESSAGE, over the seven malformed shapes the
+      character class rejects. Every one of those ids also misses the namespace, so
+      the miss branch raises the SAME `ConfigurationError` for all of them: a
+      class-only assertion stayed green while the identity was no longer checked at
+      all. The assertion now names the rule the identity broke, which only that
+      branch states; its control
       (test_the_control_a_namespace_miss_is_not_reported_as_a_malformed_identity)
-      pins that the miss branch does not start stating it too.
+      pins that the miss branch does not start stating it too. Message-based, hence
+      bounded by the two messages staying distinguishable — the outcome pin above
+      is the one that holds unconditionally.
+
+    — also drops the `[:40]` from `preview = repr(plugin_id[:40])`. The identity
+      branch is the ONE refusal here that echoes caller-controlled input back into
+      an error string, so the bound on how much of it is reflected is asserted, not
+      assumed. The `too_long` fixture (`'a' * 65`) drives straight through that
+      truncation. Mirrors `integrations_handler._validate_source`'s
+      `repr(source[:40])`, for the same reason on the write side.
+
+    — and empties `PLUGIN_IDENTIFIER_RULES`, the precondition both of that test's
+      message assertions rest on: `'' in message` is always true, so the pin would
+      go vacuous while its control failed as though the two messages had converged.
+      `test_the_identity_rule_is_the_one_the_write_path_enforces` pins the REGEX is
+      shared; nothing pinned the prose constant.
 
   test_a_key_outside_every_plugin_namespace_is_not_returned
     — restores BaseIngestor's "no KNOWN prefix means shared/legacy" branch and
@@ -197,9 +220,29 @@ MIXED_SECRET = {
 
 # The same payload with THIS plugin's namespace removed: what a mis-prefixed
 # identity really sees in production.
+#
+# Every key here MUST stay outside `PREFIX`. Several tests below are namespace-MISS
+# tests only because of that property — give this fixture a `test_source_*` key and
+# they start exercising the success path while still passing.
 FOREIGN_ONLY_SECRET = {
     OTHER_PLUGIN_KEY: OTHER_PLUGIN_VALUE,
     UNPREFIXED_KEY: UNPREFIXED_VALUE,
+}
+
+# A malformed identity — uppercase, so the character class refuses it — together
+# with a payload that DOES carry keys under the prefix it would produce. That pair
+# makes the identity guard observable as raise-vs-return rather than as a message;
+# see test_a_malformed_identity_is_refused_even_when_its_prefix_would_match.
+#
+# Module-level, like the two above and for the same reason: pytest expands test
+# LOCALS in a traceback (`--tb=long -l`), so a payload built inside a test body
+# would print its values on any failure in that test. This file's discipline is
+# that a refusal's output names the failure mode and nothing else.
+MALFORMED_ID = PLUGIN_ID.upper()
+MALFORMED_ID_PREFIX = plugin_secret_prefix(MALFORMED_ID)
+MALFORMED_ID_MATCHING_SECRET = {
+    f'{MALFORMED_ID_PREFIX}api_key': 'mine-key',
+    **FOREIGN_ONLY_SECRET,
 }
 
 
@@ -286,6 +329,38 @@ class TestANamespaceMissFailsClosed:
         with pytest.raises(ConfigurationError):
             filter_plugin_secrets(PLUGIN_ID, {PREFIX: 'junk', **FOREIGN_ONLY_SECRET})
 
+    def test_a_malformed_identity_is_refused_even_when_its_prefix_would_match(self):
+        """The identity guard pinned by OUTCOME rather than by wording.
+
+        Every fixture in the parametrised test below is malformed in a way that
+        ALSO misses the namespace, so deleting `if not is_valid_plugin_identifier`
+        is observable there only as a changed message — which is why that assertion
+        needs a control to stay meaningful. This case removes that dependency: the
+        payload DOES carry keys under the malformed id's prefix, so with the guard
+        deleted the call RETURNS that namespace's contents instead of raising. No
+        rewording of either message can defeat it, and it needs no control.
+
+        It is also the production hazard stated directly: an unvalidated identity
+        becoming a Secrets Manager key prefix. `'TEST_SOURCE'` is refused by the
+        character class, yet `TEST_SOURCE_api_key` is a key a write path that did
+        not share that class could have stored.
+        """
+        # Both halves of the fixture's premise, asserted rather than assumed — with
+        # either one broken by a later edit this silently becomes a second
+        # message-shaped test of the MISS branch, passing for the wrong reason.
+        assert not is_valid_plugin_identifier(MALFORMED_ID), (
+            f'{MALFORMED_ID!r} must be malformed for this to test the identity guard'
+        )
+        # The scan's own condition, so "the payload matches" means what the code
+        # means by it.
+        assert any(
+            key.startswith(MALFORMED_ID_PREFIX) and len(key) > len(MALFORMED_ID_PREFIX)
+            for key in MALFORMED_ID_MATCHING_SECRET
+        ), 'the payload must match the malformed prefix, or the miss branch raises instead'
+
+        with pytest.raises(ConfigurationError):
+            filter_plugin_secrets(MALFORMED_ID, MALFORMED_ID_MATCHING_SECRET)
+
     @pytest.mark.parametrize(
         'identity',
         ['', None, 'Test_Source', 'test-source', '_test_source', 'test_source_', 'a' * 65],
@@ -298,37 +373,58 @@ class TestANamespaceMissFailsClosed:
         the one that matters most: `prefix = '_'` would otherwise match nothing
         and, under the old fallback, return everything.
 
-        `pytest.raises(ConfigurationError)` ALONE does not pin the identity guard,
-        and that is not theoretical: delete `if not is_valid_plugin_identifier` and
-        every fixture here still raises `ConfigurationError`, from the namespace-miss
-        branch three checks below — none of these malformed ids has a matching key
-        in `MIXED_SECRET`, by construction. The class is the same, so the MESSAGE is
-        the only evidence of which branch ran (issue #398 A.1).
+        Every id here also MISSES the namespace, so `pytest.raises` alone proves
+        nothing about which branch ran — the message is the only evidence, and the
+        control below keeps it evidence. The outcome-based sibling above pins the
+        same guard without depending on either message; the REVERT MAP entry has
+        the full argument.
 
-        Asserted against the imported `PLUGIN_IDENTIFIER_RULES` rather than a
-        quoted phrase: it is the actionable half of the identity message, only that
-        branch states it, and a test carrying its own copy of the wording would
-        fail on a rewording that broke nothing. The paired control below pins that
-        the two branches remain distinguishable this way.
+        `PLUGIN_IDENTIFIER_RULES` is asserted as the IMPORTED constant, not a quoted
+        copy, so a rewording that breaks nothing does not fail this.
         """
         with pytest.raises(ConfigurationError) as excinfo:
             filter_plugin_secrets(identity, MIXED_SECRET)
 
-        # Only the failure mode is named, never the payload: this message must stay
-        # free of secret values and of another plugin's key names, so the assertion
-        # output does too (TestErrorsRevealTheMisconfigurationAndNothingElse pins
-        # the message itself).
-        assert PLUGIN_IDENTIFIER_RULES in str(excinfo.value), (
+        message = str(excinfo.value)
+
+        # The precondition both message assertions rest on, since `'' in anything`
+        # is True and `'' not in anything` is False: an emptied constant would make
+        # the check below pass on all seven fixtures with the guard deleted, and
+        # break the control in a way that reads as "the messages converged".
+        assert PLUGIN_IDENTIFIER_RULES, 'the rules constant must state the rules'
+
+        assert PLUGIN_IDENTIFIER_RULES in message, (
             'the refusal must identify a missing or malformed plugin identity and '
             'state the rule it broke; a message that instead reports a missing '
             'secret namespace means the identity guard did not run'
         )
 
+        # The identity message's OWN no-leak property, asserted here rather than
+        # borrowed: `TestErrorsRevealTheMisconfigurationAndNothingElse` covers the
+        # MISS message only — every case there passes a valid `PLUGIN_ID` and so
+        # never reaches this branch. And this is the branch that matters most for
+        # leakage, being the only refusal that echoes caller-controlled input back
+        # into the string.
+        assert OTHER_PLUGIN_VALUE not in message
+        assert UNPREFIXED_VALUE not in message
+        # Reflected input is BOUNDED at 40 characters, mirroring
+        # `integrations_handler._validate_source`'s `repr(source[:40])`. The
+        # `too_long` fixture is 65 `a`s, so a 41st means the truncation went.
+        assert 'a' * 41 not in message
+
     def test_the_control_a_namespace_miss_is_not_reported_as_a_malformed_identity(self):
         """Non-vacuity for the assertion above: it separates the two refusals only
         while their messages differ. A namespace miss carries a VALID identity, so
         restating the identity rules there would silently make that assertion pass
-        with the guard deleted."""
+        with the guard deleted.
+
+        Deliberately negative only. The POSITIVE half of this message — that it
+        names the identity and the expected prefix and nothing else — is asserted by
+        `TestErrorsRevealTheMisconfigurationAndNothingElse
+        ::test_the_error_names_the_identity_and_prefix_and_nothing_else`, off the
+        same call, so restating it here would be a second copy rather than more
+        coverage.
+        """
         with pytest.raises(ConfigurationError) as excinfo:
             filter_plugin_secrets(PLUGIN_ID, FOREIGN_ONLY_SECRET)
 


### PR DESCRIPTION
## Summary

One completed slice of the umbrella issue #398 — **item A.1 only**. The other A/B/C/D
items (the `AppEditorForm` Save gate, the CHANGELOG seeding note, the two route
classifications, and the five editorial items) are deliberately untouched and remain open.

`filter_plugin_secrets`'s identity guard (`plugins/_shared/plugin_secrets.py:122`) was
deletable with the whole plugin suite green. `test_a_missing_or_malformed_identity_raises`
asserted only `pytest.raises(ConfigurationError)`, and the namespace-miss branch three
checks below raises the *same class* for every one of that test's malformed fixtures —
none of them has a matching key in `MIXED_SECRET`, by construction. So the class was no
evidence of which branch ran, and an unvalidated plugin id would still have been turned
into a Secrets Manager key prefix, which since #251 is the entire isolation boundary.

The change is one strengthened assertion plus its control:

- **The assertion** now requires the message to state `PLUGIN_IDENTIFIER_RULES`. Asserted
  against the **imported** constant rather than a quoted phrase, per the repo's "assert the
  property, not one spelling of it" rule: only the identity branch states those rules, and
  a test carrying its own copy of the wording would fail on a rewording that broke nothing.
- **`test_the_control_a_namespace_miss_is_not_reported_as_a_malformed_identity`** pins that
  the miss branch does *not* state them. Without it the pin lapses silently the day the two
  messages converge — the assertion above only separates the branches while they differ.
- A **REVERT MAP entry** in the module docstring, matching the existing convention where
  every assertion in this file names the mutation it catches.

**Production behaviour is unchanged** — `plugin_secrets.py` is byte-identical to
`development`, verified with `git diff`. The diff is one test file: +48/−3.

Closes item A.1 of #398.

## Build and test results

Ran from the repo root against `development`.

| Gate | Command | Result |
|---|---|---|
| Focused plugin-secret test | `pytest plugins/_shared/test/test_plugin_secret_isolation.py` | **68 passed** (was 67; +1 control) |
| Whole plugin tree | `pytest plugins` | **361 passed** |
| Backend | `npm run test:backend` | **4155 passed**, exit 0 |
| Targeted Ruff | `ruff check plugins/_shared/test/test_plugin_secret_isolation.py plugins/_shared/plugin_secrets.py` | **All checks passed** |
| Repo Ruff | `npm run lint:python` | 518 findings — **the documented baseline**, delta **zero** (see below) |
| Frontend typecheck | `npm run typecheck` | exit 0 |
| CDK typecheck | `npm run typecheck:cdk` | exit 0 |
| Frontend build | `npm run build` | **fails for an environmental reason, pre-existing** (below) |
| CDK tests | `npm run test:cdk` | 69 failed / 232 passed — **environmental, pre-existing** (below) |

### The mutation, run rather than asserted

Per #398's acceptance criterion ("delete the guard, watch the named test go red, restore,
watch it pass"), I deleted the 15-line `if not is_valid_plugin_identifier(plugin_id):` block
and ran the suite:

- **Guard deleted →** all **7** parametrised cases fail (`empty`, `none`, `uppercase`,
  `hyphen`, `leading_underscore`, `trailing_underscore`, `too_long`), each reporting that it
  got the namespace-miss message instead. Across the **entire** plugin tree those 7 were the
  **only** failures — `7 failed, 354 passed`, where before this PR the same mutation gave
  361 passed. That is the guard's blast radius reduced to exactly this test, which is what
  makes it the pin.
- **Guard restored →** `361 passed`. The restore was a byte-for-byte copy, confirmed by an
  empty `git diff` on `plugin_secrets.py`.

The sibling namespace-miss tests in the same class stayed **green** under the mutation, so
the new assertion is discriminating between the two branches rather than just being strict.

### No secret material in assertion output

Re-ran the red case with `--tb=long -l` (maximum verbosity, locals expanded) and grepped the
output for every piece of secret material the fixtures define — `other-plugins-value`,
`generated-by-secrets-manager`, `mine-key`, `synthetic_reviews`, `company_name`,
`placeholder`: **zero matches**. The assertion reads only `str(excinfo.value)`, and the
payload is a module-level global rather than a test local, so it does not surface in a
traceback.

### Ruff delta measured, not assumed

`requirements-dev.txt` notes the count moves with the ruff version and that the invariant is
"no new findings against the same version". Under ruff 0.16.5 I captured
`ruff check lambda plugins scripts --statistics` before (via `git stash`) and after: the two
files are **identical**. 518 both ways, all pre-existing.

### Pre-existing failures, unrelated to this diff

Both were failing before my change and neither can be affected by a Python test file:

- `npm run build` — `tsc -b` passes, then vite fails resolving a transitive `uuid` import
  from `@aws-amplify/core`, absent from the sandbox install. (First attempt failed differently,
  on `EMFILE: too many open files` against the container's 1024 fd limit, which I could not raise.)
- `npm run test:cdk` — the 4 failing files all report
  `CannotFindAsset: Cannot find asset at voc-datalake/frontend/dist`, i.e. they need the
  frontend build above. The other 14 files pass.

Note: `mise run build` does not exist in this repo (`mise ERROR no tasks defined`), so I used
the `package.json` gates the house rules name instead.

## Decisions made

- **Asserted the imported constant, not a literal.** `PLUGIN_IDENTIFIER_RULES` already exists
  and is shared by the read and write paths, so this reuses the choke point rather than
  hardcoding prose. #398 suggested `'missing or malformed' in str(exc.value)`; the rules
  constant is strictly stronger (it is the actionable half of the message, and only the
  identity branch emits it) and cannot drift from the production wording.
- **Added the control.** #398 said "one line". I added a second test because a one-line
  assertion that distinguishes two branches by message is only valid while the messages
  differ, and nothing else in the file would notice if they converged. This matches the
  file's existing pattern — it already carries four `_control_` tests for exactly this reason.
- **Scope held to A.1**, as instructed, including leaving the guard's now-provable
  correctness alone.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).

```abca-verify
no-ui
```

## Agent notes

**What went well.** The repo made this easy in an unusual way: `test_plugin_secret_isolation.py`
opens with a 150-line REVERT MAP naming, per assertion, the mutation it catches. That told me
where the new entry belonged and what tone it needed, and the file's existing `_control_` tests
established the non-vacuity convention so the control did not need inventing. The mutation itself
was cheap to run and gave an unusually crisp signal — 7 failures out of 361, all in the intended
test.

**What was difficult.** The container had no Python environment (`voc-datalake/.venv` absent) and
no `node_modules`, so `test:backend` could not run initially. Building the venv took three rounds
of dependency discovery: `requirements-dev.txt` alone is insufficient — Powertools' `Tracer` needs
`aws-xray-sdk`, and the plugin base classes need the two `lambda/layers/*/requirements.txt` sets
that the dev file mentions only in a comment. Worth automating. The frontend build then hit the
container's 1024 fd limit, which I could not raise, and afterwards a genuinely missing transitive
dep — so the TS gates are only partially reportable from here.

**Patterns discovered.** (1) `npm run check` chains with `&&`, so the first failure hides later
steps — running the individual scripts is the right triage move, as the house rules say. (2) Ruff's
absolute count is meaningless; the invariant is a zero delta against the same version, and
`git stash` + `--statistics` is a cheap way to measure it. (3) The Powertools logger does not
propagate, so `caplog` never sees it and the suites patch the logger object instead — relevant to
anyone extending the log assertions here.

**Suggestions for future tasks.** The remaining #398 items are independent and separable; A.2
(the `AppEditorForm` Save gate) is the one with real user-visible consequence and is a frontend
test, so it needs a working `node_modules` — likely worth doing in a run that starts by fixing
the install. More broadly, this repo would benefit from a documented one-command test-env
bootstrap (the three requirements files plus `aws-xray-sdk`), since the pytest gate is otherwise
unrunnable from a clean checkout.