### PR TITLE
fix(frontend): label Automatic from the deployment-wide model pin (#275)

### DIFF
--- a/voc-datalake/frontend/src/pages/Settings/AiModelSection.test.tsx
+++ b/voc-datalake/frontend/src/pages/Settings/AiModelSection.test.tsx
@@ -1,5 +1,16 @@
 /**
  * @fileoverview Tests for the per-surface AI model picker (issue #96).
+ *
+ * REVERT MAP for the Automatic-label precedence (issue #275) — each assertion
+ * names the mutation it catches:
+ *   - labelling from `surface.default_id` while a global pin is deployed →
+ *     'names the deployment-wide pin in every Automatic option'.
+ *   - labelling from `data.model_id` unconditionally (so a null/absent pin
+ *     erases the tuned per-surface defaults) → 'shows each surface default
+ *     inside its Automatic option' and 'ignores an empty-string pin'.
+ *   - letting the pin drive the *selected* value, not just the Automatic label →
+ *     'keeps an explicit per-surface selection selected under a global pin'.
+ *   - dropping the id-string fallback → 'falls back to the pinned id'.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, within } from '@testing-library/react'
@@ -19,13 +30,16 @@ vi.mock('../../api/client', () => ({
 }))
 
 const SONNET5 = 'global.anthropic.claude-sonnet-5'
+const SONNET46 = 'global.anthropic.claude-sonnet-4-6'
 const OPUS5 = 'global.anthropic.claude-opus-5'
 const HAIKU45 = 'global.anthropic.claude-haiku-4-5-20251001-v1:0'
+
+const SURFACE_LABELS = ['AI Chat', 'Document Generation', 'Prototype Builder', 'Feedback Enrichment', 'Utilities']
 
 const modelSettingsFixture = {
   available_models: [
     { key: 'sonnet5', id: SONNET5, label: 'Claude Sonnet 5', description: 'Latest Sonnet' },
-    { key: 'sonnet46', id: 'global.anthropic.claude-sonnet-4-6', label: 'Claude Sonnet 4.6', description: 'Previous Sonnet' },
+    { key: 'sonnet46', id: SONNET46, label: 'Claude Sonnet 4.6', description: 'Previous Sonnet' },
     { key: 'opus5', id: OPUS5, label: 'Claude Opus 5', description: 'Deepest reasoning' },
     { key: 'haiku45', id: HAIKU45, label: 'Claude Haiku 4.5', description: 'Fastest' },
   ],
@@ -79,8 +93,7 @@ describe('AiModelSection', () => {
     render(<AiModelSection apiEndpoint="https://api.example.com" isAdmin />, { wrapper: createWrapper() })
 
     await waitFor(() => expect(screen.getByLabelText('AI Chat')).toBeInTheDocument())
-    const surfaceLabels = ['AI Chat', 'Document Generation', 'Prototype Builder', 'Feedback Enrichment', 'Utilities']
-    for (const label of surfaceLabels) {
+    for (const label of SURFACE_LABELS) {
       const select = screen.getByLabelText(label)
       expect(select).toHaveValue('')
     }
@@ -94,6 +107,70 @@ describe('AiModelSection', () => {
     expect(within(prototypeSelect).getByText('Automatic — Claude Opus 5')).toBeInTheDocument()
     const enrichmentSelect = screen.getByLabelText('Feedback Enrichment')
     expect(within(enrichmentSelect).getByText('Automatic — Claude Haiku 4.5')).toBeInTheDocument()
+  })
+
+  it('keeps each surface default in its Automatic option when the pin field is absent', async () => {
+    // Positive control for the null case above: `model_id` missing from the
+    // payload (not merely null) must not be read as a pin either.
+    const { model_id: _absent, ...withoutPinField } = modelSettingsFixture
+    mockGetModelSettings.mockResolvedValue(withoutPinField)
+    render(<AiModelSection apiEndpoint="https://api.example.com" isAdmin />, { wrapper: createWrapper() })
+
+    await waitFor(() => expect(screen.getByLabelText('Prototype Builder')).toBeInTheDocument())
+    expect(within(screen.getByLabelText('Prototype Builder')).getByText('Automatic — Claude Opus 5')).toBeInTheDocument()
+    expect(within(screen.getByLabelText('AI Chat')).getByText('Automatic — Claude Sonnet 5')).toBeInTheDocument()
+  })
+
+  it('names the deployment-wide pin in every Automatic option', async () => {
+    // The resolver ranks settings.model_id above SURFACE_DEFAULTS, so a pinned
+    // deployment runs Sonnet 4.6 everywhere — the label has to say so (#275).
+    mockGetModelSettings.mockResolvedValue({ ...modelSettingsFixture, model_id: SONNET46 })
+    render(<AiModelSection apiEndpoint="https://api.example.com" isAdmin />, { wrapper: createWrapper() })
+
+    await waitFor(() => expect(screen.getByLabelText('AI Chat')).toBeInTheDocument())
+    for (const label of SURFACE_LABELS) {
+      const select = screen.getByLabelText(label)
+      expect(within(select).getByText('Automatic — Claude Sonnet 4.6')).toBeInTheDocument()
+      expect(select).toHaveValue('')
+    }
+    // No surface keeps advertising its built-in default under a pin.
+    expect(screen.queryByText('Automatic — Claude Opus 5')).not.toBeInTheDocument()
+  })
+
+  it('keeps an explicit per-surface selection selected under a global pin', async () => {
+    // The pin only re-labels Automatic; a stored per-surface choice still wins
+    // in the resolver and must stay the selected option.
+    mockGetModelSettings.mockResolvedValue({
+      ...modelSettingsFixture,
+      model_id: SONNET46,
+      surfaces: modelSettingsFixture.surfaces.map((s) =>
+        s.key === 'chat' ? { ...s, selected: OPUS5 } : s,
+      ),
+    })
+    render(<AiModelSection apiEndpoint="https://api.example.com" isAdmin />, { wrapper: createWrapper() })
+
+    await waitFor(() => expect(screen.getByLabelText('AI Chat')).toHaveValue(OPUS5))
+    expect(within(screen.getByLabelText('AI Chat')).getByText('Automatic — Claude Sonnet 4.6')).toBeInTheDocument()
+  })
+
+  it('falls back to the pinned id when no friendly label is available', async () => {
+    mockGetModelSettings.mockResolvedValue({ ...modelSettingsFixture, model_id: 'global.anthropic.claude-unknown-9' })
+    render(<AiModelSection apiEndpoint="https://api.example.com" isAdmin />, { wrapper: createWrapper() })
+
+    await waitFor(() => expect(screen.getByLabelText('AI Chat')).toBeInTheDocument())
+    expect(
+      within(screen.getByLabelText('AI Chat')).getByText('Automatic — global.anthropic.claude-unknown-9'),
+    ).toBeInTheDocument()
+  })
+
+  it('ignores an empty-string pin and keeps the surface default', async () => {
+    // '' is not an allowlisted id; treating it as a pin would label Automatic
+    // with the empty string and lose the default entirely.
+    mockGetModelSettings.mockResolvedValue({ ...modelSettingsFixture, model_id: '' })
+    render(<AiModelSection apiEndpoint="https://api.example.com" isAdmin />, { wrapper: createWrapper() })
+
+    await waitFor(() => expect(screen.getByLabelText('Prototype Builder')).toBeInTheDocument())
+    expect(within(screen.getByLabelText('Prototype Builder')).getByText('Automatic — Claude Opus 5')).toBeInTheDocument()
   })
 
   it('saves a per-surface selection and shows the Saved badge', async () => {

--- a/voc-datalake/frontend/src/pages/Settings/AiModelSection.tsx
+++ b/voc-datalake/frontend/src/pages/Settings/AiModelSection.tsx
@@ -10,6 +10,9 @@
  * Free-form model IDs are rejected server-side, and the PUT is admin-gated
  * server-side too (not just hidden in the UI).
  *
+ * The Automatic label follows the resolver's precedence, not just the surface
+ * default — see the comment on `pinnedId` below (issue #275).
+ *
  * Model NAMES are product names (identical in every language), so they render
  * from the server-provided `label` and are intentionally NOT in locale files —
  * the i18n gate rejects same-as-English values. Surface labels/descriptions and
@@ -113,20 +116,37 @@ function AiModelSectionBody({ data, isLoading, isError, isSaving, savedSurface, 
   // Model id → display label (product name, served by the backend).
   const labelForId = new Map(data.available_models.map((model) => [model.id, model.label]))
 
+  // 🔑 The deployment-wide pin (`settings.model_id`, seeded by
+  // `-c defaultModelId=<id>`) outranks every surface's built-in default in
+  // shared/model_config.py: per-surface override > global pin > SURFACE_DEFAULTS.
+  // Labelling Automatic from `surface.default_id` alone — which is what this did
+  // before #275 — made a pinned deployment advertise a model it never invokes,
+  // and invited an admin to "correct" it by explicitly selecting the advertised
+  // model, which in a workshop account cannot be invoked at all. Truthiness, not
+  // `?? null`: the field can arrive absent or as '' from an older payload, and
+  // neither is a pin. Tests: 'names the deployment-wide pin in every Automatic
+  // option' and 'ignores an empty-string pin and keeps the surface default'.
+  const pinnedId = data.model_id ? data.model_id : null
+
   return (
     <fieldset className="space-y-3" disabled={isSaving}>
       <legend className="sr-only">{t('aiModel.title')}</legend>
-      {data.surfaces.map((surface) => (
-        <SurfaceRow
-          key={surface.key}
-          surfaceKey={surface.key}
-          selected={surface.selected}
-          defaultLabel={labelForId.get(surface.default_id) ?? surface.default_id}
-          models={data.available_models}
-          justSaved={savedSurface === surface.key}
-          onSelect={(modelId) => onSelect(surface.key, modelId)}
-        />
-      ))}
+      {data.surfaces.map((surface) => {
+        // What Automatic actually resolves to for this surface. The pin does not
+        // touch `selected`: a stored per-surface choice still outranks it.
+        const effectiveId = pinnedId ?? surface.default_id
+        return (
+          <SurfaceRow
+            key={surface.key}
+            surfaceKey={surface.key}
+            selected={surface.selected}
+            automaticLabel={labelForId.get(effectiveId) ?? effectiveId}
+            models={data.available_models}
+            justSaved={savedSurface === surface.key}
+            onSelect={(modelId) => onSelect(surface.key, modelId)}
+          />
+        )
+      })}
     </fieldset>
   )
 }
@@ -134,13 +154,14 @@ function AiModelSectionBody({ data, isLoading, isError, isSaving, savedSurface, 
 interface SurfaceRowProps {
   readonly surfaceKey: string
   readonly selected: string | null
-  readonly defaultLabel: string
+  /** Label for the model Automatic resolves to — the global pin when one is deployed. */
+  readonly automaticLabel: string
   readonly models: ModelSettings['available_models']
   readonly justSaved: boolean
   readonly onSelect: (modelId: string | null) => void
 }
 
-function SurfaceRow({ surfaceKey, selected, defaultLabel, models, justSaved, onSelect }: SurfaceRowProps) {
+function SurfaceRow({ surfaceKey, selected, automaticLabel, models, justSaved, onSelect }: SurfaceRowProps) {
   const { t } = useTranslation('settings')
   const selectId = `ai-model-${surfaceKey}`
   return (
@@ -163,7 +184,7 @@ function SurfaceRow({ surfaceKey, selected, defaultLabel, models, justSaved, onS
           value={selected ?? ''}
           onChange={(event) => onSelect(event.target.value === '' ? null : event.target.value)}
         >
-          <option value="">{t('aiModel.automaticOption', { model: defaultLabel })}</option>
+          <option value="">{t('aiModel.automaticOption', { model: automaticLabel })}</option>
           {models.map((model) => (
             <option key={model.id} value={model.id}>{model.label}</option>
           ))}


### PR DESCRIPTION
## Summary

Resolves #275.

`GET /settings/model` already returns everything the card needs: each surface's built-in `default_id` **and** the deployment-wide `model_id` override. `AiModelSectionBody` built every `Automatic — X` label from `default_id` alone, but `shared/model_config.py` resolves in the order *per-surface override > global pin (`settings.model_id`) > `SURFACE_DEFAULTS`*. A deployment with `-c defaultModelId=<id>` therefore advertised a model it never invokes on all five surfaces.

The change is one derived value in the one place the label is computed:

- `pinnedId` — the returned `model_id` when truthy, else `null`.
- `effectiveId` — `pinnedId ?? surface.default_id`, mapped through the **existing** `labelForId` map from `available_models`, with the existing `?? effectiveId` id-string fallback.
- `SurfaceRow`'s `defaultLabel` prop is renamed `automaticLabel`, because it is no longer necessarily the surface default. No other prop, no new translation key, no change to the `aiModel.automaticOption` shape.

`selected` is deliberately untouched — the pin only re-labels the Automatic option, so a stored per-surface choice remains the selected option, matching the resolver.

### Deliberately out of scope

Suggestion 2 in the issue (marking or disabling options the account cannot invoke, via `ListFoundationModels` / `GetFoundationModelAvailability`) is **not** in this PR. It needs a new Bedrock permission on the settings Lambda, a cache, and a response-shape change; the task asks to keep availability discovery and invocability checks separate. The label fix alone removes the trap the issue describes as worst — an admin reading a wrong Automatic label and "correcting" it to an uninvocable model.

I also did not add `Automatic — X (pinned for this deployment)` as the issue sketches: that suffix is new user-facing English and would need eight locale files plus a new key. The label now names the right model, which is the acceptance criterion; the parenthetical is a separate copy decision for a maintainer.

## Acceptance criteria

| Criterion | Test |
|---|---|
| Non-null `model_id`, null per-surface selections → every Automatic names the pin | `names the deployment-wide pin in every Automatic option` |
| `model_id` absent or null → Automatic keeps naming `default_id` | `keeps each surface default in its Automatic option when the pin field is absent`, plus the pre-existing `shows each surface default inside its Automatic option` (fixture has `model_id: null`) |
| A non-null per-surface `selected` stays the selected option | `keeps an explicit per-surface selection selected under a global pin` |
| Unknown effective id degrades to the id string | `falls back to the pinned id when no friendly label is available` |

## Build and test results

Run from the repo root unless noted. `node_modules` was absent in the container, so `npm ci` was run in `voc-datalake/` and `voc-datalake/frontend/` first.

| Command | Result |
|---|---|
| `npx vitest --run src/pages/Settings/AiModelSection.test.tsx` (focused) | **PASS** — 13/13 |
| `npm run test` (full frontend vitest) | **PASS** — 192 files, 3285 tests, exit 0 |
| `npm run typecheck` (frontend src) | **PASS** — clean |
| `npm run lint:frontend` (ESLint `--max-warnings 0`) | **PASS** — clean |
| `npm run build` (`tsc -b && vite build`) | **PASS** — built in 9.36s |
| `npm run typecheck:tests` | 87 errors — **pre-existing baseline**, byte-identical count with my change stashed; none in the files I touched (`configStore.test.ts`, `test/test-utils.tsx` etc.) |
| `npm run i18n:check` | exit 1 — **pre-existing baseline**, same exit with my change stashed; findings are hardcoded strings in `DataExplorer/`, `FeedbackDetail/`, `ChatSidebar/` and others, untouched here |

`mise run build` was attempted as instructed and reports `no tasks defined in /workspace/...` — this repo has no mise task file, so the equivalent `npm run build` above is the real build gate.

### Test integrity (red-then-green + mutation)

- Against unfixed `AiModelSection.tsx`, the new assertions were **3 failed / 10 passed**. The two that passed before the fix are intentional negative controls (absent-pin and empty-string-pin must keep the surface default, which the old code did by accident).
- After the fix: **13 passed**.
- Mutation check on the truthiness guard: replacing `data.model_id ? data.model_id : null` with `data.model_id ?? null` → **caught**, `ignores an empty-string pin and keeps the surface default` fails. Working tree restored and re-verified green.

## Agent notes

**What went well.** The issue's root-cause analysis was accurate and the API already returned `model_id`, so the fix needed no backend change, no new prop plumbing beyond a rename, and no new dependency — one derived value at the single place the label is computed. Writing the tests first paid off immediately: it surfaced that two of the five new cases pass against the *unfixed* code, which correctly identifies them as controls rather than regression coverage, and that distinction is now recorded in the REVERT MAP instead of being implied.

**What was difficult.** Separating my results from the container's baseline. Two gates (`typecheck:tests`, `i18n:check`) fail on `development` already, and the setup notes said both the initial build and lint "FAILED" — that turned out to be missing `node_modules` plus the absent mise task, not a broken tree. I stashed and re-ran each failing gate to pin the baseline rather than guess; that is the only way to report these honestly. Also worth flagging that the repo's `npm run check` chains everything with `&&`, so on this tree it can never reach the later legs — triaging by individual script is the only workable approach.

**Conventions discovered.** Comments here carry the *argument*, not the mechanics — the load-bearing one on `pinnedId` records what the previous implementation was, why it was wrong, and which named test fails if it returns. Tests are named as outcomes (`names the deployment-wide pin ...`), and the module docstring carries a REVERT MAP mapping each mutation to the assertion that catches it. Model product names are deliberately absent from locale files because the i18n gate rejects same-as-English values, which is exactly why reusing the server-provided `label` mapping was the right lever rather than adding a key.

**Suggestions for future tasks.** (1) The uninvocable-model half of #275 deserves its own issue — it is a backend/IAM change, not a label change, and bundling it would have hidden this one-value fix. (2) `typecheck:tests` at 87 errors and `i18n:check` red on `development` mean neither can gate a PR today; a "no new findings" baseline check (the pattern `ruff.toml` already uses) would make them useful again. (3) A `mise` task file, or a blueprint `pipeline.buildCommand` of `npm run build`, would turn on the build-regression gate that the harness reported as inert.

## Verification

```abca-verify
selector #ai-model-chat
selector #ai-model-prototype
text #ai-model-chat "Automatic"
no-console-errors
```

The AI Models card is admin-only and renders one `<select id="ai-model-{surface}">` per surface, with the Automatic option present on load regardless of data — the assertions target that chrome. Which *model name* follows "Automatic" depends on whether the preview deployment sets a global pin, so I assert the stable prefix rather than a specific model; the pin-versus-default branch itself is covered by the Vitest cases above.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).