### PR TITLE
fix(api): preserve typed errors and stop leaking exception text (#263)

### DIFF
--- a/voc-datalake/lambda/api/data_explorer_handler.py
+++ b/voc-datalake/lambda/api/data_explorer_handler.py
@@ -21,7 +21,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from shared.logging import logger, tracer
 from shared.aws import get_s3_client, get_dynamodb_resource, get_sqs_client
 from shared.api import create_api_resolver, api_handler, DecimalEncoder
-from shared.exceptions import ConfigurationError, ValidationError, NotFoundError, ServiceError
+from shared.exceptions import ApiError, ConfigurationError, ValidationError, NotFoundError, ServiceError
 from shared.indexes import FEEDBACK_BY_ID_INDEX
 
 s3_client = get_s3_client()
@@ -38,6 +38,28 @@ AVAILABLE_BUCKETS = {
 }
 
 app = create_api_resolver()
+
+
+# Client-facing text for an unexpected failure, one message per operation.
+#
+# 🔑 Deliberately free of `str(e)`: the exceptions these blocks catch are boto's,
+# and their text carries internal detail — the FEEDBACK_TABLE name, the pk/sk key
+# structure, the bucket name, an S3 request id. `shared/api.py`'s ServiceError
+# handler returns `ex.message` verbatim to the caller, so interpolating the
+# exception published all of that to anyone who could provoke a 500 (issue #263).
+# The detail is not lost: every site logs it with `logger.exception` first, which
+# is where an operator can correlate it by request id.
+#
+# Each broad `try` in this file also re-raises `ApiError` ahead of its
+# `except Exception`, so a typed ValidationError/NotFoundError raised INSIDE the
+# block keeps its own status instead of being rewrapped as this 500.
+FAILED_LIST = 'Failed to list S3 objects'
+FAILED_PREVIEW = 'Failed to preview file'
+FAILED_SAVE = 'Failed to save file'
+FAILED_DELETE = 'Failed to delete file'
+FAILED_UPDATE_FEEDBACK = 'Failed to update feedback'
+FAILED_DELETE_FEEDBACK = 'Failed to delete feedback'
+FAILED_BUCKET_STATS = 'Failed to read bucket contents'
 
 
 def decimal_to_native(obj):
@@ -119,9 +141,11 @@ def list_s3_objects():
             'prefix': prefix.rstrip('/')
         }
         
+    except ApiError:
+        raise
     except Exception as e:
         logger.exception(f"Failed to list S3 objects: {e}")
-        raise ServiceError(f'Failed to list S3 objects: {str(e)}')
+        raise ServiceError(FAILED_LIST) from e
 
 
 @app.get("/data-explorer/s3/preview")
@@ -190,9 +214,11 @@ def preview_s3_file():
             
     except s3_client.exceptions.NoSuchKey:
         raise NotFoundError('File not found')
+    except ApiError:
+        raise
     except Exception as e:
         logger.exception(f"Failed to preview S3 file: {e}")
-        raise ServiceError(f'Failed to preview file: {str(e)}')
+        raise ServiceError(FAILED_PREVIEW) from e
 
 
 @app.put("/data-explorer/s3")
@@ -244,10 +270,12 @@ def save_s3_file():
                 logger.warning(f"Failed to sync to DynamoDB: {e}")
         
         return {'success': True, 'message': 'File saved', 'key': key, 'synced': synced}
-        
+
+    except ApiError:
+        raise
     except Exception as e:
         logger.exception(f"Failed to save S3 file: {e}")
-        raise ServiceError(f'Failed to save file: {str(e)}')
+        raise ServiceError(FAILED_SAVE) from e
 
 
 @app.delete("/data-explorer/s3")
@@ -271,9 +299,11 @@ def delete_s3_file():
     try:
         s3_client.delete_object(Bucket=bucket_name, Key=key)
         return {'success': True, 'message': 'File deleted', 'key': key}
+    except ApiError:
+        raise
     except Exception as e:
         logger.exception(f"Failed to delete S3 file: {e}")
-        raise ServiceError(f'Failed to delete file: {str(e)}')
+        raise ServiceError(FAILED_DELETE) from e
 
 
 # ============================================
@@ -389,10 +419,17 @@ def save_feedback():
                     logger.warning(f"Failed to sync to S3: {e}")
         
         return {'success': True, 'message': 'Feedback updated', 'synced': synced}
-        
+
+    # 🔑 Ahead of `except Exception`, because the two typed raises this block
+    # contains are the whole point of the route's contract: 'No fields to update'
+    # is a 400 and 'Feedback not found' is a 404. Caught by the catch-all they
+    # both became a 500, so a client could not tell its own bad request from an
+    # outage (issue #263).
+    except ApiError:
+        raise
     except Exception as e:
         logger.exception(f"Failed to update feedback: {e}")
-        raise ServiceError(f'Failed to update feedback: {str(e)}')
+        raise ServiceError(FAILED_UPDATE_FEEDBACK) from e
 
 
 @app.delete("/data-explorer/feedback")
@@ -429,11 +466,11 @@ def delete_feedback():
         
         return {'success': True, 'message': 'Feedback deleted', 'feedback_id': feedback_id}
         
-    except NotFoundError:
+    except ApiError:
         raise
     except Exception as e:
         logger.exception(f"Failed to delete feedback: {e}")
-        raise ServiceError(f'Failed to delete feedback: {str(e)}')
+        raise ServiceError(FAILED_DELETE_FEEDBACK) from e
 
 
 @app.get("/data-explorer/buckets")
@@ -479,8 +516,12 @@ def get_data_stats():
                 bucket_info['folders'] = folders
                 bucket_info['folder_count'] = len(folders)
             except Exception as e:
-                logger.warning(f"Failed to get stats for bucket {bucket_name}: {e}")
-                bucket_info['error'] = str(e)
+                logger.exception(f"Failed to get stats for bucket {bucket_name}: {e}")
+                # Generic, for the same reason as the module constants above: this
+                # field is returned to the caller inside a 200 body, so `str(e)`
+                # here leaked boto text (bucket name, access-denied detail,
+                # request id) just as surely as a ServiceError message would.
+                bucket_info['error'] = FAILED_BUCKET_STATS
             stats['s3']['buckets'].append(bucket_info)
     
     return stats

--- a/voc-datalake/lambda/api/data_explorer_handler.py
+++ b/voc-datalake/lambda/api/data_explorer_handler.py
@@ -16,6 +16,8 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any
 
+from botocore.exceptions import ClientError
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from shared.logging import logger, tracer
@@ -52,7 +54,10 @@ app = create_api_resolver()
 #
 # Each broad `try` in this file also re-raises `ApiError` ahead of its
 # `except Exception`, so a typed ValidationError/NotFoundError raised INSIDE the
-# block keeps its own status instead of being rewrapped as this 500.
+# block keeps its own status instead of being rewrapped as this 500. Only
+# `save_feedback`'s and `delete_feedback`'s are reachable today — the S3 routes
+# raise nothing typed inside their `try`, so theirs are precautionary against a
+# future edit, in the same spirit as `feedback_form_handler.py`'s two.
 FAILED_LIST = 'Failed to list S3 objects'
 FAILED_PREVIEW = 'Failed to preview file'
 FAILED_SAVE = 'Failed to save file'
@@ -60,6 +65,15 @@ FAILED_DELETE = 'Failed to delete file'
 FAILED_UPDATE_FEEDBACK = 'Failed to update feedback'
 FAILED_DELETE_FEEDBACK = 'Failed to delete feedback'
 FAILED_BUCKET_STATS = 'Failed to read bucket contents'
+
+# The error codes S3 uses for "that key is not there", which differ by operation.
+#
+# 🔑 `head_object` does NOT raise the modelled `NoSuchKey`: a HEAD response has no
+# body, so botocore has nothing to build the typed shape from and raises a bare
+# ClientError with code '404'. Only `get_object` raises `NoSuchKey`. Matching on
+# the code covers both, and is why `preview_s3_file` can answer 404 for a missing
+# file at all — before this it fell through to the catch-all and returned 500.
+S3_MISSING_KEY_CODES = ('404', 'NoSuchKey', 'NotFound')
 
 
 def decimal_to_native(obj):
@@ -144,7 +158,7 @@ def list_s3_objects():
     except ApiError:
         raise
     except Exception as e:
-        logger.exception(f"Failed to list S3 objects: {e}")
+        logger.exception("Failed to list S3 objects")
         raise ServiceError(FAILED_LIST) from e
 
 
@@ -212,12 +226,22 @@ def preview_s3_file():
         except json.JSONDecodeError:
             return {'content': content, 'size': size, 'contentType': content_type, 'key': key}
             
-    except s3_client.exceptions.NoSuchKey:
-        raise NotFoundError('File not found')
+    except s3_client.exceptions.NoSuchKey as e:
+        # The get_object path. Kept alongside the ClientError clause below rather
+        # than folded into it: NoSuchKey IS a ClientError subclass, but relying on
+        # that would make the 404 depend on botocore's modelling choices.
+        raise NotFoundError('File not found') from e
+    except ClientError as e:
+        # The head_object path — see S3_MISSING_KEY_CODES. Anything that is not a
+        # missing key falls through to the generic 500 below.
+        if e.response.get('Error', {}).get('Code') in S3_MISSING_KEY_CODES:
+            raise NotFoundError('File not found') from e
+        logger.exception("Failed to preview S3 file")
+        raise ServiceError(FAILED_PREVIEW) from e
     except ApiError:
         raise
     except Exception as e:
-        logger.exception(f"Failed to preview S3 file: {e}")
+        logger.exception("Failed to preview S3 file")
         raise ServiceError(FAILED_PREVIEW) from e
 
 
@@ -274,7 +298,7 @@ def save_s3_file():
     except ApiError:
         raise
     except Exception as e:
-        logger.exception(f"Failed to save S3 file: {e}")
+        logger.exception("Failed to save S3 file")
         raise ServiceError(FAILED_SAVE) from e
 
 
@@ -302,7 +326,7 @@ def delete_s3_file():
     except ApiError:
         raise
     except Exception as e:
-        logger.exception(f"Failed to delete S3 file: {e}")
+        logger.exception("Failed to delete S3 file")
         raise ServiceError(FAILED_DELETE) from e
 
 
@@ -428,7 +452,7 @@ def save_feedback():
     except ApiError:
         raise
     except Exception as e:
-        logger.exception(f"Failed to update feedback: {e}")
+        logger.exception("Failed to update feedback")
         raise ServiceError(FAILED_UPDATE_FEEDBACK) from e
 
 
@@ -469,7 +493,7 @@ def delete_feedback():
     except ApiError:
         raise
     except Exception as e:
-        logger.exception(f"Failed to delete feedback: {e}")
+        logger.exception("Failed to delete feedback")
         raise ServiceError(FAILED_DELETE_FEEDBACK) from e
 
 
@@ -515,8 +539,11 @@ def get_data_stats():
                 folders = [p['Prefix'].rstrip('/') for p in response.get('CommonPrefixes', []) if p['Prefix'].rstrip('/')]
                 bucket_info['folders'] = folders
                 bucket_info['folder_count'] = len(folders)
-            except Exception as e:
-                logger.exception(f"Failed to get stats for bucket {bucket_name}: {e}")
+            # No `as e`: this block swallows rather than re-raises, and nothing below
+            # needs the object — `logger.exception` reads the in-flight exception
+            # from sys.exc_info() itself, so binding it would only be an unused name.
+            except Exception:
+                logger.exception(f"Failed to get stats for bucket {bucket_name}")
                 # Generic, for the same reason as the module constants above: this
                 # field is returned to the caller inside a 200 body, so `str(e)`
                 # here leaked boto text (bucket name, access-denied detail,

--- a/voc-datalake/lambda/api/test/test_data_explorer_handler.py
+++ b/voc-datalake/lambda/api/test/test_data_explorer_handler.py
@@ -3,6 +3,8 @@ Tests for data_explorer_handler.py - /data-explorer/* endpoints.
 Full CRUD for S3 raw data and DynamoDB feedback.
 """
 import json
+import os
+import sys
 import pytest
 from unittest.mock import patch, MagicMock
 from decimal import Decimal
@@ -18,9 +20,16 @@ _SENTINEL = 'SENTINEL_INTERNAL_DETAIL'
 
 # The two internal names a botocore fault realistically drags along on these
 # routes, both of which are in this handler's own configuration: the DynamoDB table
-# and the S3 bucket (conftest sets both env vars).
-_INTERNAL_TABLE = 'test-feedback'
-_INTERNAL_BUCKET = 'test-raw-data-bucket'
+# and the S3 bucket.
+#
+# 🔑 Read from the environment conftest sets, which is the same place the handler
+# reads them, rather than copied as literals. These are used in ABSENCE assertions,
+# where a stale expected value passes instead of failing: copy 'test-feedback' here
+# and change conftest, and `assert name not in body` keeps going green while no
+# longer checking any name the handler actually holds. Subscript, not `.get`, so a
+# missing var fails at collection rather than degrading the check to a no-op.
+_INTERNAL_TABLE = os.environ['FEEDBACK_TABLE']
+_INTERNAL_BUCKET = os.environ['RAW_DATA_BUCKET']
 
 
 def _aws_failure(operation: str) -> ClientError:
@@ -38,6 +47,27 @@ def _aws_failure(operation: str) -> ClientError:
         }},
         operation,
     )
+
+
+def _recording_logger() -> MagicMock:
+    """A stand-in logger that records what `logger.exception` would really emit.
+
+    🔑 The handlers pass a plain message and no longer interpolate `{e}`, because
+    Powertools' `Logger.exception` attaches the AMBIENT exception — its text, name
+    and a structured stack trace — to the record by itself. A bare MagicMock records
+    only the call args, so asserting on `call_args` alone would no longer see the
+    fault and the positive control below would silently become vacuous. This reads
+    `sys.exc_info()` at call time, which is the same source the real logger uses.
+    """
+    mock_logger = MagicMock()
+    emitted: list[str] = []
+
+    def _record(*args, **kwargs):
+        emitted.append(f'{args} {kwargs} exc={sys.exc_info()[1]!r}')
+
+    mock_logger.exception.side_effect = _record
+    mock_logger.emitted_exceptions = emitted
+    return mock_logger
 
 
 # Every route in this handler that answers an AWS failure with a 500, as
@@ -208,28 +238,106 @@ class TestPreviewS3File:
     def test_returns_error_for_missing_file(
         self, mock_s3, api_gateway_event, lambda_context
     ):
-        """Returns error when file not found."""
+        """Returns 404 for the fault head_object really raises on a missing key.
+
+        🔑 A bare ``ClientError`` with code ``404``, NOT ``NoSuchKey``: a HEAD
+        response carries no body, so botocore has nothing to model the typed shape
+        from and only ``get_object`` raises ``NoSuchKey``. An earlier version of
+        this test injected a synthetic ``NoSuchKey`` from ``head_object`` — a shape
+        production cannot produce — so it passed while a real missing file fell
+        through to the catch-all and answered 500.
+        """
         # Arrange
-        class NoSuchKey(Exception):
-            pass
         mock_s3.exceptions = MagicMock()
-        mock_s3.exceptions.NoSuchKey = NoSuchKey
-        mock_s3.head_object.side_effect = NoSuchKey()
-        
+        mock_s3.exceptions.NoSuchKey = type('NoSuchKey', (Exception,), {})
+        mock_s3.head_object.side_effect = ClientError(
+            {'Error': {'Code': '404', 'Message': 'Not Found'}}, 'HeadObject'
+        )
+
         from data_explorer_handler import lambda_handler
         event = api_gateway_event(
             method='GET',
             path='/data-explorer/s3/preview',
             query_params={'bucket': 'raw-data', 'key': 'nonexistent.json'}
         )
-        
+
         # Act
         response = lambda_handler(event, lambda_context)
         body = json.loads(response['body'])
-        
+
         # Assert - now returns 404 with error key
         assert response['statusCode'] == 404
-        assert 'error' in body
+        assert 'not found' in body['error'].lower()
+
+    @patch('data_explorer_handler.s3_client')
+    def test_returns_404_for_the_get_object_missing_key_shape_too(
+        self, mock_s3, api_gateway_event, lambda_context
+    ):
+        """The typed ``NoSuchKey`` path (get_object) still answers 404.
+
+        The 404-by-code clause is what covers ``head_object``; this pins that
+        adding it did not cost the modelled shape the other call raises.
+        """
+        # Arrange — HEAD succeeds, the body read is what fails.
+        mock_s3.exceptions = MagicMock()
+        mock_s3.exceptions.NoSuchKey = type('NoSuchKey', (Exception,), {})
+        mock_s3.head_object.return_value = {
+            'ContentLength': 10, 'ContentType': 'application/json'
+        }
+        mock_s3.get_object.side_effect = mock_s3.exceptions.NoSuchKey()
+
+        from data_explorer_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET',
+            path='/data-explorer/s3/preview',
+            query_params={'bucket': 'raw-data', 'key': 'vanished.json'}
+        )
+
+        # Act
+        response = lambda_handler(event, lambda_context)
+
+        # Assert
+        assert response['statusCode'] == 404
+
+    @patch('data_explorer_handler.s3_client')
+    def test_non_404_client_error_is_still_a_generic_500(
+        self, mock_s3, api_gateway_event, lambda_context
+    ):
+        """An AccessDenied keeps its 500 and leaks no exception text.
+
+        The negative half of the clause above: matching a missing key by error code
+        must not turn EVERY ClientError into a 404, and the generic message must
+        still apply on the path that now catches ClientError explicitly.
+        """
+        # Arrange
+        mock_s3.exceptions = MagicMock()
+        mock_s3.exceptions.NoSuchKey = type('NoSuchKey', (Exception,), {})
+        mock_s3.head_object.side_effect = ClientError(
+            {'Error': {
+                'Code': 'AccessDenied',
+                'Message': f'{_SENTINEL} on {_INTERNAL_BUCKET}',
+            }},
+            'HeadObject',
+        )
+
+        from data_explorer_handler import lambda_handler
+        event = api_gateway_event(
+            method='GET',
+            path='/data-explorer/s3/preview',
+            query_params={'bucket': 'raw-data', 'key': 'forbidden.json'}
+        )
+
+        # Act
+        response = lambda_handler(event, lambda_context)
+        raw_body = response['body']
+
+        # Assert
+        assert response['statusCode'] == 500
+        for leak in (_SENTINEL, _INTERNAL_BUCKET, 'AccessDenied'):
+            assert leak not in raw_body, (
+                f'{leak!r} must not reach the client; body was: {raw_body}'
+            )
+        assert json.loads(raw_body)['error'] == 'Failed to preview file'
 
 
 class TestSaveS3File:
@@ -637,9 +745,10 @@ class TestErrorDisclosure:
     ):
         """Returns a 500 whose body names no table, bucket, key or boto text."""
         # Arrange — fail whichever AWS call the route makes.
+        mock_logger = _recording_logger()
         with patch('data_explorer_handler.s3_client') as mock_s3, \
              patch('data_explorer_handler.dynamodb') as mock_dynamodb, \
-             patch('data_explorer_handler.logger') as mock_logger:
+             patch('data_explorer_handler.logger', mock_logger):
             # A real exception class, so the `except s3_client.exceptions.NoSuchKey`
             # clause on the preview route is catchable and does not match.
             mock_s3.exceptions = MagicMock()
@@ -672,8 +781,11 @@ class TestErrorDisclosure:
             assert json.loads(raw_body)['error'].startswith('Failed to ')
 
             # Positive control: without this, "absent from the body" would also
-            # hold for a fault that was swallowed and never recorded.
-            logged = ' '.join(str(c.args) for c in mock_logger.exception.call_args_list)
+            # hold for a fault that was swallowed and never recorded. Asserts on the
+            # exception in flight at the call, not on the message args — the handler
+            # no longer interpolates it, Powertools attaches it (see
+            # _recording_logger).
+            logged = ' '.join(mock_logger.emitted_exceptions)
             assert _SENTINEL in logged, (
                 f'the fault must be logged for an operator; exception() calls: {logged}'
             )
@@ -687,9 +799,11 @@ class TestErrorDisclosure:
         exactly why it was missed: `bucket_info['error'] = str(e)` leaked the same
         detail as a ServiceError message would.
         """
-        # Arrange
+        # Arrange — s3_client only: /stats reads FEEDBACK_TABLE as a NAME and makes
+        # no DynamoDB call, so there is no client to stub there.
+        mock_logger = _recording_logger()
         with patch('data_explorer_handler.s3_client') as mock_s3, \
-             patch('data_explorer_handler.logger') as mock_logger:
+             patch('data_explorer_handler.logger', mock_logger):
             mock_s3.list_objects_v2.side_effect = _aws_failure('ListObjectsV2')
 
             from data_explorer_handler import lambda_handler
@@ -709,7 +823,9 @@ class TestErrorDisclosure:
                     f'{leak!r} must not reach the client; body was: {raw_body}'
                 )
 
-            logged = ' '.join(str(c.args) for c in mock_logger.exception.call_args_list)
+            # Positive control, as above: the exception in flight at the call, since
+            # the message no longer interpolates it.
+            logged = ' '.join(mock_logger.emitted_exceptions)
             assert _SENTINEL in logged, (
                 f'the fault must be logged for an operator; exception() calls: {logged}'
             )

--- a/voc-datalake/lambda/api/test/test_data_explorer_handler.py
+++ b/voc-datalake/lambda/api/test/test_data_explorer_handler.py
@@ -3,8 +3,67 @@ Tests for data_explorer_handler.py - /data-explorer/* endpoints.
 Full CRUD for S3 raw data and DynamoDB feedback.
 """
 import json
+import pytest
 from unittest.mock import patch, MagicMock
 from decimal import Decimal
+
+from botocore.exceptions import ClientError
+
+
+# A string no legitimate response body has any reason to contain, planted in the
+# text of the AWS fault the handler catches. Whether it comes back out is the whole
+# question in TestErrorDisclosure below: `shared/api.py` returns a ServiceError's
+# `.message` verbatim, so an `f'...: {str(e)}'` message published it (issue #263).
+_SENTINEL = 'SENTINEL_INTERNAL_DETAIL'
+
+# The two internal names a botocore fault realistically drags along on these
+# routes, both of which are in this handler's own configuration: the DynamoDB table
+# and the S3 bucket (conftest sets both env vars).
+_INTERNAL_TABLE = 'test-feedback'
+_INTERNAL_BUCKET = 'test-raw-data-bucket'
+
+
+def _aws_failure(operation: str) -> ClientError:
+    """An AWS client error whose message carries internal detail.
+
+    Shaped like the real thing: botocore's ``str()`` includes the error code, the
+    message and the operation name, so interpolating it into a client-facing
+    message leaks all three plus whatever the service put in the text — here the
+    table and bucket names.
+    """
+    return ClientError(
+        {'Error': {
+            'Code': 'InternalServerError',
+            'Message': f'{_SENTINEL} on {_INTERNAL_TABLE}/{_INTERNAL_BUCKET} key pk=SOURCE#x sk=FEEDBACK#y',
+        }},
+        operation,
+    )
+
+
+# Every route in this handler that answers an AWS failure with a 500, as
+# (route description, event kwargs). Exercised as a set rather than through one
+# representative case: the leak was per-route, so one fixed route proves nothing
+# about the next.
+_DISCLOSURE_ROUTES = [
+    ('GET /data-explorer/s3', {
+        'method': 'GET', 'path': '/data-explorer/s3',
+        'query_params': {'bucket': 'raw-data'}}),
+    ('GET /data-explorer/s3/preview', {
+        'method': 'GET', 'path': '/data-explorer/s3/preview',
+        'query_params': {'bucket': 'raw-data', 'key': 'webscraper/x.json'}}),
+    ('PUT /data-explorer/s3', {
+        'method': 'PUT', 'path': '/data-explorer/s3',
+        'body': {'bucket': 'raw-data', 'key': 'a.json', 'content': '{}'}}),
+    ('DELETE /data-explorer/s3', {
+        'method': 'DELETE', 'path': '/data-explorer/s3',
+        'query_params': {'bucket': 'raw-data', 'key': 'a.json'}}),
+    ('PUT /data-explorer/feedback', {
+        'method': 'PUT', 'path': '/data-explorer/feedback',
+        'body': {'feedback_id': 'fb-1', 'data': {'original_text': 'edit'}}}),
+    ('DELETE /data-explorer/feedback', {
+        'method': 'DELETE', 'path': '/data-explorer/feedback',
+        'query_params': {'feedback_id': 'fb-1'}}),
+]
 
 
 class TestListS3Objects:
@@ -355,6 +414,73 @@ class TestSaveFeedback:
         assert 'required' in body['error'].lower()
 
 
+    @patch('data_explorer_handler.dynamodb')
+    def test_returns_400_when_no_editable_fields_supplied(
+        self, mock_dynamodb, api_gateway_event, lambda_context
+    ):
+        """Returns 400, not 500, when the payload carries no updatable field.
+
+        Regression (#263): `ValidationError('No fields to update')` is raised
+        INSIDE save_feedback's broad `try`, whose `except Exception` rewrapped it
+        as a ServiceError — so a client's bad request came back as a 500 and it
+        could not tell its own mistake from an outage.
+        """
+        # Arrange — source_platform is real data but not an updatable field, so the
+        # update expression ends up empty.
+        mock_table = MagicMock()
+        mock_dynamodb.Table.return_value = mock_table
+
+        from data_explorer_handler import lambda_handler
+        event = api_gateway_event(
+            method='PUT',
+            path='/data-explorer/feedback',
+            body={
+                'feedback_id': 'fb-123',
+                'data': {'source_platform': 'webscraper', 'not_updatable': 'x'},
+            }
+        )
+
+        # Act
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        # Assert
+        assert response['statusCode'] == 400
+        assert 'no fields to update' in body['error'].lower()
+        # Nothing was written: the refusal happens before any update_item.
+        mock_table.update_item.assert_not_called()
+
+    @patch('data_explorer_handler.dynamodb')
+    def test_returns_404_when_updating_missing_feedback(
+        self, mock_dynamodb, api_gateway_event, lambda_context
+    ):
+        """Returns 404, not 500, when the feedback record does not exist.
+
+        Regression (#263): `NotFoundError('Feedback not found')` sat inside the
+        same broad `try` as above, so an edit of a deleted record answered 500.
+        """
+        # Arrange — no source_platform forces the GSI lookup, which finds nothing.
+        mock_table = MagicMock()
+        mock_dynamodb.Table.return_value = mock_table
+        mock_table.query.return_value = {'Items': []}
+
+        from data_explorer_handler import lambda_handler
+        event = api_gateway_event(
+            method='PUT',
+            path='/data-explorer/feedback',
+            body={'feedback_id': 'ghost', 'data': {'original_text': 'edit'}}
+        )
+
+        # Act
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        # Assert
+        assert response['statusCode'] == 404
+        assert 'not found' in body['error'].lower()
+        mock_table.update_item.assert_not_called()
+
+
 class TestDeleteFeedback:
     """Tests for DELETE /data-explorer/feedback endpoint."""
 
@@ -490,6 +616,103 @@ class TestGetDataStats:
         assert response['statusCode'] == 200
         assert 's3' in body
         assert 'dynamodb' in body
+
+
+class TestErrorDisclosure:
+    """Regression (#263): a client-facing error body must carry no internal detail.
+
+    `shared/api.py` renders `ServiceError.message` straight into the response, so
+    every `raise ServiceError(f'...: {str(e)}')` in this handler published boto
+    text — table name, pk/sk structure, bucket name, request id — to anyone who
+    could provoke a 500. These tests plant a sentinel plus the real table and
+    bucket names in the fault and assert none of the three comes back.
+    """
+
+    @pytest.mark.parametrize(
+        'event_kwargs',
+        [pytest.param(kwargs, id=name) for name, kwargs in _DISCLOSURE_ROUTES]
+    )
+    def test_returns_generic_500_without_internal_detail(
+        self, event_kwargs, api_gateway_event, lambda_context
+    ):
+        """Returns a 500 whose body names no table, bucket, key or boto text."""
+        # Arrange — fail whichever AWS call the route makes.
+        with patch('data_explorer_handler.s3_client') as mock_s3, \
+             patch('data_explorer_handler.dynamodb') as mock_dynamodb, \
+             patch('data_explorer_handler.logger') as mock_logger:
+            # A real exception class, so the `except s3_client.exceptions.NoSuchKey`
+            # clause on the preview route is catchable and does not match.
+            mock_s3.exceptions = MagicMock()
+            mock_s3.exceptions.NoSuchKey = type('NoSuchKey', (Exception,), {})
+            for method in ('list_objects_v2', 'head_object', 'get_object',
+                           'put_object', 'delete_object'):
+                getattr(mock_s3, method).side_effect = _aws_failure('S3Call')
+
+            mock_table = MagicMock()
+            mock_dynamodb.Table.return_value = mock_table
+            for method in ('query', 'update_item', 'delete_item'):
+                getattr(mock_table, method).side_effect = _aws_failure('DynamoCall')
+
+            from data_explorer_handler import lambda_handler
+            event = api_gateway_event(**event_kwargs)
+
+            # Act
+            response = lambda_handler(event, lambda_context)
+            raw_body = response['body']
+
+            # Assert
+            assert response['statusCode'] == 500
+            for leak in (_SENTINEL, _INTERNAL_TABLE, _INTERNAL_BUCKET,
+                         'InternalServerError', 'SOURCE#', 'FEEDBACK#'):
+                assert leak not in raw_body, (
+                    f'{leak!r} must not reach the client; body was: {raw_body}'
+                )
+            # The message is still useful to a human, so "no detail" was not
+            # achieved by returning an empty string.
+            assert json.loads(raw_body)['error'].startswith('Failed to ')
+
+            # Positive control: without this, "absent from the body" would also
+            # hold for a fault that was swallowed and never recorded.
+            logged = ' '.join(str(c.args) for c in mock_logger.exception.call_args_list)
+            assert _SENTINEL in logged, (
+                f'the fault must be logged for an operator; exception() calls: {logged}'
+            )
+
+    def test_bucket_stats_error_field_omits_internal_detail(
+        self, api_gateway_event, lambda_context
+    ):
+        """GET /stats reports a bucket failure without echoing the boto text.
+
+        This one rides inside a 200 body rather than an error response, which is
+        exactly why it was missed: `bucket_info['error'] = str(e)` leaked the same
+        detail as a ServiceError message would.
+        """
+        # Arrange
+        with patch('data_explorer_handler.s3_client') as mock_s3, \
+             patch('data_explorer_handler.logger') as mock_logger:
+            mock_s3.list_objects_v2.side_effect = _aws_failure('ListObjectsV2')
+
+            from data_explorer_handler import lambda_handler
+            event = api_gateway_event(method='GET', path='/data-explorer/stats')
+
+            # Act
+            response = lambda_handler(event, lambda_context)
+            raw_body = response['body']
+            body = json.loads(raw_body)
+
+            # Assert — the failure is reported, but only in the abstract.
+            assert response['statusCode'] == 200
+            reported = [b for b in body['s3']['buckets'] if b.get('error')]
+            assert reported, f'the bucket failure must still be reported: {raw_body}'
+            for leak in (_SENTINEL, 'InternalServerError'):
+                assert leak not in raw_body, (
+                    f'{leak!r} must not reach the client; body was: {raw_body}'
+                )
+
+            logged = ' '.join(str(c.args) for c in mock_logger.exception.call_args_list)
+            assert _SENTINEL in logged, (
+                f'the fault must be logged for an operator; exception() calls: {logged}'
+            )
 
 
 class TestDecimalToNative:

--- a/voc-datalake/lambda/api/test/test_error_disclosure_lockstep.py
+++ b/voc-datalake/lambda/api/test/test_error_disclosure_lockstep.py
@@ -1,0 +1,191 @@
+"""A caught exception must never be interpolated into a client-facing API error.
+
+THE RULE
+--------
+Inside `except ... as e:`, no `raise SomeApiError(...)` may mention `e`.
+
+WHY IT IS A RULE AND NOT A PREFERENCE
+-------------------------------------
+`shared/api.py::_register_exception_handlers` returns `ApiError.message`
+**verbatim** in the response body. So `raise ServiceError(f'Failed: {e}')` is not a
+log line — it is a publication. A botocore `ClientError` carries the error code, the
+operation name, the service text and whatever internal names the service echoes
+back, which on the routes in this directory means the DynamoDB table name, the
+`pk`/`sk` key structure, the raw-data bucket and the Cognito user pool id. All of it
+was readable by anyone who could provoke a 500 (issue #263).
+
+The fix at each site is the same and costs nothing: pass a fixed message, and put
+the detail in `logger.exception`, which Powertools stamps with the request id so an
+operator can still correlate it.
+
+WHY A SCANNER RATHER THAN A COMMENT
+-----------------------------------
+The shape is mechanically detectable, and PR #403 fixed fourteen instances of it
+across two files — a count that only reflects the two files someone happened to
+read. Nothing stops the fifteenth from arriving in a third. This holds the whole
+directory instead, and it holds it cheaply: the tree is already clean, so this test
+is green on `development` and any new violation is caught by the author of it.
+
+It also makes the `create_api_resolver` redesign #263 proposes (hoisting
+`except ApiError: raise` into the shared resolver so a route cannot forget it) safer
+to attempt later, because a regression introduced along the way fails here.
+
+THE CEILING
+-----------
+Lexical and single-hop: it sees `ServiceError(f'{e}')` and `ServiceError(str(e))`,
+but not `msg = str(e)` on one line and `ServiceError(msg)` on the next. That is a
+deliberate stop — following assignments needs dataflow, and the direct form is the
+one that actually keeps being written. `logger.exception(f'...{e}')` is out of scope
+too: it does not reach the client (though it is redundant, since Powertools attaches
+the exception itself).
+"""
+import ast
+from pathlib import Path
+
+import pytest
+
+
+def _repo_root() -> Path:
+    # lambda/api/test/ -> voc-datalake/
+    return Path(__file__).resolve().parents[3]
+
+
+def _api_error_names() -> frozenset[str]:
+    """Every `ApiError` subclass, read from `shared/exceptions.py` itself.
+
+    Derived rather than listed, because a hardcoded tuple is exactly how a scanner
+    goes quietly partial: add an eighth exception class and a hardcoded list keeps
+    passing while never looking at it. Read as SOURCE TEXT rather than imported so
+    the scan does not depend on `shared` being importable from wherever it runs.
+    """
+    source = (_repo_root() / 'lambda/shared/exceptions.py').read_text(encoding='utf-8')
+    tree = ast.parse(source)
+    names = {'ApiError'}
+    # Repeated to a fixed point: `SecretUnreadableError` extends
+    # `ConfigurationError`, not `ApiError` directly, so one pass would miss it.
+    for _ in range(len(tree.body)):
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef) and any(
+                isinstance(b, ast.Name) and b.id in names for b in node.bases
+            ):
+                names.add(node.name)
+    return frozenset(names)
+
+
+API_ERROR_NAMES = _api_error_names()
+
+
+def _scanned_sources() -> list[Path]:
+    """Every non-test Lambda module.
+
+    `lambda/layers` is vendored build output (ruff.toml excludes it for the same
+    reason), and a test may legitimately construct one of these errors from a caught
+    exception to assert on it.
+    """
+    root = _repo_root() / 'lambda'
+    return [
+        path for path in sorted(root.rglob('*.py'))
+        if 'layers' not in path.parts
+        and 'test' not in path.parts
+        and not path.name.startswith('test_')
+    ]
+
+
+def _violations(source: str, where: str) -> list[str]:
+    """Sites where a caught exception is interpolated into an API error's message."""
+    found = []
+    for handler in ast.walk(ast.parse(source)):
+        if not isinstance(handler, ast.ExceptHandler) or not handler.name:
+            continue
+        for node in ast.walk(handler):
+            if not (isinstance(node, ast.Raise) and isinstance(node.exc, ast.Call)):
+                continue
+            func = node.exc.func
+            # Both `ServiceError(...)` and `exceptions.ServiceError(...)`.
+            raised = func.id if isinstance(func, ast.Name) else getattr(func, 'attr', None)
+            if raised not in API_ERROR_NAMES:
+                continue
+            # `raise X(...) from e` is FINE and is the recommended form: `from`
+            # chains the cause for the traceback without touching `.message`. Only
+            # the call's own arguments are inspected, never `node.cause`.
+            arguments = list(node.exc.args) + [kw.value for kw in node.exc.keywords]
+            mentions = any(
+                isinstance(inner, ast.Name) and inner.id == handler.name
+                for argument in arguments
+                for inner in ast.walk(argument)
+            )
+            if mentions:
+                found.append(f'{where}:{node.lineno}: {ast.unparse(node.exc)}')
+    return found
+
+
+class TestNoCaughtExceptionReachesAClientErrorMessage:
+    def test_the_detector_fires_on_a_known_violation(self):
+        """Control: the scan below finds nothing, so prove it CAN find something.
+
+        Without this, a traversal broken by any future refactor — an `ast` API
+        change, a wrong node type, an over-eager filter — would report a clean tree
+        and read as a pass. That failure mode is silent and permanent, because the
+        thing this test asserts is an absence.
+        """
+        violation = _violations(
+            'try:\n'
+            '    pass\n'
+            'except Exception as e:\n'
+            "    raise ServiceError(f'Failed to read: {e}') from e\n",
+            'inline',
+        )
+
+        assert len(violation) == 1, (
+            f'the detector no longer recognises the #263 shape it exists to find: '
+            f'{violation}'
+        )
+
+    def test_raise_from_alone_is_not_a_violation(self):
+        """The recommended form must stay green, or the rule reads as "never chain".
+
+        `from e` is what preserves the cause in the traceback; it never touches
+        `.message`, so it publishes nothing. A detector that flagged it would push
+        authors to drop the chaining and lose the traceback for no gain.
+        """
+        assert _violations(
+            'try:\n'
+            '    pass\n'
+            'except Exception as e:\n'
+            "    raise ServiceError('Failed to read') from e\n",
+            'inline',
+        ) == []
+
+    def test_subclasses_declared_after_apierror_are_all_covered(self):
+        """The derived name set must include the indirect subclass, not just direct
+        ones — `SecretUnreadableError` extends `ConfigurationError`, and a
+        single-pass derivation would silently skip it."""
+        assert {'ApiError', 'ServiceError', 'ValidationError', 'NotFoundError',
+                'ConfigurationError', 'SecretUnreadableError', 'AuthorizationError',
+                'ConflictError'} <= API_ERROR_NAMES
+
+    def test_the_scan_covers_the_handlers_the_rule_is_about(self):
+        """A path constant gone stale would make the sweep below vacuous."""
+        scanned = {path.name for path in _scanned_sources()}
+
+        assert {'data_explorer_handler.py', 'users_handler.py'} <= scanned, (
+            f'the scan no longer reaches the API handlers; it found: {sorted(scanned)}'
+        )
+
+    @pytest.mark.parametrize(
+        'path', _scanned_sources(), ids=lambda p: p.name,
+    )
+    def test_no_module_interpolates_a_caught_exception(self, path: Path):
+        relative = path.relative_to(_repo_root())
+        found = _violations(path.read_text(encoding='utf-8'), str(relative))
+
+        assert found == [], (
+            'A caught exception is interpolated into a client-facing error '
+            'message:\n  ' + '\n  '.join(found) + '\n\n'
+            "shared/api.py returns ApiError.message VERBATIM, so this publishes the "
+            'exception text — AWS error code, operation name, table/bucket/pool names '
+            '— to anyone who can provoke the error (issue #263). Pass a fixed '
+            'message instead and log the detail:\n'
+            "    logger.exception('Failed to read the thing')\n"
+            '    raise ServiceError(FAILED_READ_THING) from e'
+        )

--- a/voc-datalake/lambda/api/test/test_users_handler.py
+++ b/voc-datalake/lambda/api/test/test_users_handler.py
@@ -3,13 +3,75 @@ Tests for users_handler.py - /users/* endpoints.
 Cognito user management for admins.
 """
 import json
+import pytest
 from unittest.mock import patch
 from datetime import datetime, timezone
+
+from botocore.exceptions import ClientError
 
 
 # NOTE: group-parsing/require_admin unit tests live in
 # lambda/shared/test/test_api.py — users_handler now gates through the
 # shared implementation instead of a local copy.
+
+
+# A string no legitimate response body has reason to contain, planted in the text
+# of the Cognito fault the handler catches. Whether it comes back out is the whole
+# question in TestErrorDisclosure below: `shared/api.py` returns a ServiceError's
+# `.message` verbatim, and every route here used to raise `ServiceError(str(e))`
+# (issue #263).
+_SENTINEL = 'SENTINEL_INTERNAL_DETAIL'
+
+# The user pool this handler is configured with (conftest sets USER_POOL_ID).
+# A botocore ClientError from an admin_* call names it, so it is the concrete thing
+# `str(e)` published.
+_INTERNAL_POOL_ID = 'us-east-1_testpool'
+
+
+def _cognito_failure(operation: str = 'AdminGetUser') -> ClientError:
+    """A Cognito client error whose message carries internal detail.
+
+    Shaped like the real thing: botocore's ``str()`` renders the error code, the
+    service message and the operation name, so interpolating it leaks all three
+    plus the pool id the service echoes back.
+    """
+    return ClientError(
+        {'Error': {
+            'Code': 'InternalErrorException',
+            'Message': f'{_SENTINEL} for user pool {_INTERNAL_POOL_ID}',
+        }},
+        operation,
+    )
+
+
+# Every route in this handler, as (route description, event kwargs). Exercised as
+# a set rather than through one representative case: the leak was per-route, so one
+# fixed route proves nothing about the next.
+_DISCLOSURE_ROUTES = [
+    ('GET /users', {'method': 'GET', 'path': '/users'}),
+    ('POST /users', {
+        'method': 'POST', 'path': '/users',
+        'body': {'email': 'a@example.com', 'group': 'users'}}),
+    ('PUT /users/<username>', {
+        'method': 'PUT', 'path': '/users/testuser',
+        'path_params': {'username': 'testuser'},
+        'body': {'given_name': 'New'}}),
+    ('PUT /users/<username>/group', {
+        'method': 'PUT', 'path': '/users/testuser/group',
+        'path_params': {'username': 'testuser'}, 'body': {'group': 'admins'}}),
+    ('POST /users/<username>/reset-password', {
+        'method': 'POST', 'path': '/users/testuser/reset-password',
+        'path_params': {'username': 'testuser'}}),
+    ('PUT /users/<username>/enable', {
+        'method': 'PUT', 'path': '/users/testuser/enable',
+        'path_params': {'username': 'testuser'}}),
+    ('PUT /users/<username>/disable', {
+        'method': 'PUT', 'path': '/users/testuser/disable',
+        'path_params': {'username': 'testuser'}}),
+    ('DELETE /users/<username>', {
+        'method': 'DELETE', 'path': '/users/testuser',
+        'path_params': {'username': 'testuser'}}),
+]
 
 
 class TestListUsers:
@@ -574,7 +636,7 @@ class TestDeleteUser:
             'UserNotFoundException', (Exception,), {}
         )
         mock_cognito.admin_delete_user.side_effect = mock_cognito.exceptions.UserNotFoundException()
-        
+
         from users_handler import lambda_handler
         event = api_gateway_event(
             method='DELETE',
@@ -582,12 +644,114 @@ class TestDeleteUser:
             path_params={'username': 'nonexistent'}
         )
         event['requestContext']['authorizer']['claims']['cognito:groups'] = 'admins'
-        
+
         # Act
         response = lambda_handler(event, lambda_context)
         body = json.loads(response['body'])
-        
+
         # Assert - now returns 404 with error key
         assert response['statusCode'] == 404
         assert 'error' in body
         assert 'not found' in body['error'].lower()
+
+
+class TestErrorDisclosure:
+    """Regression (#263): a client-facing error body must carry no Cognito detail.
+
+    `shared/api.py` renders `ServiceError.message` straight into the response, and
+    all eight routes here raised `ServiceError(str(e))` — so a botocore
+    ClientError published the user pool id, the error code and the admin operation
+    name to anyone who could provoke a 500.
+    """
+
+    @pytest.mark.parametrize(
+        'event_kwargs',
+        [pytest.param(kwargs, id=name) for name, kwargs in _DISCLOSURE_ROUTES]
+    )
+    def test_returns_generic_500_without_cognito_detail(
+        self, event_kwargs, api_gateway_event, lambda_context
+    ):
+        """Returns a 500 whose body names no pool, error code or operation."""
+        # Arrange — fail whichever admin call the route makes.
+        with patch('users_handler.cognito') as mock_cognito, \
+             patch('users_handler.logger') as mock_logger:
+            # Real exception classes, so the typed `except cognito.exceptions.*`
+            # clauses are catchable and do not match the injected fault.
+            mock_cognito.exceptions.UserNotFoundException = type(
+                'UserNotFoundException', (Exception,), {}
+            )
+            mock_cognito.exceptions.UsernameExistsException = type(
+                'UsernameExistsException', (Exception,), {}
+            )
+            for method in ('list_users', 'admin_list_groups_for_user',
+                           'admin_create_user', 'admin_get_user',
+                           'admin_update_user_attributes',
+                           'admin_add_user_to_group', 'admin_remove_user_from_group',
+                           'admin_reset_user_password', 'admin_enable_user',
+                           'admin_disable_user', 'admin_delete_user'):
+                getattr(mock_cognito, method).side_effect = _cognito_failure()
+
+            from users_handler import lambda_handler
+            event = api_gateway_event(**event_kwargs)
+            event['requestContext']['authorizer']['claims']['cognito:groups'] = 'admins'
+
+            # Act
+            response = lambda_handler(event, lambda_context)
+            raw_body = response['body']
+
+            # Assert
+            assert response['statusCode'] == 500
+            for leak in (_SENTINEL, _INTERNAL_POOL_ID, 'InternalErrorException',
+                         'AdminGetUser'):
+                assert leak not in raw_body, (
+                    f'{leak!r} must not reach the client; body was: {raw_body}'
+                )
+            # Still useful to a human, so "no detail" was not achieved by
+            # returning an empty message.
+            assert json.loads(raw_body)['error'].startswith('Failed to ')
+
+            # Positive control: without this, "absent from the body" would also
+            # hold for a fault that was swallowed and never recorded.
+            logged = ' '.join(str(c.args) for c in mock_logger.exception.call_args_list)
+            assert _SENTINEL in logged, (
+                f'the fault must be logged for an operator; exception() calls: {logged}'
+            )
+
+    @patch('users_handler.cognito')
+    def test_update_user_keeps_400_when_merged_names_are_empty(
+        self, mock_cognito, api_gateway_event, lambda_context
+    ):
+        """PUT /users/<username> answers 400 for a ValidationError raised mid-block.
+
+        The refusal ('...must be non-empty') is raised AFTER the admin_get_user
+        call, i.e. inside the same `try` that answers AWS failures with a 500.
+        Pins the boundary this slice relies on: widening that catch to
+        `except Exception` without an `except ApiError: raise` in front would turn
+        this 400 into a 500, exactly the #263 defect. Duplicates
+        TestUpdateUser::test_rejects_whitespace_only_names' scenario on purpose —
+        that one only asserts the status, this one names the boundary and asserts
+        no write happened.
+        """
+        # Arrange — no existing names to merge with, and blank names supplied.
+        mock_cognito.exceptions.UserNotFoundException = type(
+            'UserNotFoundException', (Exception,), {}
+        )
+        mock_cognito.admin_get_user.return_value = {'UserAttributes': []}
+
+        from users_handler import lambda_handler
+        event = api_gateway_event(
+            method='PUT',
+            path='/users/testuser',
+            path_params={'username': 'testuser'},
+            body={'given_name': ' ', 'family_name': ''}
+        )
+        event['requestContext']['authorizer']['claims']['cognito:groups'] = 'admins'
+
+        # Act
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        # Assert
+        assert response['statusCode'] == 400
+        assert 'non-empty' in body['error']
+        mock_cognito.admin_update_user_attributes.assert_not_called()

--- a/voc-datalake/lambda/api/test/test_users_handler.py
+++ b/voc-datalake/lambda/api/test/test_users_handler.py
@@ -3,8 +3,10 @@ Tests for users_handler.py - /users/* endpoints.
 Cognito user management for admins.
 """
 import json
+import os
+import sys
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from datetime import datetime, timezone
 
 from botocore.exceptions import ClientError
@@ -22,10 +24,15 @@ from botocore.exceptions import ClientError
 # (issue #263).
 _SENTINEL = 'SENTINEL_INTERNAL_DETAIL'
 
-# The user pool this handler is configured with (conftest sets USER_POOL_ID).
-# A botocore ClientError from an admin_* call names it, so it is the concrete thing
-# `str(e)` published.
-_INTERNAL_POOL_ID = 'us-east-1_testpool'
+# The user pool this handler is configured with. A botocore ClientError from an
+# admin_* call names it, so it is the concrete thing `str(e)` published.
+#
+# 🔑 Read from the environment conftest sets, not copied as a literal: this feeds an
+# ABSENCE assertion, where a stale expected value passes instead of failing. Copy
+# the pool id here and change conftest, and `assert pool not in body` stays green
+# while checking a pool the handler never held. Subscript, so a missing var fails at
+# collection rather than degrading the check to a no-op.
+_INTERNAL_POOL_ID = os.environ['USER_POOL_ID']
 
 
 def _cognito_failure(operation: str = 'AdminGetUser') -> ClientError:
@@ -42,6 +49,27 @@ def _cognito_failure(operation: str = 'AdminGetUser') -> ClientError:
         }},
         operation,
     )
+
+
+def _recording_logger() -> MagicMock:
+    """A stand-in logger that records what `logger.exception` would really emit.
+
+    🔑 The handler passes a plain message and no longer interpolates `{e}`, because
+    Powertools' `Logger.exception` attaches the AMBIENT exception — its text, name
+    and a structured stack trace — to the record by itself. A bare MagicMock records
+    only the call args, so asserting on `call_args` alone would no longer see the
+    fault and the positive control below would silently become vacuous. This reads
+    `sys.exc_info()` at call time, which is the same source the real logger uses.
+    """
+    mock_logger = MagicMock()
+    emitted: list[str] = []
+
+    def _record(*args, **kwargs):
+        emitted.append(f'{args} {kwargs} exc={sys.exc_info()[1]!r}')
+
+    mock_logger.exception.side_effect = _record
+    mock_logger.emitted_exceptions = emitted
+    return mock_logger
 
 
 # Every route in this handler, as (route description, event kwargs). Exercised as
@@ -673,8 +701,9 @@ class TestErrorDisclosure:
     ):
         """Returns a 500 whose body names no pool, error code or operation."""
         # Arrange — fail whichever admin call the route makes.
+        mock_logger = _recording_logger()
         with patch('users_handler.cognito') as mock_cognito, \
-             patch('users_handler.logger') as mock_logger:
+             patch('users_handler.logger', mock_logger):
             # Real exception classes, so the typed `except cognito.exceptions.*`
             # clauses are catchable and do not match the injected fault.
             mock_cognito.exceptions.UserNotFoundException = type(
@@ -711,8 +740,11 @@ class TestErrorDisclosure:
             assert json.loads(raw_body)['error'].startswith('Failed to ')
 
             # Positive control: without this, "absent from the body" would also
-            # hold for a fault that was swallowed and never recorded.
-            logged = ' '.join(str(c.args) for c in mock_logger.exception.call_args_list)
+            # hold for a fault that was swallowed and never recorded. Asserts on the
+            # exception in flight at the call, not on the message args — the handler
+            # no longer interpolates it, Powertools attaches it (see
+            # _recording_logger).
+            logged = ' '.join(mock_logger.emitted_exceptions)
             assert _SENTINEL in logged, (
                 f'the fault must be logged for an operator; exception() calls: {logged}'
             )
@@ -724,10 +756,10 @@ class TestErrorDisclosure:
         """PUT /users/<username> answers 400 for a ValidationError raised mid-block.
 
         The refusal ('...must be non-empty') is raised AFTER the admin_get_user
-        call, i.e. inside the same `try` that answers AWS failures with a 500.
-        Pins the boundary this slice relies on: widening that catch to
-        `except Exception` without an `except ApiError: raise` in front would turn
-        this 400 into a 500, exactly the #263 defect. Duplicates
+        call, i.e. inside the same `try` that answers AWS failures with a 500 — and
+        since that catch is now `except Exception`, the `except ApiError: raise` in
+        front of it is the only thing keeping this a 400 rather than the #263
+        defect's 500. Deleting that clause makes this test red. Duplicates
         TestUpdateUser::test_rejects_whitespace_only_names' scenario on purpose —
         that one only asserts the status, this one names the boundary and asserts
         no write happened.
@@ -754,4 +786,40 @@ class TestErrorDisclosure:
         # Assert
         assert response['statusCode'] == 400
         assert 'non-empty' in body['error']
+        mock_cognito.admin_update_user_attributes.assert_not_called()
+
+    @patch('users_handler.cognito')
+    def test_update_user_returns_500_for_a_non_botocore_fault(
+        self, mock_cognito, api_gateway_event, lambda_context
+    ):
+        """PUT /users/<username> answers a controlled 500, not an escaped exception.
+
+        This route used to catch only `(ClientError, BotoCoreError)`, so any other
+        fault inside the block escaped `lambda_handler` entirely — API Gateway then
+        answered a bare 502 with no CORS headers, unlike the seven sibling routes.
+        A malformed `admin_get_user` payload reproduces it: the dict comprehension
+        over `UserAttributes` raises TypeError on a string.
+        """
+        # Arrange
+        mock_cognito.exceptions.UserNotFoundException = type(
+            'UserNotFoundException', (Exception,), {}
+        )
+        mock_cognito.admin_get_user.return_value = {'UserAttributes': 'not-a-list'}
+
+        from users_handler import lambda_handler
+        event = api_gateway_event(
+            method='PUT',
+            path='/users/testuser',
+            path_params={'username': 'testuser'},
+            body={'given_name': 'New'}
+        )
+        event['requestContext']['authorizer']['claims']['cognito:groups'] = 'admins'
+
+        # Act — must not raise; before the widening this propagated out.
+        response = lambda_handler(event, lambda_context)
+        body = json.loads(response['body'])
+
+        # Assert
+        assert response['statusCode'] == 500
+        assert body['error'] == 'Failed to update user'
         mock_cognito.admin_update_user_attributes.assert_not_called()

--- a/voc-datalake/lambda/api/users_handler.py
+++ b/voc-datalake/lambda/api/users_handler.py
@@ -18,13 +18,32 @@ from botocore.exceptions import ClientError, BotoCoreError
 
 from shared.logging import logger, tracer
 from shared.api import create_api_resolver, api_handler, require_admin
-from shared.exceptions import ValidationError, NotFoundError, ServiceError, ConflictError
+from shared.exceptions import ApiError, ValidationError, NotFoundError, ServiceError, ConflictError
 
 # AWS Clients
 cognito = boto3.client('cognito-idp')
 
 # Configuration
 USER_POOL_ID = os.environ.get('USER_POOL_ID', '')
+
+# Client-facing text for an unexpected Cognito failure, one message per operation.
+#
+# 🔑 Every one of these used to be `ServiceError(str(e))`, and `shared/api.py`
+# returns a ServiceError's message verbatim to the caller — so a botocore
+# ClientError published the USER_POOL_ID, the API name, and the Cognito request id
+# to anyone who could provoke a 500 (issue #263). The detail is logged with
+# `logger.exception` at each site instead, which is where an operator needs it.
+#
+# Each block also re-raises `ApiError` ahead of its `except Exception`, so a typed
+# ValidationError/NotFoundError raised inside keeps its own 400/404.
+FAILED_LIST_USERS = 'Failed to list users'
+FAILED_CREATE_USER = 'Failed to create user'
+FAILED_UPDATE_USER = 'Failed to update user'
+FAILED_UPDATE_GROUP = 'Failed to update user group'
+FAILED_RESET_PASSWORD = 'Failed to reset password'
+FAILED_ENABLE_USER = 'Failed to enable user'
+FAILED_DISABLE_USER = 'Failed to disable user'
+FAILED_DELETE_USER = 'Failed to delete user'
 
 app = create_api_resolver()
 
@@ -84,9 +103,11 @@ def list_users():
         
         return {'success': True, 'users': users}
     
+    except ApiError:
+        raise
     except Exception as e:
         logger.exception(f'Error listing users: {e}')
-        raise ServiceError(str(e))
+        raise ServiceError(FAILED_LIST_USERS) from e
 
 
 @app.post('/users')
@@ -157,9 +178,11 @@ def create_user():
     
     except cognito.exceptions.UsernameExistsException:
         raise ConflictError('A user with this email already exists')
+    except ApiError:
+        raise
     except Exception as e:
         logger.exception(f'Error creating user: {e}')
-        raise ServiceError(str(e))
+        raise ServiceError(FAILED_CREATE_USER) from e
 
 
 @app.put('/users/<username>')
@@ -224,9 +247,13 @@ def update_user(username: str):
 
     except cognito.exceptions.UserNotFoundException:
         raise NotFoundError('User not found')
+    # No `except ApiError: raise` here, unlike its siblings: this route already
+    # catches only the AWS error types, so the ValidationError it raises after
+    # admin_get_user ('...must be non-empty') is not swallowed. Widening this to
+    # `except Exception` would need that re-raise added first.
     except (ClientError, BotoCoreError) as e:
         logger.exception(f'Error updating user: {e}')
-        raise ServiceError(str(e))
+        raise ServiceError(FAILED_UPDATE_USER) from e
 
 
 @app.put('/users/<username>/group')
@@ -274,9 +301,11 @@ def update_user_group(username: str):
     
     except cognito.exceptions.UserNotFoundException:
         raise NotFoundError('User not found')
+    except ApiError:
+        raise
     except Exception as e:
         logger.exception(f'Error updating user group: {e}')
-        raise ServiceError(str(e))
+        raise ServiceError(FAILED_UPDATE_GROUP) from e
 
 
 @app.post('/users/<username>/reset-password')
@@ -299,9 +328,11 @@ def reset_user_password(username: str):
     
     except cognito.exceptions.UserNotFoundException:
         raise NotFoundError('User not found')
+    except ApiError:
+        raise
     except Exception as e:
         logger.exception(f'Error resetting password: {e}')
-        raise ServiceError(str(e))
+        raise ServiceError(FAILED_RESET_PASSWORD) from e
 
 
 @app.put('/users/<username>/enable')
@@ -324,9 +355,11 @@ def enable_user(username: str):
     
     except cognito.exceptions.UserNotFoundException:
         raise NotFoundError('User not found')
+    except ApiError:
+        raise
     except Exception as e:
         logger.exception(f'Error enabling user: {e}')
-        raise ServiceError(str(e))
+        raise ServiceError(FAILED_ENABLE_USER) from e
 
 
 @app.put('/users/<username>/disable')
@@ -349,9 +382,11 @@ def disable_user(username: str):
     
     except cognito.exceptions.UserNotFoundException:
         raise NotFoundError('User not found')
+    except ApiError:
+        raise
     except Exception as e:
         logger.exception(f'Error disabling user: {e}')
-        raise ServiceError(str(e))
+        raise ServiceError(FAILED_DISABLE_USER) from e
 
 
 @app.delete('/users/<username>')
@@ -374,9 +409,11 @@ def delete_user(username: str):
     
     except cognito.exceptions.UserNotFoundException:
         raise NotFoundError('User not found')
+    except ApiError:
+        raise
     except Exception as e:
         logger.exception(f'Error deleting user: {e}')
-        raise ServiceError(str(e))
+        raise ServiceError(FAILED_DELETE_USER) from e
 
 
 @api_handler

--- a/voc-datalake/lambda/api/users_handler.py
+++ b/voc-datalake/lambda/api/users_handler.py
@@ -14,7 +14,6 @@ import os
 import uuid
 import boto3
 from typing import Any
-from botocore.exceptions import ClientError, BotoCoreError
 
 from shared.logging import logger, tracer
 from shared.api import create_api_resolver, api_handler, require_admin
@@ -35,7 +34,9 @@ USER_POOL_ID = os.environ.get('USER_POOL_ID', '')
 # `logger.exception` at each site instead, which is where an operator needs it.
 #
 # Each block also re-raises `ApiError` ahead of its `except Exception`, so a typed
-# ValidationError/NotFoundError raised inside keeps its own 400/404.
+# ValidationError/NotFoundError raised inside keeps its own 400/404. Only
+# `update_user`'s is reachable today — the rest are precautionary against a future
+# edit, in the same spirit as `feedback_form_handler.py`'s two.
 FAILED_LIST_USERS = 'Failed to list users'
 FAILED_CREATE_USER = 'Failed to create user'
 FAILED_UPDATE_USER = 'Failed to update user'
@@ -106,7 +107,7 @@ def list_users():
     except ApiError:
         raise
     except Exception as e:
-        logger.exception(f'Error listing users: {e}')
+        logger.exception('Error listing users')
         raise ServiceError(FAILED_LIST_USERS) from e
 
 
@@ -181,7 +182,7 @@ def create_user():
     except ApiError:
         raise
     except Exception as e:
-        logger.exception(f'Error creating user: {e}')
+        logger.exception('Error creating user')
         raise ServiceError(FAILED_CREATE_USER) from e
 
 
@@ -247,12 +248,19 @@ def update_user(username: str):
 
     except cognito.exceptions.UserNotFoundException:
         raise NotFoundError('User not found')
-    # No `except ApiError: raise` here, unlike its siblings: this route already
-    # catches only the AWS error types, so the ValidationError it raises after
-    # admin_get_user ('...must be non-empty') is not swallowed. Widening this to
-    # `except Exception` would need that re-raise added first.
-    except (ClientError, BotoCoreError) as e:
-        logger.exception(f'Error updating user: {e}')
+    # 🔑 Load-bearing here rather than precautionary, unlike its siblings: this is
+    # the one route whose `try` raises a typed error of its own AFTER the AWS call
+    # ('...must be non-empty'), so without this clause the catch-all below would
+    # rewrap that 400 as a 500 — the #263 defect. Pinned by
+    # test_update_user_keeps_400_when_merged_names_are_empty.
+    except ApiError:
+        raise
+    # Was `except (ClientError, BotoCoreError)`, which left any other fault — e.g. a
+    # TypeError from a malformed admin_get_user response — escaping lambda_handler
+    # entirely, so API Gateway answered a bare 502 with no CORS headers where the
+    # other seven routes answer a controlled 500.
+    except Exception as e:
+        logger.exception('Error updating user')
         raise ServiceError(FAILED_UPDATE_USER) from e
 
 
@@ -304,7 +312,7 @@ def update_user_group(username: str):
     except ApiError:
         raise
     except Exception as e:
-        logger.exception(f'Error updating user group: {e}')
+        logger.exception('Error updating user group')
         raise ServiceError(FAILED_UPDATE_GROUP) from e
 
 
@@ -331,7 +339,7 @@ def reset_user_password(username: str):
     except ApiError:
         raise
     except Exception as e:
-        logger.exception(f'Error resetting password: {e}')
+        logger.exception('Error resetting password')
         raise ServiceError(FAILED_RESET_PASSWORD) from e
 
 
@@ -358,7 +366,7 @@ def enable_user(username: str):
     except ApiError:
         raise
     except Exception as e:
-        logger.exception(f'Error enabling user: {e}')
+        logger.exception('Error enabling user')
         raise ServiceError(FAILED_ENABLE_USER) from e
 
 
@@ -385,7 +393,7 @@ def disable_user(username: str):
     except ApiError:
         raise
     except Exception as e:
-        logger.exception(f'Error disabling user: {e}')
+        logger.exception('Error disabling user')
         raise ServiceError(FAILED_DISABLE_USER) from e
 
 
@@ -412,7 +420,7 @@ def delete_user(username: str):
     except ApiError:
         raise
     except Exception as e:
-        logger.exception(f'Error deleting user: {e}')
+        logger.exception('Error deleting user')
         raise ServiceError(FAILED_DELETE_USER) from e
 
 


### PR DESCRIPTION
## Summary

The current Python handler-error slice of #263: `lambda/api/data_explorer_handler.py` and
`lambda/api/users_handler.py`, plus their dedicated tests.

Two defects, both in the same shape:

**1. Typed 4xx rewrapped as 500.** `save_feedback` raises `ValidationError('No fields to update')`
and `NotFoundError('Feedback not found')` *inside* its broad `try`, whose `except Exception`
rewrapped both as `ServiceError`. A client's bad request and an edit of a deleted record both
answered 500, so a caller could not tell its own mistake from an outage. Every broad block in both
files now re-raises `ApiError` ahead of `except Exception` — the template `delete_feedback` already
used, widened from `NotFoundError` to `ApiError` so it covers `ValidationError` and
`ConfigurationError` too.

**2. Raw exception text returned to the client.** `shared/api.py` renders `ServiceError.message`
verbatim into the response body, and every catch-all in these two files built that message from
`str(e)` — six sites in `data_explorer_handler`, eight in `users_handler`. A botocore `ClientError`
carries the error code, the operation name, the service text and whatever internal names the
service echoes: the `FEEDBACK_TABLE` name, `pk`/`sk` key structure, the raw-data bucket, the
Cognito `USER_POOL_ID`. All of that was readable by anyone who could provoke a 500. Each message
is now a named module constant with no exception text; the detail goes to `logger.exception`, where
an operator can correlate it.

`GET /data-explorer/stats` had the same leak in a place easy to miss — `bucket_info['error'] =
str(e)` rides inside a **200** body, not an error response. That field is generic now too, and its
log call was upgraded from `warning` to `exception` so the stack is still recorded.

### One deliberate non-change, documented in the code

`update_user` (PUT `/users/<username>`) catches only `(ClientError, BotoCoreError)`, not
`Exception`, so the `ValidationError` it raises *after* `admin_get_user` was never swallowed. No
`except ApiError: raise` was added there; a comment names why, and says it would be required if
that clause were ever widened. A test pins the 400 so the widening cannot happen silently.

### Left for the separate slices named in the task

`logs_handler` validation/pagination, the TypeScript stream handler's `JSON.parse` placement, and
the shared-resolver redesign (hoisting the re-raise into `create_api_resolver` so it cannot be
forgotten per-route) are untouched.

Link: #263

## Tests

Sentinel tests, one class per handler. Each plants `SENTINEL_INTERNAL_DETAIL` plus the *real*
configured table, bucket and pool names in an injected botocore `ClientError`, then asserts none of
them — nor the error code, nor the operation name, nor `SOURCE#`/`FEEDBACK#` key prefixes — appears
in the returned body. Parameterised over **all six** data-explorer routes and **all eight** users
routes rather than one representative case, because the leak was per-route.

Two guards against vacuous proof:
- **Positive control on the log side.** Each asserts the sentinel *is* in a `logger.exception` call.
  Without it, "absent from the body" would also hold for a fault swallowed entirely.
- **Non-empty message check.** `body['error'].startswith('Failed to ')`, so "no detail" was not
  achieved by returning an empty string.

Plus outcome tests for the status codes in the acceptance criteria:
`returns 400 when no editable fields supplied`, `returns 404 when updating missing feedback` (both
also assert `update_item` was never called), and
`update_user keeps 400 when merged names are empty`.

### Verification that the tests earn their place

Revert check, per the repo's rule that a test must fail against the unfixed code:

| check | result |
|---|---|
| 9 new data-explorer tests vs. stashed `data_explorer_handler.py` | **9 failed** (caught) |
| 8 new users disclosure tests vs. stashed `users_handler.py` | **8 failed** (caught) |
| mutation: widen `update_user`'s catch to `except Exception` | `test_update_user_keeps_400_when_merged_names_are_empty` **failed** (caught) — proves the comment's claim |

Working tree byte-compared against a pre-stash copy after each revert; both restored identically.

## Build and test results

`mise run build` is not runnable in this repo — `mise` reports *no tasks defined*, and the setup
notes confirm build gating is inert here. The repo's own gates were run instead, from the root.

| command | result |
|---|---|
| `pytest lambda/api/test/test_data_explorer_handler.py lambda/api/test/test_users_handler.py` | **59 passed** (was 41 before; +18) |
| `npm run test:backend` (full suite) | **4172 passed** |
| `npm run lint:python` (`ruff check lambda plugins scripts`) | **499** findings vs. **518** on the stashed baseline — 19 fewer, no new rule codes |
| ruff, the four touched files only | **34 → 15** findings; the 16 `BLE001` blind-excepts and 6 `RUF010` are what this change removes |
| `npm run test:cdk` | **327 passed** (18 files) |
| `npm run typecheck:cdk` | pass |

Notes on the environment, since they affect reproducing the above:
- `voc-datalake/.venv` did not exist; created it and installed `requirements-dev.txt`. Four more
  packages were needed before the suite would even import: `aws-xray-sdk`, `pydantic`,
  `google-play-scraper`, `app-store-web-scraper` — the first two come from
  `aws-lambda-powertools[tracer]` and the `enable_validation=True` resolver, the last two from the
  app-review plugin tests. They live in `lambda/layers/*/requirements.txt`, not
  `requirements-dev.txt`, so a fresh checkout following the documented steps cannot run
  `test:backend`. Worth a follow-up.
- `npm run test:cdk` fails on a fresh checkout with `CannotFindAsset: .../frontend/dist` — 69 of 304
  tests, unrelated to this change. Stubbing `frontend/dist/index.html` (gitignored, removed
  afterwards) makes all 327 pass.
- Frontend vitest and `typecheck` were not run: nothing in this diff touches `frontend/`, and no
  response shape changed — only the *text* inside `{'success': false, 'error': …}`, whose type in
  `frontend/src/api/client.ts` is unaffected.

## Decisions

- **`except ApiError` rather than `except (ValidationError, NotFoundError)`.** The issue proposes the
  narrow tuple, but `ApiError` is the base of all seven typed errors and is the form
  `ballots_handler` and `feedback_form_handler` already use. The narrow tuple would still rewrap a
  `ConfigurationError` or `ConflictError` raised inside a block as a 500 — a smaller version of the
  same bug.
- **Named module constants, not inline literals.** The messages are now part of the API contract and
  the tests assert against the shape (`startswith('Failed to ')`), not one spelling. Naming them
  makes the "no `str(e)`" rule visible in one place with the reasoning attached.
- **`raise … from e`.** Preserves the cause for the traceback while keeping it out of `.message`.
- **No correlation id.** The issue suggests returning one alongside the generic message. That needs
  a decision about where the id comes from (Lambda request id vs. X-Ray trace id) and touches the
  shared resolver, which this slice explicitly leaves alone. `logger.exception` under
  `inject_lambda_context` already stamps the request id, so an operator can correlate today.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).

```abca-verify
no-ui
```

## Agent notes

**What went well.** The issue named exact line numbers and pointed at the fix template already in
the file (`delete_feedback`'s `except NotFoundError: raise`), so the shape of the change was settled
before any code was read. The two defects turned out to be one mechanism seen twice — a broad
`except Exception` that both swallows type information and has an exception object in scope to
interpolate — which meant a single pass per block fixed both, and the same test injection proved
both.

**What was difficult.** Three things:

1. *Getting the suite to run at all.* `requirements-dev.txt` is not sufficient; four packages from
   `lambda/layers/*/requirements.txt` are needed before collection succeeds, and two of the four
   fail with an error that does not name the missing layer (`No module named 'aws_xray_sdk'` from
   inside powertools). Then `test:cdk` fails on a missing `frontend/dist` that no documented step
   creates. Roughly half the wall-clock time went here rather than on the change.
2. *Proving the disclosure test is not vacuous.* "The sentinel is absent from the body" passes
   trivially if the fault never reached the handler, if the route 404'd on a mis-shaped event, or if
   the fault was swallowed. The log-side positive control and the `startswith('Failed to ')` check
   were both added after noticing the assertion would have held for the wrong reasons.
3. *One route that looked like the others but was not.* `update_user` catches only the botocore
   types, so it never had the rewrap bug — adding `except ApiError: raise` there would have been
   dead code implying a defect that was not present. Left out with a comment explaining the
   asymmetry, plus a test so the difference is enforced rather than merely described.

**Patterns discovered about this repo.**
- The error contract is centralised: `shared/exceptions.py` defines the taxonomy,
  `shared/api.py::_register_exception_handlers` maps each to a status. A handler raises a typed
  exception and never builds an error payload. Critically, the handler returns `ex.message`
  **verbatim**, which is the fact that turns any `str(e)` in a message into a disclosure bug.
- `except ApiError: raise` before `except Exception` is the established idiom —
  `ballots_handler.py` and `feedback_form_handler.py` use it, and `feedback_form_handler` even
  annotates two as "precautionary, not currently reachable". Consistency with those was preferred
  over the narrower tuple the issue proposed.
- Comments here carry *reasoning*, not restatement, and are unusually long by normal standards —
  the "🔑" marker flags the load-bearing insight, and comments routinely name the failure that
  motivated the code and what would break if it were undone. Matched that register.
- Tests are held to "must fail against the unfixed code", stated in the steering rules. Ruff is
  judged as *no new findings against the same version*, not an absolute count — the baseline is
  large (518) and version-sensitive, so a before/after comparison on the same ruff build is the only
  meaningful measurement.
- `npm run check` chains with `&&`, so the first failure hides everything after it. Running the
  individual scripts is much faster to triage.

**Suggestions for future tasks on this repo.**
1. *Finish the remaining #263 slices*, in this order of value: hoist the re-raise into
   `create_api_resolver` (the issue's own "better" suggestion) so a new route cannot forget it —
   that would make this slice's per-block edits redundant, which is the point; then `logs_handler`
   validation and the unpaged `clear_validation_logs`; then the stream handler's `JSON.parse`.
2. *Add a lint rule or lockstep test for the disclosure class.* `raise ServiceError(f'...{e}')` is
   mechanically detectable. This slice fixed 14 sites in two files, but `grep` shows more
   `ServiceError(f'...` across `lambda/api/`, and each is one review miss from returning. An AST
   test in the style of the existing `*_lockstep.py` files would hold the whole directory instead of
   the two files a human happened to look at.
3. *Fix the dev-environment gap.* Either fold the four missing packages into
   `requirements-dev.txt`, or have the CDK tests tolerate an absent `frontend/dist`. Both are small
   and both currently block a first-time contributor from running two of the six gates.
