### PR TITLE
perf(derivation): build one source index per project collection pass (#399)

### DIFF
--- a/voc-datalake/frontend/src/api/derivation.test.ts
+++ b/voc-datalake/frontend/src/api/derivation.test.ts
@@ -12,13 +12,18 @@
  *    three origins → "answers exactly what resolveDerivation answers", which pins
  *    a declared, a legacy and an unresolved-source document as whole objects
  *    rather than field by field, because the promise is the whole answer;
- *  * `resolveDerivation` indexing per SOURCE rather than per call, or a memo
- *    creeping in behind it → "builds one index per call and none per source" and
- *    "builds no index of its own when given one", which count the builder's
- *    invocations through a `Map` subclass instead of timing anything. Their
- *    positive control is the first assertion of each: an index that was never
- *    consulted would report zero lookups, so a count of zero constructions could
- *    otherwise be a resolver that reads no index at all.
+ *  * a memo creeping in behind `resolveDerivationAgainst`, or the resolver reading
+ *    the wire a second time instead of the index it was handed → "consults the index
+ *    once per source and holds no state between calls" and "reads what a source is
+ *    from the given index and never from the wire again", which count the index's
+ *    lookups through a `Map` subclass instead of timing anything. Their positive
+ *    control is the first assertion of each — the titles the index actually resolved
+ *    — because a count is otherwise indistinguishable from the silence of a resolver
+ *    that looks nothing up;
+ *  * `derivationSourceIndex` dropping a field a source displays, or keeping an
+ *    entry for a record naming no document → "indexes a document list once for
+ *    every field a source displays", which is what lets `resolved: false` mean "not
+ *    among the documents supplied" rather than "supplied without a title".
  */
 import { describe, it, expect } from 'vitest'
 import {

--- a/voc-datalake/frontend/src/api/derivation.test.ts
+++ b/voc-datalake/frontend/src/api/derivation.test.ts
@@ -5,14 +5,31 @@
  *
  * Every expectation is a literal — nothing here is derived from the code under
  * test.
+ *
+ * REVERT MAP for the prebuilt-index seam (issue #399 B):
+ *
+ *  * `resolveDerivationAgainst` diverging from `resolveDerivation` in ANY of the
+ *    three origins → "answers exactly what resolveDerivation answers", which pins
+ *    a declared, a legacy and an unresolved-source document as whole objects
+ *    rather than field by field, because the promise is the whole answer;
+ *  * `resolveDerivation` indexing per SOURCE rather than per call, or a memo
+ *    creeping in behind it → "builds one index per call and none per source" and
+ *    "builds no index of its own when given one", which count the builder's
+ *    invocations through a `Map` subclass instead of timing anything. Their
+ *    positive control is the first assertion of each: an index that was never
+ *    consulted would report zero lookups, so a count of zero constructions could
+ *    otherwise be a resolver that reads no index at all.
  */
 import { describe, it, expect } from 'vitest'
 import {
   DERIVATION_ROLES,
+  derivationSourceIndex,
   emptyDerivation,
   normalizeDerivation,
   resolveDerivation,
+  resolveDerivationAgainst,
 } from './derivation'
+import type { DerivationSourceFields } from './derivation'
 
 const PRD = { document_id: 'prd_1', document_type: 'prd', title: 'Onboarding PRD' }
 const PRFAQ = { document_id: 'prfaq_1', document_type: 'prfaq', title: 'Onboarding PR/FAQ' }
@@ -508,5 +525,104 @@ describe('a cyclic reference chain', () => {
     expect(resolveDerivation(self, [self]).sources).toEqual([
       { document_id: 'self', role: 'reference', title: 'Self', document_type: 'prd', resolved: true },
     ])
+  })
+})
+
+describe('resolving against an index the caller already built', () => {
+  const DOCUMENTS = [PRD, PRFAQ]
+
+  /**
+   * One document per origin the contract distinguishes, plus the shape whose
+   * sources do NOT resolve — which is the case an index can get wrong in a way the
+   * other two cannot, because a missing entry and an empty one are what `resolved`
+   * tells apart.
+   */
+  const BY_ORIGIN = {
+    declared: {
+      document_id: 'prototype_1',
+      derivation: {
+        sources: [
+          { document_id: 'prd_1', role: 'prototype_prd' },
+          { document_id: 'prfaq_1', role: 'prototype_prfaq' },
+        ],
+        selected_document_count: 3,
+        feedback_count: 7,
+        persona_ids: ['persona_1'],
+        visual_document_ids: ['vis_1'],
+        product_context_included: true,
+      },
+    },
+    legacy: { document_id: 'merge_1', source_documents: ['prd_1', 'prfaq_1'] },
+    unresolved: { document_id: 'merge_2', source_documents: ['deleted_1'] },
+    none: { document_id: 'handwritten_1', title: 'Typed by hand' },
+  }
+
+  it('answers exactly what resolveDerivation answers', () => {
+    // WHOLE OBJECTS, not fields: the promise of the seam is the whole answer, and a
+    // per-field comparison is the one that lets `origin` or `resolved` drift. Asked
+    // of all four origins — declared, legacy, a source the project no longer holds,
+    // and nothing recoverable — because each takes a different path to the index.
+    const index = derivationSourceIndex(DOCUMENTS)
+    for (const [origin, document] of Object.entries(BY_ORIGIN)) {
+      expect(resolveDerivationAgainst(document, index), origin)
+        .toEqual(resolveDerivation(document, DOCUMENTS))
+    }
+    // The control: the four documents really do exercise the three origins, so the
+    // equality above is over answers that DIFFER rather than four empty ones.
+    expect(Object.values(BY_ORIGIN).map((d) => resolveDerivation(d, DOCUMENTS).origin))
+      .toEqual(['declared', 'legacy', 'legacy', 'none'])
+  })
+
+  it('reads what a source is from the given index and never from the wire again', () => {
+    // The decisive case for "the index is the caller's": an index disagreeing with
+    // any document list, so an answer carrying its titles could not have come from
+    // re-indexing anything. A resolver that rebuilt internally has no list to
+    // rebuild from here and would report both sources unresolved.
+    const index = new Map<string, DerivationSourceFields>([
+      ['prd_1', { title: 'Indexed PRD', document_type: 'prd' }],
+      ['prfaq_1', { title: 'Indexed PR/FAQ', document_type: 'prfaq' }],
+    ])
+
+    expect(resolveDerivationAgainst(BY_ORIGIN.legacy, index).sources).toEqual([
+      { document_id: 'prd_1', role: 'merge_input', title: 'Indexed PRD', document_type: 'prd', resolved: true },
+      { document_id: 'prfaq_1', role: 'merge_input', title: 'Indexed PR/FAQ', document_type: 'prfaq', resolved: true },
+    ])
+  })
+
+  it('consults the index once per source and holds no state between calls', () => {
+    // Counted rather than timed, so the assertion is about the work done and not
+    // about this machine: a Map that records every lookup. Two calls over one index
+    // is the shape the prioritization page's loop takes, and the second must cost
+    // the same as the first — a resolver caching its answers would show fewer
+    // lookups on the second pass and start reporting a document deleted between two
+    // reads as still present.
+    const lookups: string[] = []
+    class CountingIndex extends Map<string, DerivationSourceFields> {
+      override get(id: string): DerivationSourceFields | undefined {
+        lookups.push(id)
+        return super.get(id)
+      }
+    }
+    const index = new CountingIndex(derivationSourceIndex(DOCUMENTS))
+
+    const first = resolveDerivationAgainst(BY_ORIGIN.declared, index)
+    const second = resolveDerivationAgainst(BY_ORIGIN.declared, index)
+
+    // The positive control: the index WAS the source of the answer, so the count
+    // below is a real measurement rather than the silence of a resolver that never
+    // looked anything up.
+    expect(first.sources.map((s) => s.title)).toEqual(['Onboarding PRD', 'Onboarding PR/FAQ'])
+    expect(second).toEqual(first)
+    expect(lookups).toEqual(['prd_1', 'prfaq_1', 'prd_1', 'prfaq_1'])
+  })
+
+  it('indexes a document list once for every field a source displays', () => {
+    // One entry per readable document, carrying both resolved fields, and nothing
+    // for a record naming no document — which is what lets `resolved: false` mean
+    // "not among the documents supplied" rather than "supplied without a title".
+    const index = derivationSourceIndex([PRD, { title: 'No id' }, null, 'garbage', { document_id: '' }])
+
+    expect([...index.keys()]).toEqual(['prd_1'])
+    expect(index.get('prd_1')).toEqual({ title: 'Onboarding PRD', document_type: 'prd' })
   })
 })

--- a/voc-datalake/frontend/src/api/derivation.ts
+++ b/voc-datalake/frontend/src/api/derivation.ts
@@ -263,24 +263,20 @@ export type DerivationSourceFields = Pick<DerivationSource, 'title' | 'document_
  * A project's documents reduced to what resolving a source needs: document_id →
  * the fields a source displays.
  *
- * BUILT ONCE PER PROJECT COLLECTION PASS AND HANDED BACK IN, which is what this
- * type exists to make possible. `resolveDerivation` used to build one of these on
- * every call, which cost nothing while its only callers resolved one document at a
- * time — and became the whole cost the moment a caller asked about a LIST. The
- * prioritization page calls the lineage classifiers per row and each classifier
- * calls the resolver per document on that row, so one project read of D documents
- * was walked once per (row × document) instead of once: measured inside the page's
- * `useMemo` at 200 rows / 1000 documents, 1644 ms in this container's jsdom
- * (562 ms on the reviewing machine — issue #399 B).
+ * ONE INDEX PER PROJECT READ, NOT PER CALL, and it is the CALLER'S to build and
+ * hold: `resolveDerivation` used to build one on every call, which cost nothing
+ * while its callers resolved one document at a time and became the whole cost the
+ * moment a caller asked about a LIST (issue #399 B — the measurement and the loop
+ * that exposed it are recorded at `ProjectLineageSources`, which is the caller-side
+ * type the fix introduced).
  *
  * A LOOKUP TABLE RATHER THAN AN OPAQUE HANDLE, deliberately: everything a source
- * needs is already normalised into it (`displayString`, so an unreadable title or
- * type is '' and never null — `hasSupersededSource` in
- * pages/Prioritization/rowLineage.ts turns on exactly that), and nothing is
- * memoised behind it, so the index's LIFETIME is its holder's and there is no
- * cache anywhere to invalidate. Build it from `derivationSourceIndex` rather than
- * by hand: a map whose values did not come through that builder can carry a null
- * where every reader expects '', which is the one way to make a resolved source
+ * needs is already normalised into it by `displayString`, so an unreadable title or
+ * type is '' and never null — a distinction consumers turn on. Nothing is memoised
+ * behind it either, so the index's LIFETIME is its holder's and there is no cache
+ * anywhere to invalidate. Build it from `derivationSourceIndex` rather than by
+ * hand: a map whose values did not come through that builder can carry a null where
+ * every reader expects '', which is the one way to make a resolved source
  * indistinguishable from an unresolved one.
  */
 export type DerivationSourceIndex = ReadonlyMap<string, DerivationSourceFields>

--- a/voc-datalake/frontend/src/api/derivation.ts
+++ b/voc-datalake/frontend/src/api/derivation.ts
@@ -257,15 +257,41 @@ function isEmpty(derivation: DocumentDerivation): boolean {
 }
 
 /** What a source carries once its document was found. */
-type ResolvedSourceFields = Pick<DerivationSource, 'title' | 'document_type'>
+export type DerivationSourceFields = Pick<DerivationSource, 'title' | 'document_type'>
 
 /**
- * Index of document_id → the fields a source displays, over whatever the caller
- * supplied. One index for every resolved field, so a consumer needs one pass
- * over the document list rather than one per field it wants to render.
+ * A project's documents reduced to what resolving a source needs: document_id →
+ * the fields a source displays.
+ *
+ * BUILT ONCE PER PROJECT COLLECTION PASS AND HANDED BACK IN, which is what this
+ * type exists to make possible. `resolveDerivation` used to build one of these on
+ * every call, which cost nothing while its only callers resolved one document at a
+ * time — and became the whole cost the moment a caller asked about a LIST. The
+ * prioritization page calls the lineage classifiers per row and each classifier
+ * calls the resolver per document on that row, so one project read of D documents
+ * was walked once per (row × document) instead of once: measured inside the page's
+ * `useMemo` at 200 rows / 1000 documents, 1644 ms in this container's jsdom
+ * (562 ms on the reviewing machine — issue #399 B).
+ *
+ * A LOOKUP TABLE RATHER THAN AN OPAQUE HANDLE, deliberately: everything a source
+ * needs is already normalised into it (`displayString`, so an unreadable title or
+ * type is '' and never null — `hasSupersededSource` in
+ * pages/Prioritization/rowLineage.ts turns on exactly that), and nothing is
+ * memoised behind it, so the index's LIFETIME is its holder's and there is no
+ * cache anywhere to invalidate. Build it from `derivationSourceIndex` rather than
+ * by hand: a map whose values did not come through that builder can carry a null
+ * where every reader expects '', which is the one way to make a resolved source
+ * indistinguishable from an unresolved one.
  */
-function sourceFieldIndex(documents: readonly unknown[]): Map<string, ResolvedSourceFields> {
-  const index = new Map<string, ResolvedSourceFields>()
+export type DerivationSourceIndex = ReadonlyMap<string, DerivationSourceFields>
+
+/**
+ * Index the documents a source may resolve against — one pass over the list, for
+ * every resolved field at once, so a consumer needs one pass rather than one per
+ * field it wants to render.
+ */
+export function derivationSourceIndex(documents: readonly unknown[]): DerivationSourceIndex {
+  const index = new Map<string, DerivationSourceFields>()
   for (const raw of documents) {
     const record = asRecord(raw)
     if (!record) continue
@@ -299,10 +325,39 @@ function sourceFieldIndex(documents: readonly unknown[]): Map<string, ResolvedSo
  * never a source's sources. A cyclic chain (A built from B, B built from A) is
  * therefore inert — each call returns the other document, once, and there is no
  * traversal to loop.
+ *
+ * ONE DOCUMENT AT A TIME, and a caller asking about a LIST should reach for
+ * `resolveDerivationAgainst` instead: this overload indexes `projectDocuments`
+ * afresh on every call, so asking it about N documents of one project walks that
+ * project's list N times. Kept exactly as it was because that is the right
+ * signature for the callers that hold one document (DocumentsTab), and because
+ * every existing caller's behaviour is this function's contract.
  */
 export function resolveDerivation(
   document: unknown,
   projectDocuments: readonly unknown[] = [],
+): ResolvedDerivation {
+  return resolveDerivationAgainst(document, derivationSourceIndex(projectDocuments))
+}
+
+/**
+ * `resolveDerivation` against an index the caller already built — the same answer,
+ * without the per-call pass over the project's documents.
+ *
+ * THE SAME FUNCTION, not a faster approximation of it: `resolveDerivation` is now
+ * this function plus one `derivationSourceIndex` call, so there is no second
+ * resolution rule that could drift from the first. `derivation.test.ts` pins the
+ * equivalence on a declared, a legacy and an unresolved-source document anyway,
+ * because "one function delegates to the other" is a fact about today's source and
+ * the promise is about the answers.
+ *
+ * @param index Built by `derivationSourceIndex` from the project's documents, and
+ *   owned by whoever built it — see `DerivationSourceIndex` for why this is
+ *   explicit plumbing rather than a memo inside the resolver.
+ */
+export function resolveDerivationAgainst(
+  document: unknown,
+  index: DerivationSourceIndex,
 ): ResolvedDerivation {
   const record = asRecord(document)
   if (!record) return { ...emptyDerivation(), sources: [], origin: 'none' }
@@ -311,7 +366,6 @@ export function resolveDerivation(
   const useDeclared = !isEmpty(declared)
   const derivation = useDeclared ? declared : derivationFromLegacyFields(record)
 
-  const fields = sourceFieldIndex(projectDocuments)
   return {
     ...derivation,
     origin: originOf(derivation, useDeclared),
@@ -319,7 +373,7 @@ export function resolveDerivation(
       // One lookup decides all three: an unresolved source degrades every
       // resolved field to null together, so a consumer cannot render a type
       // without a title or vice versa.
-      const found = fields.get(source.document_id)
+      const found = index.get(source.document_id)
       return {
         document_id: source.document_id,
         role: source.role,

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.indexReuse.test.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.indexReuse.test.ts
@@ -1,0 +1,189 @@
+/**
+ * One project read is indexed ONCE for every row and every lineage rule asked
+ * about it (issue #399 B).
+ *
+ * COUNTED, NEVER TIMED, and that is the whole reason this file exists rather than
+ * an assertion inside `prioritizationUtils.test.ts`'s `collectRows` block: the
+ * defect was quadratic work, and a wall-clock threshold for it would either pass on
+ * a fast machine with the defect restored or fail on a loaded one without it. The
+ * countable thing is the number of times `derivationSourceIndex` is CALLED, which is
+ * a property of the code and identical on every machine — so the mock below wraps
+ * the real builder and changes nothing about the answers.
+ *
+ * REVERT MAP:
+ *
+ *  * `collectRows` passing `project.documents` instead of the prepared
+ *    `project.lineage` → "indexes a project read once however many rows name it"
+ *    (measured: the count goes from 1 to 13 at three rows, one per row per rule);
+ *  * `fresherCoherentSelection` passing `projectDocuments` to its nested
+ *    `classifySelectionLineage` → the same case (measured: 1 → 2, since one frozen
+ *    row's candidate is re-indexed);
+ *  * `projectLineageSources` hoisted out of the details loop, or shared between
+ *    projects → "indexes each project read separately", which is the assertion that
+ *    stops "once" being satisfied by an index built once for the whole page and
+ *    handed to every project — a row would then resolve its sources against another
+ *    project's documents;
+ *  * `lineageSourcesOf` building a fresh index even for a prepared read → both
+ *    cases.
+ *
+ * THE POSITIVE CONTROL each case carries is its lineage assertion, and it is not a
+ * formality: a `collectRows` that stopped classifying lineage altogether would also
+ * report one construction, or none. So each case first pins the row states the
+ * fixture is built to produce — a crossing, a coherent chain and an absent one — and
+ * only then the count.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import type { PrioritizationRow, Project, ProjectDocument } from '../../api/types'
+
+/**
+ * The real builder, wrapped in a counter.
+ *
+ * `importOriginal` rather than a stub, following `ScraperCard.test.tsx`: the answers
+ * must be the production ones, because the control assertions below read the lineage
+ * states this fixture is built to produce. Only the call count is observed.
+ */
+const indexBuilds = vi.hoisted(() => ({ count: 0 }))
+vi.mock('../../api/derivation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/derivation')>()
+  return {
+    ...actual,
+    derivationSourceIndex: (documents: readonly unknown[]) => {
+      indexBuilds.count += 1
+      return actual.derivationSourceIndex(documents)
+    },
+  }
+})
+
+const { collectRows } = await import('./prioritizationUtils')
+
+const project = (projectId: string, name: string): Project => ({
+  project_id: projectId,
+  name,
+  description: '',
+  status: 'active',
+  created_at: '',
+  updated_at: '',
+  persona_count: 0,
+  document_count: 0,
+})
+
+const doc = (
+  documentId: string,
+  documentType: ProjectDocument['document_type'],
+  createdAt: string,
+  extra: Record<string, unknown> = {},
+): ProjectDocument => ({
+  document_id: documentId,
+  document_type: documentType,
+  title: `${documentType} ${documentId}`,
+  content: '',
+  created_at: createdAt,
+  ...extra,
+})
+
+/** A declared derivation naming one source, as `lambda/shared/derivation.py` writes it. */
+const builtFrom = (...ids: readonly string[]) => ({
+  derivation: {
+    sources: ids.map((id) => ({ document_id: id, role: 'reference' })),
+    selected_document_count: ids.length,
+    feedback_count: 0,
+    persona_ids: [],
+    visual_document_ids: [],
+    product_context_included: false,
+  },
+})
+
+const storedRow = (
+  rowId: string,
+  projectId: string,
+  documentIds: readonly string[],
+  isFrozen = false,
+): PrioritizationRow => ({
+  row_id: rowId,
+  project_id: projectId,
+  document_ids: [...documentIds],
+  prototype_id: '',
+  is_default: true,
+  created_at: '2026-01-01',
+  is_frozen: isFrozen,
+})
+
+/**
+ * Documents of ONE project, shaped so the three rows below land in three different
+ * lineage states — which is what makes the control assertions distinguishing.
+ *
+ * `prfaq_1` is built from `prd_1`, and `prd_2` supersedes `prd_1`, so a row holding
+ * {prd_2, prfaq_1} crosses generations while {prd_2, prfaq_2} is one chain and
+ * {prd_3} (a hand-authored PRD recording nothing) is lineage-absent.
+ */
+const DOCUMENTS: ProjectDocument[] = [
+  doc('prd_1', 'prd', '2025-01-01T09:00:00Z'),
+  doc('prfaq_1', 'prfaq', '2025-01-01T09:00:00Z', builtFrom('prd_1')),
+  doc('prd_2', 'prd', '2025-02-01T09:00:00Z', builtFrom('prd_1')),
+  doc('prfaq_2', 'prfaq', '2025-02-01T09:00:00Z', builtFrom('prd_2')),
+  doc('prd_3', 'prd', '2025-03-01T09:00:00Z'),
+]
+
+const ROWS: Record<string, PrioritizationRow> = {
+  crossing: storedRow('crossing', 'p1', ['prd_2', 'prfaq_1'], true),
+  coherent: storedRow('coherent', 'p1', ['prd_2', 'prfaq_2'], true),
+  absent: storedRow('absent', 'p1', ['prd_3'], true),
+}
+
+/** State and reason per row id, so a control assertion reads as one object. */
+const lineageByRow = (rows: ReturnType<typeof collectRows>) => Object.fromEntries(
+  rows.map((row) => [row.row_id, `${row.lineage.state}/${row.lineage.reason}`]),
+)
+
+describe('collectRows indexes each project read once', () => {
+  it('indexes a project read once however many rows name it', () => {
+    indexBuilds.count = 0
+
+    const rows = collectRows(ROWS, [{ documents: DOCUMENTS }], [project('p1', 'P1')])
+
+    // The control, asserted FIRST: three rows really were classified, in three
+    // different states, off the shared index. A `collectRows` that skipped the
+    // lineage would report one construction too — or none — so the count below only
+    // means something once this holds.
+    expect(lineageByRow(rows)).toEqual({
+      crossing: 'crossGeneration/supersededSource',
+      coherent: 'coherent/oneChain',
+      absent: 'absent/noneRecorded',
+    })
+    // ONE, not "three" and not "one per rule": the three rows, the classifier's two
+    // derivation-reading rules, and the frozen rows' candidate classification all
+    // read the same index. Before this change the resolver built one per call, so the
+    // same fixture built 13.
+    expect(indexBuilds.count).toBe(1)
+  })
+
+  it('indexes each project read separately', () => {
+    // The other direction, and the reason "once" is not enough on its own: an index
+    // built once for the WHOLE page would satisfy the case above while resolving one
+    // project's sources against another project's documents. Two projects, so the
+    // count tracks project reads rather than being pinned at 1.
+    indexBuilds.count = 0
+    const second = [doc('prd_9', 'prd', '2025-01-01T09:00:00Z', builtFrom('prd_1'))]
+
+    const rows = collectRows(
+      { ...ROWS, other: storedRow('other', 'p2', ['prd_9'], true) },
+      [{ documents: DOCUMENTS }, { documents: second }],
+      [project('p1', 'P1'), project('p2', 'P2')],
+    )
+
+    // The control: `prd_9` names `prd_1` as its source, which project 2 does NOT
+    // hold — so it resolves against project 2's own index and stays unresolved,
+    // reading `coherent` rather than crossing with project 1's PRD.
+    expect(lineageByRow(rows).other).toBe('coherent/oneChain')
+    expect(indexBuilds.count).toBe(2)
+  })
+
+  it('builds nothing for a page whose project reads have not landed', () => {
+    // The floor: no project read, no index. Pins that the builder moved into the
+    // details loop rather than being called unconditionally per page render.
+    indexBuilds.count = 0
+
+    expect(collectRows(ROWS, undefined, undefined)).toStrictEqual([])
+    expect(indexBuilds.count).toBe(0)
+  })
+})

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.indexReuse.test.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.indexReuse.test.ts
@@ -10,6 +10,19 @@
  * a property of the code and identical on every machine — so the mock below wraps
  * the real builder and changes nothing about the answers.
  *
+ * COUNTING THE INDEX BUILDER ALONE WAS NOT ENOUGH, which is the reason the second
+ * counter below exists. `vi.mock` replaces the binding OTHER modules import;
+ * `resolveDerivation` calls `derivationSourceIndex` through the module-local binding
+ * inside `derivation.ts`, which no mock of this module can reach. So the single most
+ * likely regression — `hasSupersededSource`/`recordsNoLineage` going back to
+ * `resolveDerivation(raw, projectDocuments)`, which is exactly the code #399 B
+ * replaces — rebuilt one index per resolver call and still reported
+ * `indexBuilds.count === 1` (measured: the whole suite stayed green under that
+ * revert). What closes the hole is counting the OTHER side of the seam: every
+ * resolution on this page's path must go through `resolveDerivationAgainst`, so
+ * `resolveDerivation` must be called ZERO times during `collectRows`, and any route
+ * back through it is visible whether or not it happens to rebuild an index.
+ *
  * REVERT MAP:
  *
  *  * `collectRows` passing `project.documents` instead of the prepared
@@ -18,6 +31,13 @@
  *  * `fresherCoherentSelection` passing `projectDocuments` to its nested
  *    `classifySelectionLineage` → the same case (measured: 1 → 2, since one frozen
  *    row's candidate is re-indexed);
+ *  * `hasSupersededSource`/`recordsNoLineage` reverted to their pre-#399 B
+ *    `resolveDerivation(raw, projectDocuments)` — the faithful `git revert` of the
+ *    hot path, with `collectRows`' `projectLineageSources` left in place → "indexes a
+ *    project read once however many rows name it", and ONLY via its
+ *    `resolveDerivationCalls.count` assertion (measured: 11 calls, expected 0; the
+ *    `indexBuilds.count === 1` assertion beside it stays green, which is why that
+ *    assertion is not the one this entry names);
  *  * `projectLineageSources` hoisted out of the details loop, or shared between
  *    projects → "indexes each project read separately", which is the assertion that
  *    stops "once" being satisfied by an index built once for the whole page and
@@ -36,13 +56,23 @@ import { describe, it, expect, vi } from 'vitest'
 import type { PrioritizationRow, Project, ProjectDocument } from '../../api/types'
 
 /**
- * The real builder, wrapped in a counter.
+ * The real builder and the per-call resolver, each wrapped in a counter.
  *
  * `importOriginal` rather than a stub, following `ScraperCard.test.tsx`: the answers
  * must be the production ones, because the control assertions below read the lineage
- * states this fixture is built to produce. Only the call count is observed.
+ * states this fixture is built to produce. Only the call counts are observed.
+ *
+ * TWO COUNTERS BECAUSE ONE OF THEM CANNOT SEE INSIDE `derivation.ts`. This mock
+ * replaces the bindings other modules import, so `indexBuilds` counts the index
+ * builds `rowLineage.ts`/`prioritizationUtils.ts` ask for and NOT the one
+ * `resolveDerivation` makes for itself through its module-local binding.
+ * `resolveDerivationCalls` covers exactly that blind spot: it is the per-call
+ * resolver this optimisation replaces, so on the page's path it must never be
+ * reached at all. See the file docstring for the revert that proved one counter
+ * insufficient.
  */
 const indexBuilds = vi.hoisted(() => ({ count: 0 }))
+const resolveDerivationCalls = vi.hoisted(() => ({ count: 0 }))
 vi.mock('../../api/derivation', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../api/derivation')>()
   return {
@@ -50,6 +80,10 @@ vi.mock('../../api/derivation', async (importOriginal) => {
     derivationSourceIndex: (documents: readonly unknown[]) => {
       indexBuilds.count += 1
       return actual.derivationSourceIndex(documents)
+    },
+    resolveDerivation: (document: unknown, projectDocuments?: readonly unknown[]) => {
+      resolveDerivationCalls.count += 1
+      return actual.resolveDerivation(document, projectDocuments)
     },
   }
 })
@@ -138,6 +172,7 @@ const lineageByRow = (rows: ReturnType<typeof collectRows>) => Object.fromEntrie
 describe('collectRows indexes each project read once', () => {
   it('indexes a project read once however many rows name it', () => {
     indexBuilds.count = 0
+    resolveDerivationCalls.count = 0
 
     const rows = collectRows(ROWS, [{ documents: DOCUMENTS }], [project('p1', 'P1')])
 
@@ -155,6 +190,14 @@ describe('collectRows indexes each project read once', () => {
     // read the same index. Before this change the resolver built one per call, so the
     // same fixture built 13.
     expect(indexBuilds.count).toBe(1)
+    // ZERO, and this is the assertion the count above cannot make. `resolveDerivation`
+    // indexes the project list for ITSELF, through a binding inside `derivation.ts`
+    // that no mock of that module reaches — so a rule going back to
+    // `resolveDerivation(raw, projectDocuments)` rebuilds an index per resolver call
+    // and `indexBuilds.count` still reads 1. Every resolution on this page's path
+    // must go through `resolveDerivationAgainst`, which is a property of the code
+    // and countable here whether or not the route back happens to re-index.
+    expect(resolveDerivationCalls.count).toBe(0)
   })
 
   it('indexes each project read separately', () => {

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
@@ -75,9 +75,8 @@ export interface PrioritizationRowView {
    * where the row's documents and the project's are both already in hand
    * (`collectRows`), so nothing can look the documents up a second time and
    * disagree with the first — and the source index those lookups go through is
-   * built there ONCE per project read rather than per call, which is what took
-   * the reviewed 200-row / 1000-document fixture from 1644 ms to 615 ms in this
-   * container's jsdom (issue #399 B).
+   * built there ONCE per project read rather than per call (see
+   * `ProjectLineageSources`, issue #399 B, for the measurement).
    *
    * DESCRIBES, NEVER GATES. Every state is scorable and keeps every composition
    * control it would otherwise have; the only thing this decides is what the row
@@ -1558,11 +1557,18 @@ export function collectRows(
    * recorded source against. Both were built inside the per-row loop, over a list
    * that cannot change while it runs, so one project read of D documents was walked
    * once per row — and the index, which the classifiers ask for per row AND per
-   * document on that row, once per (row × document × rule). Measured at 200 rows /
-   * 1000 documents: 1644 ms in this container's jsdom, 562 ms as reviewed in issue
-   * #399 B. Prepared here rather than memoised inside the shared helper so the
+   * document on that row, once per (row × document × rule). ONE SOURCE INDEX PER
+   * PROJECT READ, NOT PER CALL; see `ProjectLineageSources` (issue #399 B) for the
+   * measurement, and `prioritizationUtils.indexReuse.test.ts` for the count that
+   * pins it. Prepared here rather than memoised inside the shared helper so the
    * index's lifetime is this pass's and there is nothing to invalidate — the next
    * call gets a new one from whatever the reads then say.
+   *
+   * PER PROJECT READ AND NOT PER ROW, which is one `Map` and one index MORE than
+   * before for a loaded project no visible row names — `byId` used to be built
+   * lazily inside the loop. Deliberate: `Prioritization.tsx` fans out over exactly
+   * the projects it shows, so the untouched-project case is hypothetical, while the
+   * per-row rebuild was the measured cost.
    */
   const byProject = new Map<string, {
     name: string;

--- a/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/prioritizationUtils.ts
@@ -4,8 +4,8 @@
  */
 
 import { z } from 'zod'
-import { rowLineageOf } from './rowLineage'
-import type { RowLineage } from './rowLineage'
+import { projectLineageSources, rowLineageOf } from './rowLineage'
+import type { ProjectLineageSources, RowLineage } from './rowLineage'
 import type {
   Project, ProjectDocument, PrioritizationScore, PrioritizationAggregate,
   PrioritizationBallotEdit, PrioritizationRow,
@@ -70,11 +70,14 @@ export interface PrioritizationRowView {
    * not itself cross generations. See `rowLineage`.
    *
    * ON THE VIEW rather than derived in the component, for the reason the team
-   * view is resolved once before the sort: `resolveDerivation` runs per document
-   * per row, and this page re-renders on every slider drag. Resolved where the
-   * row's documents and the project's are both already in hand
+   * view is resolved once before the sort: the derivation resolver runs per
+   * document per row, and this page re-renders on every slider drag. Resolved
+   * where the row's documents and the project's are both already in hand
    * (`collectRows`), so nothing can look the documents up a second time and
-   * disagree with the first.
+   * disagree with the first — and the source index those lookups go through is
+   * built there ONCE per project read rather than per call, which is what took
+   * the reviewed 200-row / 1000-document fixture from 1644 ms to 615 ms in this
+   * container's jsdom (issue #399 B).
    *
    * DESCRIBES, NEVER GATES. Every state is scorable and keeps every composition
    * control it would otherwise have; the only thing this decides is what the row
@@ -1547,23 +1550,42 @@ export function collectRows(
   projects: readonly Project[] | undefined,
 ): PrioritizationRowView[] {
   if (!allProjectDetails || !projects) return []
+  /**
+   * Each project read, prepared ONCE for however many rows name it.
+   *
+   * `byId` resolves a row's stored ids and its prototype; `lineage` is the same
+   * documents plus the derivation source index the lineage rules resolve every
+   * recorded source against. Both were built inside the per-row loop, over a list
+   * that cannot change while it runs, so one project read of D documents was walked
+   * once per row — and the index, which the classifiers ask for per row AND per
+   * document on that row, once per (row × document × rule). Measured at 200 rows /
+   * 1000 documents: 1644 ms in this container's jsdom, 562 ms as reviewed in issue
+   * #399 B. Prepared here rather than memoised inside the shared helper so the
+   * index's lifetime is this pass's and there is nothing to invalidate — the next
+   * call gets a new one from whatever the reads then say.
+   */
   const byProject = new Map<string, {
     name: string;
     documents: ProjectDocument[]
+    byId: Map<string, ProjectDocument>
+    lineage: ProjectLineageSources
   }>()
   for (const [index, detail] of allProjectDetails.entries()) {
     const project = projects[index]
     if (!project || !detail) continue
+    const documents = detail.documents ?? []
     byProject.set(project.project_id, {
       name: project.name,
-      documents: detail.documents ?? [],
+      documents,
+      byId: new Map(documents.map((doc) => [doc.document_id, doc])),
+      lineage: projectLineageSources(documents),
     })
   }
 
   return Object.values(rows).flatMap((row): PrioritizationRowView[] => {
     const project = byProject.get(row.project_id)
     if (!project) return []
-    const byId = new Map(project.documents.map((doc) => [doc.document_id, doc]))
+    const byId = project.byId
     const documents = row.document_ids
       .flatMap((documentId) => {
         const doc = byId.get(documentId)
@@ -1610,7 +1632,7 @@ export function collectRows(
         is_frozen: row.is_frozen,
         documents,
         composition_truncated: documents.length !== row.document_ids.length,
-      }, project.documents),
+      }, project.lineage),
       prototype: byId.get(row.prototype_id) ?? latestPrototypeOf(project.documents),
     }]
   })

--- a/voc-datalake/frontend/src/pages/Prioritization/rowLineage.test.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/rowLineage.test.ts
@@ -97,6 +97,18 @@
  *    version" (the case `lineage.staleReason`'s wording answers to);
  *  * `selectionEntry`'s id requirement deleted → "an unreadable document decides
  *    nothing";
+ *  * `lineageSourcesOf`'s nullish guard deleted (back to a bare `'sourceIndex' in
+ *    project`) → "resolves nothing rather than throwing when the project read is
+ *    missing entirely", which is the module's "no throwing" promise at the one input
+ *    `in` raises a TypeError on;
+ *  * either arm of `ProjectLineageRead` diverging from the other — `lineageSourcesOf`
+ *    ignoring a prepared read's `sourceIndex`, or `fresherCoherentSelection` reading
+ *    `newestOfType` off a different list than its nested classify's index → "answers
+ *    the same for a document list as for a read prepared from it", plus the empty-list
+ *    case beside it. Pinned where the union is DECLARED rather than left to
+ *    `prioritizationUtils.indexReuse.test.ts`, because the "one delegates to the
+ *    other" argument that carries the resolver seam does not carry here: the two arms
+ *    diverge at three separate reads;
  *  * any two `LINEAGE_REASON_KEY` entries cross-wired → "gives each reason the sentence
  *    that describes IT". `tsc` pins that table's COVERAGE (a `Record` over the union)
  *    and "names every state and every reason with a key the catalogue holds" pins that
@@ -196,6 +208,7 @@ import {
   fresherCoherentSelection,
   LINEAGE_REASON_KEY,
   LINEAGE_STYLE,
+  projectLineageSources,
   rowLineageOf,
 } from './rowLineage'
 import type { LineageReason } from './rowLineage'
@@ -753,6 +766,84 @@ describe('a selection of documents reads as coherent, crossing generations, or u
     const direct = doc('prfaq_d', 'prfaq', '2025-01-20', builtFrom('prd_1'))
     expect(classifySelectionLineage([prd2, direct], [prd1, prd2, direct]))
       .toEqual({ state: 'crossGeneration', reason: 'supersededSource' })
+  })
+
+  it('resolves nothing rather than throwing when the project read is missing entirely', () => {
+    // NOT an unreachable branch dressed up as a case: every in-repo call site is typed,
+    // but this module's docstring promises "no throwing" and the rules are reachable
+    // from component code, where a project detail that has not landed is `undefined`
+    // rather than `[]`. `lineageSourcesOf` narrows on `'sourceIndex' in project`, and
+    // `in` raises a TypeError on a nullish value — where the pre-index path bottomed out
+    // in `resolveDerivation`'s `projectDocuments = []` default and simply resolved
+    // nothing. Both spellings, because `== null` is what covers them together.
+    const prfaq = doc('prfaq_1', 'prfaq', '2025-02-01', builtFrom('prd_1'))
+
+    for (const missing of [undefined, null]) {
+      expect(classifySelectionLineage([prfaq], missing as never))
+        .toEqual({ state: 'coherent', reason: 'oneChain' })
+      expect(fresherCoherentSelection([prfaq], missing as never)).toBeNull()
+      expect(rowLineageOf({ is_frozen: true, documents: [prfaq] }, missing as never).stale)
+        .toBe(false)
+    }
+    // The control: `prd_1` is the source this PR/FAQ names, so with a project read that
+    // CARRIES it beside another PRD the same selection crosses generations. The answers
+    // above are therefore "the sources resolved against nothing", not a classifier that
+    // answers `coherent` regardless.
+    const prd1 = doc('prd_1', 'prd', '2025-01-01', builtFromFeedback)
+    const prd2 = doc('prd_2', 'prd', '2025-03-01', builtFromFeedback)
+    expect(classifySelectionLineage([prfaq, prd2], [prd1, prd2, prfaq]))
+      .toEqual({ state: 'crossGeneration', reason: 'supersededSource' })
+  })
+})
+
+describe('the two shapes of project read a rule accepts answer identically', () => {
+  /**
+   * PINNED WHERE THE UNION IS DECLARED, and not left to `collectRows`' coverage. The
+   * equivalence argument that carries `resolveDerivationAgainst` — one function
+   * delegating to the other — does not carry here: `fresherCoherentSelection` reads
+   * `sources.documents` for `newestOfType` and `sources.sourceIndex` for its nested
+   * classify, so the prepared arm and the list arm diverge at three separate reads
+   * rather than one. Each rule is asked both ways over one fixture, and the answers
+   * must be the same object.
+   */
+  const prd1 = doc('prd_1', 'prd', '2025-01-01', builtFromFeedback)
+  const prfaq1 = doc('prfaq_1', 'prfaq', '2025-01-01', builtFrom('prd_1'))
+  const prd2 = doc('prd_2', 'prd', '2025-03-01', builtFrom('prd_1'))
+  const prfaq2 = doc('prfaq_2', 'prfaq', '2025-03-01', builtFrom('prd_2'))
+  const documents = [prd1, prfaq1, prd2, prfaq2]
+
+  it('answers the same for a document list as for a read prepared from it', () => {
+    const prepared = projectLineageSources(documents)
+    // A row crossing generations (its PR/FAQ names the PRD the row's other document
+    // supersedes) AND stale, so all three rules have something to say — asserted as
+    // literals first, so the equalities below are over answers that are not the empty
+    // or default one.
+    const row = { is_frozen: true, documents: [prd2, prfaq1] }
+    expect(classifySelectionLineage(row.documents, documents))
+      .toEqual({ state: 'crossGeneration', reason: 'supersededSource' })
+    expect(fresherCoherentSelection(row.documents, documents)).toEqual(['prd_2', 'prfaq_2'])
+    expect(rowLineageOf(row, documents).stale).toBe(true)
+
+    expect(classifySelectionLineage(row.documents, prepared))
+      .toEqual(classifySelectionLineage(row.documents, documents))
+    expect(fresherCoherentSelection(row.documents, prepared))
+      .toEqual(fresherCoherentSelection(row.documents, documents))
+    expect(rowLineageOf(row, prepared)).toEqual(rowLineageOf(row, documents))
+  })
+
+  it('answers the same for a read prepared from an EMPTY list as for that list', () => {
+    // The other end of the fixture range, and the one that would catch a prepared arm
+    // reading its documents from somewhere other than the read it was given: with no
+    // project documents nothing resolves, so a row that crosses generations above is
+    // merely coherent, and no candidate can be formed.
+    const row = { is_frozen: true, documents: [prd2, prfaq1] }
+    expect(classifySelectionLineage(row.documents, projectLineageSources([])))
+      .toEqual(classifySelectionLineage(row.documents, []))
+    expect(rowLineageOf(row, projectLineageSources([]))).toEqual(rowLineageOf(row, []))
+    // The control that these are the "resolved nothing" answers rather than the
+    // crossing ones, so the equalities are not both reporting the same rich answer.
+    expect(rowLineageOf(row, projectLineageSources([])))
+      .toEqual({ state: 'coherent', reason: 'oneChain', stale: false, fresherDocumentIds: [] })
   })
 })
 

--- a/voc-datalake/frontend/src/pages/Prioritization/rowLineage.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/rowLineage.ts
@@ -16,6 +16,17 @@
  * — plus the documents' own `document_type` and `created_at`, which the project
  * read already carries. No route changes, no new field on the wire.
  *
+ * ONE SOURCE INDEX PER PROJECT READ, NOT PER CALL, which is the only thing about
+ * these rules a caller has to know (issue #399 B). The resolver looks each recorded
+ * source up in an index of the project's documents; these rules are asked per ROW
+ * and each of them asks the resolver per DOCUMENT on that row, so an index built
+ * inside the resolver was rebuilt (rows × documents × rules) times over one
+ * unchanging project read — 1644 ms at 200 rows / 1000 documents in this
+ * container's jsdom, 562 ms as reviewed. Every exported rule therefore takes EITHER
+ * the document list or a read `projectLineageSources` prepared from it; see
+ * `ProjectLineageSources` for why the index is the caller's to hold rather than a
+ * memo inside the shared helper.
+ *
  * ROLE-BLIND ON PURPOSE. Every entry of the closed role vocabulary
  * (`DERIVATION_ROLES`: reference, prototype_prd, prototype_prfaq, merge_input) is
  * read as one thing — "this document was built from that one" — because that is
@@ -42,7 +53,8 @@
  * @module pages/Prioritization/rowLineage
  */
 
-import { resolveDerivation } from '../../api/derivation'
+import { derivationSourceIndex, resolveDerivationAgainst } from '../../api/derivation'
+import type { DerivationSourceIndex } from '../../api/derivation'
 import { asRecord, displayString } from '../../api/wireRecord'
 
 /**
@@ -133,6 +145,68 @@ export interface RowLineage extends SelectionLineage {
 
 /** Shared empty list, so the common non-stale answer allocates nothing. */
 const NO_IDS: readonly string[] = []
+
+/**
+ * A project read prepared for these rules: the documents themselves, plus the
+ * derivation source index built ONCE over them.
+ *
+ * WHY THE INDEX TRAVELS WITH THE DOCUMENTS RATHER THAN BESIDE THEM. Every rule
+ * below asks the project read one of two questions — "what IS the document this
+ * source names" (the index) and "what does the project hold of this type" (the
+ * list) — and they have to be asking about the SAME read, or a row is classified
+ * against one project and advised against another. A second parameter carrying a
+ * prebuilt index could be handed a stale one by a caller that resolved its
+ * documents twice; one object built by `projectLineageSources` cannot.
+ *
+ * WHY IT IS THE CALLER'S TO BUILD, and not a memo inside `resolveDerivation`
+ * (issue #399 B). These classifiers are called per ROW and each of them calls the
+ * resolver per DOCUMENT on that row, so the index the resolver used to build
+ * per call was rebuilt (rows × documents × rules) times over one unchanging
+ * project read — 1644 ms at 200 rows / 1000 documents in this container's jsdom,
+ * 562 ms as reviewed. Passing it in keeps the index's LIFETIME the collection
+ * pass's own (`collectRows`), so there is no cache to invalidate when a project
+ * read lands, a document is deleted, or a row is recomposed: the next pass builds
+ * a new one and the old one is garbage.
+ */
+export interface ProjectLineageSources {
+  /** The project's documents, as the project read supplied them. */
+  readonly documents: readonly unknown[]
+  /** `derivationSourceIndex` over exactly those documents. */
+  readonly sourceIndex: DerivationSourceIndex
+}
+
+/**
+ * A project read prepared once for every row and every rule that will be asked
+ * about it.
+ */
+export function projectLineageSources(projectDocuments: readonly unknown[]): ProjectLineageSources {
+  return { documents: projectDocuments, sourceIndex: derivationSourceIndex(projectDocuments) }
+}
+
+/**
+ * What the exported rules accept for "the project read": the documents, or a
+ * `ProjectLineageSources` already prepared from them.
+ *
+ * BOTH, so hoisting the index is the CALLER'S optimisation and not a new contract
+ * every call site has to satisfy. A caller holding one selection and one document
+ * list — every case at this seam, and `RowLineagePanels`' eventual one — passes the
+ * list and pays for one index, exactly as before; the page's per-row loop prepares
+ * the read once and passes that. The two paths are the same code one line down:
+ * `lineageSourcesOf` builds from a list and returns a prepared read untouched.
+ */
+export type ProjectLineageRead = readonly unknown[] | ProjectLineageSources
+
+/**
+ * The prepared read, building one only for the caller that passed a plain list.
+ *
+ * Narrowed on `'sourceIndex' in project` rather than on `Array.isArray`, which
+ * `tsc` refuses to narrow a `readonly unknown[]` arm out of (its signature answers
+ * `any[]`, and a readonly array is not one) — leaving the list in the prepared
+ * branch's type.
+ */
+function lineageSourcesOf(project: ProjectLineageRead): ProjectLineageSources {
+  return 'sourceIndex' in project ? project : projectLineageSources(project)
+}
 
 /**
  * One document reduced to what a generation check reads off it.
@@ -285,7 +359,7 @@ function repeatsAType(selected: readonly SelectedDocument[]): boolean {
 function hasSupersededSource(
   selection: readonly unknown[],
   selected: readonly SelectedDocument[],
-  projectDocuments: readonly unknown[],
+  sourceIndex: DerivationSourceIndex,
 ): boolean {
   const selectedIds = new Set(selected.map((entry) => entry.id))
   return selection.some((raw) => {
@@ -299,7 +373,7 @@ function hasSupersededSource(
         .filter((held) => held.id !== entry.id && held.type !== '')
         .map((held) => held.type),
     )
-    return resolveDerivation(raw, projectDocuments).sources.some((source) => (
+    return resolveDerivationAgainst(raw, sourceIndex).sources.some((source) => (
       !selectedIds.has(source.document_id)
       && source.document_type !== null
       && otherTypes.has(source.document_type)
@@ -334,11 +408,11 @@ function hasSupersededSource(
  */
 function recordsNoLineage(
   selection: readonly unknown[],
-  projectDocuments: readonly unknown[],
+  sourceIndex: DerivationSourceIndex,
 ): boolean {
   return selection
     .filter((raw) => selectionEntry(raw) !== null)
-    .every((raw) => resolveDerivation(raw, projectDocuments).origin === 'none')
+    .every((raw) => resolveDerivationAgainst(raw, sourceIndex).origin === 'none')
 }
 
 /**
@@ -365,14 +439,18 @@ function recordsNoLineage(
  * @param selection The row's own documents, as the project read supplied them.
  *   Concrete records rather than ids, because the caller has already resolved
  *   them (`collectRows`) and a second lookup could disagree with the first.
- * @param projectDocuments The project's documents, used only to resolve what each
+ * @param project The project's documents, used only to resolve what each
  *   recorded source IS — its type. A source that is not among them stays
- *   unresolved and decides nothing; see `hasSupersededSource`.
+ *   unresolved and decides nothing; see `hasSupersededSource`. A caller
+ *   classifying MANY selections against one project read passes
+ *   `projectLineageSources(documents)` instead of the list, which is the same
+ *   answer with the source index built once — see `ProjectLineageRead`.
  */
 export function classifySelectionLineage(
   selection: readonly unknown[],
-  projectDocuments: readonly unknown[],
+  project: ProjectLineageRead,
 ): SelectionLineage {
+  const sources = lineageSourcesOf(project)
   const selected = selectionEntries(selection)
   if (repeatsAType(selected)) {
     return {
@@ -380,13 +458,13 @@ export function classifySelectionLineage(
       reason: 'repeatedType',
     }
   }
-  if (hasSupersededSource(selection, selected, projectDocuments)) {
+  if (hasSupersededSource(selection, selected, sources.sourceIndex)) {
     return {
       state: 'crossGeneration',
       reason: 'supersededSource',
     }
   }
-  if (recordsNoLineage(selection, projectDocuments)) {
+  if (recordsNoLineage(selection, sources.sourceIndex)) {
     return {
       state: 'absent',
       reason: 'noneRecorded',
@@ -774,8 +852,10 @@ function newestOfType(
  */
 export function fresherCoherentSelection(
   selection: readonly unknown[],
-  projectDocuments: readonly unknown[],
+  project: ProjectLineageRead,
 ): readonly string[] | null {
+  const sources = lineageSourcesOf(project)
+  const projectDocuments = sources.documents
   const selected = selectionEntries(selection)
   // `repeatsAType` AND NOT `hasSupersededSource`, which is the one place the two
   // rules that both answer `crossGeneration` are treated differently — deliberately,
@@ -917,7 +997,10 @@ export function fresherCoherentSelection(
   // not. `lineage.staleReason` is worded to that limit rather than to the stronger
   // claim — see the fifth condition, and `hasSupersededSource` for why traversing
   // would grey the ordinary regenerated row instead of fixing this.
-  if (classifySelectionLineage(records, projectDocuments).state === 'crossGeneration') return null
+  // The PREPARED read, not `projectDocuments`: the candidate is classified against
+  // the same project and the same source index this call was asked about, so the
+  // nested call cannot re-index a list the caller already indexed.
+  if (classifySelectionLineage(records, sources).state === 'crossGeneration') return null
   return chosen.map((entry) => entry.id)
 }
 
@@ -974,11 +1057,18 @@ export function rowLineageOf(
      */
     readonly composition_truncated?: boolean
   },
-  projectDocuments: readonly unknown[],
+  /**
+   * The project's documents, or a read `projectLineageSources` already prepared
+   * from them. A caller with ONE row passes the list; `collectRows` prepares the
+   * read once and passes it for every row of that project, which is what stops one
+   * project read being re-indexed per row — see `ProjectLineageSources`.
+   */
+  project: ProjectLineageRead,
 ): RowLineage {
-  const lineage = classifySelectionLineage(row.documents, projectDocuments)
+  const sources = lineageSourcesOf(project)
+  const lineage = classifySelectionLineage(row.documents, sources)
   const fresher = row.is_frozen && row.composition_truncated !== true
-    ? fresherCoherentSelection(row.documents, projectDocuments)
+    ? fresherCoherentSelection(row.documents, sources)
     : null
   return {
     ...lineage,

--- a/voc-datalake/frontend/src/pages/Prioritization/rowLineage.ts
+++ b/voc-datalake/frontend/src/pages/Prioritization/rowLineage.ts
@@ -21,11 +21,10 @@
  * source up in an index of the project's documents; these rules are asked per ROW
  * and each of them asks the resolver per DOCUMENT on that row, so an index built
  * inside the resolver was rebuilt (rows × documents × rules) times over one
- * unchanging project read — 1644 ms at 200 rows / 1000 documents in this
- * container's jsdom, 562 ms as reviewed. Every exported rule therefore takes EITHER
- * the document list or a read `projectLineageSources` prepared from it; see
+ * unchanging project read. Every exported rule therefore takes EITHER the document
+ * list or a read `projectLineageSources` prepared from it. See
  * `ProjectLineageSources` for why the index is the caller's to hold rather than a
- * memo inside the shared helper.
+ * memo inside the shared helper, and for the measurement.
  *
  * ROLE-BLIND ON PURPOSE. Every entry of the closed role vocabulary
  * (`DERIVATION_ROLES`: reference, prototype_prd, prototype_prfaq, merge_input) is
@@ -160,13 +159,22 @@ const NO_IDS: readonly string[] = []
  *
  * WHY IT IS THE CALLER'S TO BUILD, and not a memo inside `resolveDerivation`
  * (issue #399 B). These classifiers are called per ROW and each of them calls the
- * resolver per DOCUMENT on that row, so the index the resolver used to build
- * per call was rebuilt (rows × documents × rules) times over one unchanging
- * project read — 1644 ms at 200 rows / 1000 documents in this container's jsdom,
- * 562 ms as reviewed. Passing it in keeps the index's LIFETIME the collection
- * pass's own (`collectRows`), so there is no cache to invalidate when a project
- * read lands, a document is deleted, or a row is recomposed: the next pass builds
- * a new one and the old one is garbage.
+ * resolver per DOCUMENT on that row, so the index the resolver used to build per
+ * call was rebuilt (rows × documents × rules) times over one unchanging project
+ * read. Passing it in keeps the index's LIFETIME the collection pass's own
+ * (`collectRows`), so there is no cache to invalidate when a project read lands, a
+ * document is deleted, or a row is recomposed: the next pass builds a new one and
+ * the old one is garbage.
+ *
+ * THE MEASUREMENT, STATED ONCE HERE because this is the type the fix introduced and
+ * every other site states the invariant instead. At 200 rows / 1000 documents one
+ * `collectRows` pass indexed the same 1000-document list roughly 2,600 times rather
+ * than once, which was 1644 ms and is 615 ms — a 2.7× pass, jsdom under this
+ * container. The same fixture's before was reported at 562 ms on the reviewing
+ * machine (issue #399 B), which is the useful thing to know about the figures: wall
+ * clock here is ~3× a reviewer's and reproduces nowhere, so the RATIO is the
+ * evidence and the invariant above is what the code has to hold. Counted rather
+ * than timed by `prioritizationUtils.indexReuse.test.ts`, for that reason.
  */
 export interface ProjectLineageSources {
   /** The project's documents, as the project read supplied them. */
@@ -203,8 +211,16 @@ export type ProjectLineageRead = readonly unknown[] | ProjectLineageSources
  * `tsc` refuses to narrow a `readonly unknown[]` arm out of (its signature answers
  * `any[]`, and a readonly array is not one) — leaving the list in the prepared
  * branch's type.
+ *
+ * NULLISH IS AN EMPTY READ, not a throw, which restores this module's "no throwing"
+ * contract: `in` raises a `TypeError` on null or undefined, where the pre-#399 B path
+ * bottomed out in `resolveDerivation`'s `projectDocuments = []` default and simply
+ * resolved nothing. Every in-repo call site is typed, so the guard is unreachable
+ * today — but a project detail that has not landed is exactly the shape a component
+ * passes through, and silence is the failure mode every other rule here chose.
  */
 function lineageSourcesOf(project: ProjectLineageRead): ProjectLineageSources {
+  if (project == null) return projectLineageSources([])
   return 'sourceIndex' in project ? project : projectLineageSources(project)
 }
 


### PR DESCRIPTION
Closes section **B** of #399 (`resolveDerivation` rebuilds its project index on every call). Sections A (locale copy) and C (data shapes) are deliberately untouched — the issue asks for them to be decided separately, and nothing in this diff touches a catalogue or a read-side dedupe.

## Summary

`resolveDerivation` built a `document_id → {title, document_type}` index over the whole project read on **every call**. That cost nothing while its only caller (`DocumentsTab`) held one document at a time. #394 made the prioritization page the first caller to invoke it in a loop: `collectRows` calls `rowLineageOf` per row, which calls `classifySelectionLineage` and `fresherCoherentSelection`, each of which calls the resolver per document on that row — so one unchanging project read of D documents was walked once per (row × document × rule).

The index is now built once and passed:

* **`api/derivation.ts`** — the private `sourceFieldIndex` becomes the exported `derivationSourceIndex`, and `resolveDerivationAgainst(document, index)` is the resolver against an index the caller already holds. `resolveDerivation` is now literally `resolveDerivationAgainst(document, derivationSourceIndex(projectDocuments))`, so there is no second resolution rule that can drift and its public behaviour is unchanged for every existing caller.
* **`pages/Prioritization/rowLineage.ts`** — `projectLineageSources(documents)` bundles the documents with one index over exactly those documents. All three exported rules (`classifySelectionLineage`, `fresherCoherentSelection`, `rowLineageOf`) take **either** a plain document list **or** a prepared read, so hoisting is the caller's optimisation and no existing call site had to change. The nested `classifySelectionLineage` call inside `fresherCoherentSelection` passes the prepared read through, so a frozen row's candidate check does not re-index either.
* **`pages/Prioritization/prioritizationUtils.ts`** — `collectRows` prepares each project read once, in the details loop, and passes it for every row of that project. `byId` (which resolves a row's stored ids and its prototype) was rebuilt per row over the same list and is hoisted alongside it.

**Explicit plumbing, not global memoization**, as the task asked: nothing is cached anywhere. The index's lifetime is the collection pass's own, so a landing project read, a deleted document or a recomposed row needs no invalidation — the next `collectRows` builds a new index from whatever the reads then say. That property is asserted, not just claimed (`consults the index once per source and holds no state between calls`).

`DocumentsTab` keeps calling `resolveDerivation` with a list: it holds one document, so a prebuilt index would be plumbing with nothing on the other end.

## Measurement (issue #399's acceptance criterion for B)

Median of five `collectRows` calls after one warm-up, over a synthetic single-project fixture of N frozen rows and D documents each declaring a source, run under the repo's own vitest/jsdom in this container. Wall clock here is ~3× the reviewer's figure for the same fixture (their 562 ms is this container's 1644 ms), so read the ratio rather than the absolute:

| fixture | before | after | |
|---|---|---|---|
| 30 rows / 100 documents | 27.3 ms | **11.9 ms** | 2.3× |
| 60 rows / 400 documents | 203.5 ms | **78.5 ms** | 2.6× |
| **200 rows / 1000 documents** | **1644.3 ms** | **615.3 ms** | **2.7×** |

**What was removed:** at 200/1000, the same 1000-document list was indexed roughly 2,600 times (200 rows × two derivation-reading rules × two documents per row, plus one candidate classification per frozen row) instead of once — every one of those passes producing a byte-identical map. The remaining 615 ms is *not* index construction: it is `fresherCoherentSelection`'s `newestOfType`, which filters the whole project list once per type per frozen row and is O(rows × documents) independent of any index. Measured by flipping the fixture's rows to un-frozen, which skips the staleness arithmetic entirely: 7.0 ms at 200/1000. That residual is a separate concern from the one #399 B names and is left for a follow-up rather than folded in here.

The measurement harness was scratch (`.tmp/`) and is not part of the diff, deliberately: a wall-clock assertion is exactly what the acceptance criteria ask *not* to gate on.

## Tests

Coverage is counted, never timed — the acceptance criterion is explicit about that, and a threshold would pass on a fast machine with the defect restored.

**`src/api/derivation.test.ts`** (+4 cases, semantic equivalence across all three origins):
* `answers exactly what resolveDerivation answers` — whole-object equality for a **declared**, a **legacy**, a legacy-with-**unresolved-source**, and a **nothing-recoverable** document, plus a control asserting the four really do produce `declared`/`legacy`/`legacy`/`none` so the equality is over answers that differ.
* `reads what a source is from the given index and never from the wire again` — an index disagreeing with every document list, so an answer carrying its titles could not have come from re-indexing anything.
* `consults the index once per source and holds no state between calls` — a `Map` subclass recording every `get`, asserting `['prd_1','prfaq_1','prd_1','prfaq_1']` over two calls. Its positive control (the titles actually resolved) is asserted first, so a count is never the silence of a resolver that looks nothing up.
* `indexes a document list once for every field a source displays` — the builder's own contract, including that an id-less record contributes no entry.

**`src/pages/Prioritization/prioritizationUtils.indexReuse.test.ts`** (new file, the deterministic construction count). `derivationSourceIndex` is wrapped via `vi.mock` + `importOriginal` (the `ScraperCard.test.tsx` precedent) so the *real* builder runs and only its call count is observed:
* `indexes a project read once however many rows name it` — three rows in three different lineage states off **one** construction. The state assertion comes first as the positive control: a `collectRows` that stopped classifying lineage would also report one construction.
* `indexes each project read separately` — two projects, **two** constructions, so "once" cannot be satisfied by one page-wide index that would resolve one project's sources against another's documents. Controlled by a source that only project 1 holds staying unresolved for project 2's row.
* `builds nothing for a page whose project reads have not landed` — the floor.

**Mutation-tested in both directions** (each restored afterwards; the working tree is clean):

| mutation | result |
|---|---|
| `collectRows` passes `project.documents` instead of `project.lineage` | **caught** — 4 constructions, expected 1 |
| `fresherCoherentSelection`'s nested classify passes the raw list | **caught** — 3 constructions, expected 1 |
| one page-wide index shared across projects | **caught** — `indexes each project read separately` only, as its docstring claims |
| a memo cache added behind `resolveDerivationAgainst` | **caught** — 3 cases, including the lookup count |
| the prebuilt-index path drops the legacy fallback | **caught** — 8 cases including the equivalence case |
| `resolveDerivation` one-sidedly diverging (`projectDocuments.slice(1)`) | **caught** — 7 cases |

Each revert is recorded in the two files' REVERT MAP docstrings, per repo convention.

## Build and gate results

Run from `voc-datalake/frontend` unless noted.

| gate | result |
|---|---|
| `npx vitest run src/api/derivation.test.ts src/pages/Prioritization src/pages/ProjectDetail` | ✅ 58 files, **1054 passed** |
| `npm run test` (full frontend suite, repo root) | ✅ 193 files, **3287 passed** |
| `npm run typecheck` (`tsc -b --noEmit`) | ✅ clean |
| `npm run lint:frontend` (`eslint . --max-warnings 0`) | ✅ clean |
| `npm run typecheck:cdk` | ✅ clean |
| `npm run typecheck:tests` | ⚠️ **87 errors, all pre-existing** (baseline on a stashed tree: 88 — one of the 88 is this branch's own new test file failing to resolve the not-yet-added export, so the count goes *down* by one). No error in any of the four files this diff touches. |
| `npm run build` / `npx vite build` | ❌ **fails identically on the unmodified tree** — `Rollup failed to resolve import "react-markdown"`. This container blocks npm install scripts (`esbuild` postinstall), so `react-markdown` is installed without its `dist`. Verified by stashing the whole diff and re-running: same failure, exit 1. Not caused by this change. (`mise run build` reports `no tasks defined` — the repo defines no mise tasks.) |
| `node scripts/i18n-check.mjs` | ⚠️ exits 1 both with and without this diff (pre-existing hardcoded-string backlog in DataExplorer, FeedbackDetail, ChatSidebar and others). No catalogue is touched here. |

## Decisions made

* **Both shapes accepted by the exported rules** (`readonly unknown[] | ProjectLineageSources`) rather than a breaking signature change. A caller with one selection pays for one index exactly as before; only the loop prepares a read. This kept all 93 existing `rowLineage.test.ts` call sites and `RowLineagePanels`' eventual one untouched.
* **The index travels with the documents** in one `ProjectLineageSources` object, not as a second parameter. A separate prebuilt-index argument can be handed an index built from a *different* read, which would classify a row against one project and advise it against another; one object built by `projectLineageSources` cannot.
* **`lineageSourcesOf` narrows on `'sourceIndex' in project`, not `Array.isArray`** — `tsc` will not narrow a `readonly unknown[]` out of a union via `Array.isArray` (its signature answers `any[]`), which leaves the list in the prepared branch's type. Noted at the function.
* **`DerivationSourceIndex` is a `ReadonlyMap` of already-normalised fields**, not an opaque handle. Every value has been through `displayString`, so an unreadable type is `''` and never `null` — `hasSupersededSource` turns on exactly that distinction, and the type's docstring says to build it only through `derivationSourceIndex`.
* **The remaining `newestOfType` cost is called out, not fixed.** Folding an O(1) per-type newest-document lookup into the same change would have mixed two optimisations under one issue item; it is documented above with its measurement instead.

## Notes for reviewers

The `1644 ms`/`615 ms` figures now appear in three docstrings (`DerivationSourceIndex`, the `rowLineage` module header, `PrioritizationRowView.lineage`) alongside the reviewer's 562 ms, labelled as this container's jsdom rather than as the reviewing machine's. If the house convention is to quote only the reviewed figure, they are one search-and-replace apart.

```abca-verify
no-ui
```

## Agent notes

**What went well.** The defect had one choke point. Making `resolveDerivation` delegate to `resolveDerivationAgainst` meant the equivalence claim needed no argument — there is one resolution rule, called two ways — which left the tests free to pin the *counting* property instead of re-testing the contract. The accept-either-shape union kept the diff to four files with no call-site churn.

**What was difficult.**
1. **The build cannot be run here.** `npx vite build` fails on the unmodified tree because this container blocks npm postinstall scripts, so `react-markdown` unpacks without its `dist`. I confirmed the baseline failure by stashing before concluding it was pre-existing; `mise run build` is also a no-op (`no tasks defined`) — the setup notes' warning that build gating is inert is accurate.
2. **Getting a trustworthy measurement.** vitest has no benchmark harness wired up here and the 10 s `testTimeout` kills a 200/1000 fixture at the pre-fix cost, so the scratch harness needed `--testTimeout`. `console.log` inside a vitest run is swallowed by the reporter — I ended up appending to a scratch file. All of it lived in `.tmp/` and is gone.
3. **`Array.isArray` will not narrow `readonly unknown[]`.** Cost one typecheck cycle to diagnose; the `in`-operator narrowing carries a comment so the next reader does not "simplify" it back.

**Conventions discovered / confirmed.**
* Comments here carry the *argument*, not the mechanics — what the previous implementation was, why it was wrong, and which test goes red if it returns. I matched that, including REVERT MAP entries with measured mutation outcomes rather than assumed ones.
* Every non-vacuity concern gets its own positive control, asserted **first** so it is visibly green. A construction count of 1 is meaningless without proof the rows were classified at all.
* `vi.mock` + `importOriginal` (rather than a stub) is the established way to observe a module boundary without changing its answers.
* `poolOptions.forks.singleFork` in `vitest.config.ts` is **inert** on vitest 4 and prints a deprecation warning on every run. Out of scope here, but worth a one-line cleanup — any comment still justifying single-fork behaviour is stale.
* `npm run typecheck:tests` and `scripts/i18n-check.mjs` both carry substantial pre-existing failure backlogs and cannot be used as absolute gates; compare against a stashed baseline instead.

**Suggestions for future tasks.**
* **`newestOfType` is the next hot spot** and section B's fix exposes it the way #394 exposed this one: 615 ms of the remaining 200/1000 cost is `fresherCoherentSelection` filtering the whole project list once per type per frozen row (7.0 ms with the same rows un-frozen). A newest-per-type map on `ProjectLineageSources` — the object now exists to hold exactly this kind of derived-once value — would close it.
* Sections **A** and **C** of #399 are untouched and independent; A is purely locale catalogues plus `rowLineage.test.ts`, C is a read-site dedupe in `_row_document_ids` plus a UX decision.
* `poolOptions` → top-level options is a mechanical vitest 4 migration that would silence a warning on every single test run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-voice-of-customer-datalake/blob/development/LICENSE).