### PR TITLE
fix(bedrock): stop a long generation retrying itself into the Lambda ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,27 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
 
 ### Fixed
 
+- A generation that needs more than five minutes of model time now succeeds, instead of failing three
+  times over and reporting nothing. The shared Bedrock client waited five minutes for a response and
+  then retried twice by itself, so its real budget was fifteen minutes — exactly the ceiling of the
+  job functions that build prototypes, documents, personas and research. A long generation therefore
+  had no path to success: it was abandoned and restarted twice, each attempt re-paying for a full
+  generation, and the function was killed part-way through the third with nothing to show while the
+  job still read as running. Those retries also happened below the platform's own retry loop, so the
+  logs said "attempt 1 of 5" for the entire fifteen minutes and the run looked like one slow call.
+  The client now makes a single attempt and waits fourteen minutes for it, and a read timeout is
+  reported and recorded as a failed job rather than retried into the ceiling. Prototype builds are
+  where this was measured, because they ask for the largest output, but every Bedrock surface shared
+  the same client and the same ceiling.
+- A failed prototype build no longer costs up to three quarters of an hour. The job functions are
+  invoked asynchronously, where AWS re-runs a failed invocation twice more by default, so one click
+  became roughly forty-five minutes of model work — invisible, because each re-run wrote progress to
+  the same job row and looked like the first attempt making none. A failure is now reported once, and
+  retrying is the reader's decision.
+- The product-document extractor, which builds its own Bedrock client, had the same collision at a
+  smaller scale: it waited sixty seconds for an image description with retries behind it, against a
+  two-minute function, so its final attempt was always cut off. It now waits ninety seconds once,
+  which also lets a slow description finish where it previously gave up.
 - A CSV upload no longer overwrites an earlier one whose `id` column covered the same numbers.
   A row's identity was the `id` column value as written, and every CSV upload enters the pipeline
   under the single `source_platform` of `manual_import`, from which the processor derives both its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   reported and recorded as a failed job rather than retried into the ceiling. Prototype builds are
   where this was measured, because they ask for the largest output, but every Bedrock surface shared
   the same client and the same ceiling.
+  Two of the shorter jobs — merging documents at ten minutes, importing a persona at five — are
+  bounded by their own limit rather than by that fourteen minutes, so a generation longer than their
+  own budget still ends without an explanation attached to it, exactly as it did before. Retrying a
+  throttled request is unaffected everywhere: that is worth a second attempt and is still made, with
+  backoff, by the platform rather than by the AWS client underneath it.
 - A failed prototype build no longer costs up to three quarters of an hour. The job functions are
   invoked asynchronously, where AWS re-runs a failed invocation twice more by default, so one click
   became roughly forty-five minutes of model work — invisible, because each re-run wrote progress to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ displays: the UI's build identifier is the short git commit SHA, injected at bui
   retrying is the reader's decision.
 - The product-document extractor, which builds its own Bedrock client, had the same collision at a
   smaller scale: it waited sixty seconds for an image description with retries behind it, against a
-  two-minute function, so its final attempt was always cut off. It now waits ninety seconds once,
+  two-minute function, so its final attempt was always cut off. It now waits eighty seconds once,
   which also lets a slow description finish where it previously gave up.
 - A CSV upload no longer overwrites an earlier one whose `id` column covered the same numbers.
   A row's identity was the `id` column value as written, and every CSV upload enters the pipeline

--- a/voc-datalake/lambda/api/manual_import_processor.py
+++ b/voc-datalake/lambda/api/manual_import_processor.py
@@ -15,6 +15,7 @@ from shared.logging import logger, tracer, metrics
 from shared.aws import get_dynamodb_resource, get_bedrock_client
 from shared.exceptions import ValidationError
 from shared.model_config import get_active_model_id, uses_adaptive_thinking
+from shared.converse import bedrock_call_with_retry
 
 dynamodb = get_dynamodb_resource()
 bedrock = get_bedrock_client()
@@ -151,11 +152,19 @@ def process_job(job_id: str) -> None:
         
         logger.info(f"Invoking Bedrock for job {job_id} with model {model_id}")
         
-        bedrock_response = bedrock.invoke_model(
-            modelId=model_id,
-            body=json.dumps(request_body),
-            contentType="application/json",
-            accept="application/json"
+        # Through the shared retry policy: this raw invoke_model path does not go
+        # through converse(), and the shared client makes one botocore attempt by
+        # design (see BEDROCK_READ_TIMEOUT_SECONDS), so without this a single
+        # throttle would fail the whole import job.
+        bedrock_response = bedrock_call_with_retry(
+            lambda: bedrock.invoke_model(
+                modelId=model_id,
+                body=json.dumps(request_body),
+                contentType="application/json",
+                accept="application/json"
+            ),
+            step_name=f'manual_import_parse_{job_id}',
+            call_label='client.invoke_model()',
         )
         
         response_body = json.loads(bedrock_response['body'].read())

--- a/voc-datalake/lambda/api/product_context.py
+++ b/voc-datalake/lambda/api/product_context.py
@@ -31,6 +31,7 @@ from shared.logging import logger, tracer
 from shared.aws import get_dynamodb_resource, get_bedrock_client
 from shared.image_limits import IMAGE_CONTENT_TYPE_EXTENSIONS, MAX_IMAGE_BYTES
 from shared.model_config import get_active_model_id, omits_temperature
+from shared.converse import bedrock_call_with_retry
 from shared.project_writes import (
     put_project_item,
     put_project_item_and_increment,
@@ -482,15 +483,24 @@ def interview_turn(project_id: str, body: dict) -> dict:
     if not omits_temperature(model):
         inference_config['temperature'] = 0.3
     try:
-        resp = client.converse(
-            modelId=model,
-            messages=messages,
-            system=[{'text': system_prompt}],
-            inferenceConfig=inference_config,
-            toolConfig={'tools': [_build_interview_tool()]},
+        # Through the shared retry policy, not bare: this raw call does not go
+        # through converse(), so without it the FIRST throttle would become a
+        # user-visible "AI interview unavailable" — the shared client makes one
+        # botocore attempt by design (see BEDROCK_READ_TIMEOUT_SECONDS).
+        resp = bedrock_call_with_retry(
+            lambda: client.converse(
+                modelId=model,
+                messages=messages,
+                system=[{'text': system_prompt}],
+                inferenceConfig=inference_config,
+                toolConfig={'tools': [_build_interview_tool()]},
+            ),
+            step_name='interview_turn',
         )
     except Exception as e:
         logger.exception(f'Interview Bedrock call failed: {e}')
+        raise ServiceError('AI interview unavailable. Please try again.')
+    if not isinstance(resp, dict):  # throttled out with retries disabled
         raise ServiceError('AI interview unavailable. Please try again.')
 
     output_blocks = resp.get('output', {}).get('message', {}).get('content', [])

--- a/voc-datalake/lambda/api/product_context.py
+++ b/voc-datalake/lambda/api/product_context.py
@@ -498,9 +498,10 @@ def interview_turn(project_id: str, body: dict) -> dict:
             step_name='interview_turn',
         )
     except Exception as e:
+        # Covers sustained throttling too: bedrock_call_with_retry raises rather
+        # than returning None while raise_on_throttle is left at its default, so
+        # there is no empty-result case to check for below.
         logger.exception(f'Interview Bedrock call failed: {e}')
-        raise ServiceError('AI interview unavailable. Please try again.')
-    if not isinstance(resp, dict):  # throttled out with retries disabled
         raise ServiceError('AI interview unavailable. Please try again.')
 
     output_blocks = resp.get('output', {}).get('message', {}).get('content', [])

--- a/voc-datalake/lambda/jobs/persona_importer/handler.py
+++ b/voc-datalake/lambda/jobs/persona_importer/handler.py
@@ -138,7 +138,7 @@ def handle_job(ctx: JobContext, project_id: str, job_id: str, import_config: dic
             inferenceConfig={'maxTokens': prompt_config['max_tokens']}
         ),
         step_name='import_persona',
-    ) or {}
+    )
     
     response_text = response.get('output', {}).get('message', {}).get('content', [{}])[0].get('text', '')
     

--- a/voc-datalake/lambda/jobs/persona_importer/handler.py
+++ b/voc-datalake/lambda/jobs/persona_importer/handler.py
@@ -24,6 +24,7 @@ from shared.persona_import import validate_import_config
 from shared.prompts import PERSONA_IMPORT_PROMPTS, format_prompt, load_prompt_file
 from shared.image_limits import converse_image_format
 from shared.aws import get_dynamodb_resource, get_bedrock_client
+from shared.converse import bedrock_call_with_retry
 from shared.model_config import get_active_model_id
 from shared.project_writes import put_project_item_and_increment
 from api.projects import generate_persona_avatar
@@ -122,15 +123,22 @@ def handle_job(ctx: JobContext, project_id: str, job_id: str, import_config: dic
     # nothing to omit for temperature-restricted models.
     model_id = get_active_model_id('documents')
     logger.info(f"[IMPORT_PERSONA_JOB] Invoking Bedrock with model {model_id}")
-    response = bedrock.converse(
-        modelId=model_id,
-        system=[{'text': system_prompt}],
-        messages=[{'role': 'user', 'content': converse_content}],
-        # From the template too, so the budget lives beside the schema it has to
-        # produce rather than as a literal here that nobody updates when the
-        # schema grows.
-        inferenceConfig={'maxTokens': prompt_config['max_tokens']}
-    )
+    # Through the shared retry policy, because this raw call does not go through
+    # converse() and the shared client makes one botocore attempt by design (see
+    # BEDROCK_READ_TIMEOUT_SECONDS): without it a single throttle would fail the
+    # import job outright, and this surface is reached straight after an upload.
+    response = bedrock_call_with_retry(
+        lambda: bedrock.converse(
+            modelId=model_id,
+            system=[{'text': system_prompt}],
+            messages=[{'role': 'user', 'content': converse_content}],
+            # From the template too, so the budget lives beside the schema it has
+            # to produce rather than as a literal here that nobody updates when
+            # the schema grows.
+            inferenceConfig={'maxTokens': prompt_config['max_tokens']}
+        ),
+        step_name='import_persona',
+    ) or {}
     
     response_text = response.get('output', {}).get('message', {}).get('content', [{}])[0].get('text', '')
     

--- a/voc-datalake/lambda/product_doc_extractor/handler.py
+++ b/voc-datalake/lambda/product_doc_extractor/handler.py
@@ -282,22 +282,18 @@ JPEG_SCAN_BYTES = 256 * 1024
 
 MAX_DESCRIPTION_TOKENS = 4096
 
-# This Lambda's Bedrock budget. Deliberately NOT imported from shared/aws.py —
-# this handler is stdlib+boto3 only so CoreStack stays container-free (see the
-# module docstring), the same reason _is_conditional_check_failure is duplicated
-# below. The reasoning is one place, there; only the numbers differ, because they
-# are sized against THIS function's 120 s timeout rather than the 15-minute jobs.
+# This Lambda's Bedrock budget. Same invariant as shared/aws.py's — the two numbers
+# multiply and the product must stay under this function's own timeout — but sized
+# against 120 s rather than the 15-minute jobs, and duplicated rather than imported
+# because this handler is stdlib+boto3 only (see the module docstring), like
+# _is_conditional_check_failure below. The reasoning lives there.
 #
-# botocore's DEFAULTS are wrong here in exactly the way the shared client's old
-# ones were: a 60 s read timeout with the default retry budget can outlast this
-# function's own 120 s ceiling, so the final attempt is always killed in flight —
-# a guaranteed-doomed retry instead of a diagnosis. One attempt, and a read
-# timeout that still leaves time to record the failure. 90 s is also a real
-# widening for a slow description: the default gave up at 60 s.
-#
-# Raising these means re-checking the 120 s timeout in core-stack.ts, which is in
-# turn bounded by product_context.py's EXTRACTION_STALL_SECONDS (300).
-BEDROCK_READ_TIMEOUT_SECONDS = 90
+# botocore's DEFAULTS break that invariant here: 60 s with the default retry budget
+# outlasts 120 s, so the final attempt is always killed in flight. 80 s x 1 leaves
+# time to record the failure, and widens the window for a slow description either
+# way. Raising it means re-checking core-stack.ts's timeout, itself bounded by
+# product_context.py's EXTRACTION_STALL_SECONDS.
+BEDROCK_READ_TIMEOUT_SECONDS = 80
 BEDROCK_MAX_ATTEMPTS = 1
 BEDROCK_CONNECT_TIMEOUT_SECONDS = 10
 

--- a/voc-datalake/lambda/product_doc_extractor/handler.py
+++ b/voc-datalake/lambda/product_doc_extractor/handler.py
@@ -282,6 +282,25 @@ JPEG_SCAN_BYTES = 256 * 1024
 
 MAX_DESCRIPTION_TOKENS = 4096
 
+# This Lambda's Bedrock budget. Deliberately NOT imported from shared/aws.py —
+# this handler is stdlib+boto3 only so CoreStack stays container-free (see the
+# module docstring), the same reason _is_conditional_check_failure is duplicated
+# below. The reasoning is one place, there; only the numbers differ, because they
+# are sized against THIS function's 120 s timeout rather than the 15-minute jobs.
+#
+# botocore's DEFAULTS are wrong here in exactly the way the shared client's old
+# ones were: a 60 s read timeout with the default retry budget can outlast this
+# function's own 120 s ceiling, so the final attempt is always killed in flight —
+# a guaranteed-doomed retry instead of a diagnosis. One attempt, and a read
+# timeout that still leaves time to record the failure. 90 s is also a real
+# widening for a slow description: the default gave up at 60 s.
+#
+# Raising these means re-checking the 120 s timeout in core-stack.ts, which is in
+# turn bounded by product_context.py's EXTRACTION_STALL_SECONDS (300).
+BEDROCK_READ_TIMEOUT_SECONDS = 90
+BEDROCK_MAX_ATTEMPTS = 1
+BEDROCK_CONNECT_TIMEOUT_SECONDS = 10
+
 # The prototype generator's neutral default palette is indigo #4F46E5 (see
 # PROTOTYPE_HTML_SYSTEM_PROMPT in lambda/jobs/document_generator/handler.py). A
 # description that comes back with adjectives instead of values leaves the
@@ -354,7 +373,12 @@ def _s3():
 
 def _bedrock():
     if 'bedrock' not in _clients:
-        _clients['bedrock'] = boto3.client('bedrock-runtime')
+        from botocore.config import Config
+        _clients['bedrock'] = boto3.client('bedrock-runtime', config=Config(
+            read_timeout=BEDROCK_READ_TIMEOUT_SECONDS,
+            connect_timeout=BEDROCK_CONNECT_TIMEOUT_SECONDS,
+            retries={'max_attempts': BEDROCK_MAX_ATTEMPTS, 'mode': 'standard'},
+        ))
     return _clients['bedrock']
 
 

--- a/voc-datalake/lambda/product_doc_extractor/test/test_handler.py
+++ b/voc-datalake/lambda/product_doc_extractor/test/test_handler.py
@@ -17,6 +17,7 @@ passes for the wrong reason:
     build_product_context_block depends on the second one.
 """
 import pytest
+from unittest.mock import patch
 
 from .conftest import (
     DOCUMENTS_DEFAULT_MODEL,
@@ -795,14 +796,7 @@ class TestTheBedrockClientBudget:
 
     @staticmethod
     def _build(extractor, times: int = 1):
-        """Call `_bedrock()` `times` over a patched boto3 and return (clients, mock).
-
-        Imported locally because this module otherwise never patches boto3 — the
-        rest of the suite injects fakes into `_clients` (see conftest), and only
-        the factory itself needs the real thing stubbed.
-        """
-        from unittest.mock import patch
-
+        """Call `_bedrock()` `times` over a patched boto3 and return (clients, mock)."""
         with patch.object(extractor, 'boto3') as mock_boto3:
             clients = [extractor._bedrock() for _ in range(times)]
         return clients, mock_boto3

--- a/voc-datalake/lambda/product_doc_extractor/test/test_handler.py
+++ b/voc-datalake/lambda/product_doc_extractor/test/test_handler.py
@@ -773,3 +773,74 @@ class TestExtractionPrompt:
         assert 'Corner radius' in prompt
         # Offline-first: the prototype can only use the system font stack.
         assert 'Do NOT name a webfont' in prompt
+
+
+class TestTheBedrockClientBudget:
+    """The client factory itself, which nothing else in this suite exercises.
+
+    Every other test injects a fake into `_clients`, so `_bedrock()` never runs —
+    which is exactly how a dropped `config=` argument would go unnoticed. The
+    constants would still be there for the CDK-side guard in core-stack.test.ts to
+    read and compare against this function's 120 s timeout, and that guard would
+    still pass while the deployed client quietly used botocore's defaults again.
+    So this asserts what reaches boto3, not what the constants say.
+
+    Why it matters here: botocore's defaults are a 60 s read timeout with retries
+    behind it, which can outlast this function's own 120 s ceiling — the last
+    attempt is then always killed in flight, a guaranteed-doomed retry rather than
+    a diagnosis. Same collision that cost 45 minutes on the prototype path; the
+    numbers are duplicated from shared/aws.py on purpose, because this handler is
+    stdlib+boto3 only and cannot import it.
+    """
+
+    @staticmethod
+    def _build(extractor, times: int = 1):
+        """Call `_bedrock()` `times` over a patched boto3 and return (clients, mock).
+
+        Imported locally because this module otherwise never patches boto3 — the
+        rest of the suite injects fakes into `_clients` (see conftest), and only
+        the factory itself needs the real thing stubbed.
+        """
+        from unittest.mock import patch
+
+        with patch.object(extractor, 'boto3') as mock_boto3:
+            clients = [extractor._bedrock() for _ in range(times)]
+        return clients, mock_boto3
+
+    @classmethod
+    def _captured_config(cls, extractor):
+        _, mock_boto3 = cls._build(extractor)
+        call = mock_boto3.client.call_args
+        assert call.args[0] == 'bedrock-runtime'
+        return call.kwargs['config']
+
+    def test_waits_and_retries_exactly_as_declared(self, extractor):
+        config = self._captured_config(extractor)
+
+        assert config.read_timeout == extractor.BEDROCK_READ_TIMEOUT_SECONDS
+        assert config.connect_timeout == extractor.BEDROCK_CONNECT_TIMEOUT_SECONDS
+        assert config.retries['max_attempts'] == extractor.BEDROCK_MAX_ATTEMPTS
+
+    def test_makes_one_attempt_in_standard_mode(self, extractor):
+        """`max_attempts` counts TOTAL attempts in standard mode.
+
+        Legacy mode's reading of the same key is ambiguous, so the mode is stated
+        rather than inherited — otherwise `max_attempts: 1` is not provably one
+        attempt, and the budget compared against the Lambda timeout is a lower
+        bound instead of the budget.
+        """
+        config = self._captured_config(extractor)
+
+        assert config.retries['mode'] == 'standard'
+        assert extractor.BEDROCK_MAX_ATTEMPTS == 1
+
+    def test_the_client_is_built_once_and_cached(self, extractor):
+        """The cache is what makes a per-invocation client construction free.
+
+        Asserted because the config now arrives through a lazily-imported Config
+        object: an accidental rebuild per call would construct one per image.
+        """
+        (first, second), mock_boto3 = self._build(extractor, times=2)
+
+        assert first is second
+        assert mock_boto3.client.call_count == 1

--- a/voc-datalake/lambda/shared/aws.py
+++ b/voc-datalake/lambda/shared/aws.py
@@ -6,6 +6,7 @@ Provides pre-configured clients with connection reuse.
 import json
 import boto3
 from functools import lru_cache
+from typing import Final
 from shared.exceptions import ValidationError
 from shared.logging import logger
 
@@ -81,19 +82,67 @@ def get_secrets_client():
     return _secrets_client
 
 
+# ── Bedrock generation budget ────────────────────────────────────────────────
+# These two numbers MULTIPLY, and their product used to be the whole bug: at
+# read_timeout=300 with max_attempts=3 the budget was 900 s, which is EXACTLY the
+# 15-minute ceiling of the job Lambdas that generate documents, prototypes,
+# personas and research. A generation needing more than five minutes therefore had
+# no path to success — measured live on a prototype build: attempt 1 read-timed
+# out at 300 s, botocore retried twice more on its own, and Lambda killed the
+# function at 900 s with nothing returned and the job row still `running`.
+#
+# Two properties of that failure are worth keeping in view, because both argue for
+# ONE attempt rather than for a longer timeout alone:
+#
+#   * The retries were INVISIBLE. They happen inside botocore, below
+#     shared/converse.py's own retry loop, so the application log read
+#     "Attempt 1/5" for the entire 900 s. Anyone reading it concludes "one slow
+#     call"; the truth was three abandoned generations, each re-submitting the
+#     prompt and re-paying for a full generation.
+#   * `converse` is NON-STREAMING, so the socket is legitimately idle until the
+#     whole generation is done. A read timeout here measures "big", not "broken" —
+#     and the larger the requested output, the more certain it fires. Retrying a
+#     request that just consumed the entire read timeout cannot succeed with less
+#     time remaining, so botocore's retries could only ever burn budget.
+#
+# shared/converse.py still retries what genuinely IS transient (throttling,
+# ServiceUnavailable) with backoff, and it logs every attempt — so one attempt
+# here removes a duplicate layer rather than removing retry. `mode: 'standard'`
+# is explicit because in that mode max_attempts counts TOTAL attempts (legacy
+# mode's reading of the same key is ambiguous); same shape as the delegation
+# client in shared/mcp_delegate.py.
+#
+# ONE attempt is also what keeps this safe for the short-timeout callers of this
+# same cached client: the budget equals the read timeout for everyone, so no
+# caller is ever handed a multiple of it. The 30 s API handlers hit their own
+# ceiling long before this timeout binds, which is unchanged from before and
+# wastes nothing now that no retry follows.
+#
+# The value sits below the longest Bedrock Lambda timeout (900 s) with room left
+# for the handler to record the failure it hit, so a too-long generation ends as
+# a `failed` job with a diagnosis instead of a silent kill. That relationship is
+# pinned in lib/stacks/api-stack.test.ts — it spans a Python constant and a CDK
+# timeout, which is exactly the pair no single file can keep honest.
+BEDROCK_READ_TIMEOUT_SECONDS: Final = 840
+BEDROCK_MAX_ATTEMPTS: Final = 1
+BEDROCK_CONNECT_TIMEOUT_SECONDS: Final = 10
+
+
 def get_bedrock_client():
     """Get shared Bedrock Runtime client with connection reuse.
-    
-    Uses extended read timeout (5 minutes) to handle long LLM responses
-    that can take 2-3 minutes for complex persona generation tasks.
+
+    ONE cached client serves every Bedrock surface — documents, prototypes,
+    personas, research, chat, category generation, scrapers — so its read/retry
+    budget is sized for the longest-running of them. See
+    BEDROCK_READ_TIMEOUT_SECONDS above for why the retry budget is 1.
     """
     global _bedrock_client
     if _bedrock_client is None:
         from botocore.config import Config
         config = Config(
-            read_timeout=300,  # 5 minutes for long LLM responses
-            connect_timeout=10,
-            retries={'max_attempts': 3}
+            read_timeout=BEDROCK_READ_TIMEOUT_SECONDS,
+            connect_timeout=BEDROCK_CONNECT_TIMEOUT_SECONDS,
+            retries={'max_attempts': BEDROCK_MAX_ATTEMPTS, 'mode': 'standard'},
         )
         _bedrock_client = boto3.client("bedrock-runtime", config=config)
     return _bedrock_client

--- a/voc-datalake/lambda/shared/aws.py
+++ b/voc-datalake/lambda/shared/aws.py
@@ -83,46 +83,30 @@ def get_secrets_client():
 
 
 # ── Bedrock generation budget ────────────────────────────────────────────────
-# These two numbers MULTIPLY, and their product used to be the whole bug: at
-# read_timeout=300 with max_attempts=3 the budget was 900 s, which is EXACTLY the
-# 15-minute ceiling of the job Lambdas that generate documents, prototypes,
-# personas and research. A generation needing more than five minutes therefore had
-# no path to success — measured live on a prototype build: attempt 1 read-timed
-# out at 300 s, botocore retried twice more on its own, and Lambda killed the
-# function at 900 s with nothing returned and the job row still `running`.
+# THE INVARIANT: these two numbers MULTIPLY, and the product must stay under the
+# timeout of the Lambda making the call. At 300 x 3 it was 900 s — exactly the
+# 15-minute job ceiling — so a generation needing over five minutes had no path to
+# success and paid for three abandoned ones on the way. Pinned across both
+# languages in lib/stacks/api-stack.test.ts and lambda/shared/test/test_aws.py,
+# because no single file can see both halves.
 #
-# Two properties of that failure are worth keeping in view, because both argue for
-# ONE attempt rather than for a longer timeout alone:
+# Why the retry budget is 1, since a longer timeout alone would not do it:
+#   * `converse` is NON-STREAMING, so the socket is idle until the generation
+#     finishes. A read timeout measures "big", not "broken", and retrying a request
+#     that just consumed the whole timeout cannot succeed with less time left.
+#   * botocore retries BELOW shared/converse.py's own loop, so its attempts are
+#     invisible in the application log. `bedrock_call_with_retry` there is the one
+#     policy that can tell a throttle (retry, nearly free) from a read timeout (do
+#     not); botocore's single attempt budget covers both and cannot.
+#   * One attempt keeps ONE cached client safe for callers of every length: the
+#     budget equals the read timeout for everyone, so nobody is handed a multiple
+#     of it. Shorter callers reach their own ceiling first, as they already did.
 #
-#   * The retries were INVISIBLE. They happen inside botocore, below
-#     shared/converse.py's own retry loop, so the application log read
-#     "Attempt 1/5" for the entire 900 s. Anyone reading it concludes "one slow
-#     call"; the truth was three abandoned generations, each re-submitting the
-#     prompt and re-paying for a full generation.
-#   * `converse` is NON-STREAMING, so the socket is legitimately idle until the
-#     whole generation is done. A read timeout here measures "big", not "broken" —
-#     and the larger the requested output, the more certain it fires. Retrying a
-#     request that just consumed the entire read timeout cannot succeed with less
-#     time remaining, so botocore's retries could only ever burn budget.
-#
-# shared/converse.py still retries what genuinely IS transient (throttling,
-# ServiceUnavailable) with backoff, and it logs every attempt — so one attempt
-# here removes a duplicate layer rather than removing retry. `mode: 'standard'`
-# is explicit because in that mode max_attempts counts TOTAL attempts (legacy
-# mode's reading of the same key is ambiguous); same shape as the delegation
-# client in shared/mcp_delegate.py.
-#
-# ONE attempt is also what keeps this safe for the short-timeout callers of this
-# same cached client: the budget equals the read timeout for everyone, so no
-# caller is ever handed a multiple of it. The 30 s API handlers hit their own
-# ceiling long before this timeout binds, which is unchanged from before and
-# wastes nothing now that no retry follows.
-#
-# The value sits below the longest Bedrock Lambda timeout (900 s) with room left
-# for the handler to record the failure it hit, so a too-long generation ends as
-# a `failed` job with a diagnosis instead of a silent kill. That relationship is
-# pinned in lib/stacks/api-stack.test.ts — it spans a Python constant and a CDK
-# timeout, which is exactly the pair no single file can keep honest.
+# `mode: 'standard'` is explicit because there max_attempts counts TOTAL attempts;
+# legacy mode's reading of the same key is ambiguous. Same shape as
+# shared/mcp_delegate.py. The 60 s left under the 900 s ceiling is for the handler
+# to record the failure (shared/jobs.py writing the job `failed`) instead of being
+# killed mid-flight.
 BEDROCK_READ_TIMEOUT_SECONDS: Final = 840
 BEDROCK_MAX_ATTEMPTS: Final = 1
 BEDROCK_CONNECT_TIMEOUT_SECONDS: Final = 10

--- a/voc-datalake/lambda/shared/converse.py
+++ b/voc-datalake/lambda/shared/converse.py
@@ -397,28 +397,47 @@ def converse(
         raise
 
 
-def _converse_with_retry(
-    client,
-    kwargs: dict,
+def bedrock_call_with_retry(
+    call: Callable[[], object],
     max_retries: int = DEFAULT_MAX_RETRIES,
     raise_on_throttle: bool = True,
     step_name: str = "unknown",
-) -> dict:
-    """
-    Invoke Bedrock converse with exponential backoff retry, returning the raw response.
+    call_label: str = "the Bedrock call",
+):
+    """Run *call*, retrying only the failures a second attempt can actually fix.
+
+    THE POLICY LIVES HERE because botocore cannot express it: **retry a throttle,
+    never retry a read timeout.** A 429 costs a round trip and no generation, so
+    retrying it with backoff is nearly free. A read timeout means the generation
+    itself outran the client's patience, and an identical request cannot go faster
+    with less time left — see BEDROCK_READ_TIMEOUT_SECONDS in shared/aws.py, whose
+    retry budget is 1 for exactly this reason. botocore's own retries could not
+    tell those two apart, and retried both.
+
+    Exposed (not underscore-private) for the RAW client callers: the product
+    interview turn, persona import and manual-import classification each build
+    their own Converse/InvokeModel request because they carry a tool config, an
+    image block or an Anthropic-native body that the text-only `converse()` helper
+    does not take. They previously leaned on botocore's attempts, which is not a
+    policy anyone chose — dropping those to 1 would otherwise have left them
+    surfacing the first 429 with no backoff anywhere.
 
     Args:
-        client: Bedrock runtime client
-        kwargs: Arguments for client.converse()
-        max_retries: Maximum retry attempts
-        raise_on_throttle: If True, raise BedrockThrottlingError after max retries
-        step_name: Name of the current step for logging
+        call: Zero-argument callable performing ONE Bedrock request. Called again
+            per retry, so it must be safe to re-run (build the request outside).
+        max_retries: Maximum attempts, including the first.
+        raise_on_throttle: If True, raise BedrockThrottlingError once throttling
+            has exhausted the attempts. If False, return None instead.
+        step_name: Name of the current step, for logging.
+        call_label: What is being called, for logging.
 
     Returns:
-        Raw Bedrock converse response dict
+        Whatever *call* returns, or None when retries are exhausted with
+        raise_on_throttle=False.
 
     Raises:
-        BedrockThrottlingError: If throttled after max retries and raise_on_throttle=True
+        BedrockThrottlingError: If throttled after max_retries and raise_on_throttle=True
+        ReadTimeoutError: Immediately, on the first read timeout, unretried
         ClientError: For non-retryable AWS errors
     """
     last_exception = None
@@ -428,23 +447,15 @@ def _converse_with_retry(
         attempt_start = time.time()
 
         try:
-            logger.info(f"[BEDROCK] Calling client.converse() for step '{step_name}'...")
-            response = client.converse(**kwargs)
+            logger.info(f"[BEDROCK] Calling {call_label} for step '{step_name}'...")
+            result = call()
             attempt_elapsed = time.time() - attempt_start
-
-            # Log response metadata
-            usage = response.get('usage', {})
-            stop_reason = response.get('stopReason', 'unknown')
-            input_tokens = usage.get('inputTokens', 0)
-            output_tokens = usage.get('outputTokens', 0)
-
             logger.info(f"[BEDROCK] Response received for step '{step_name}' in {attempt_elapsed:.2f}s")
-            logger.info(f"[BEDROCK] Usage: input_tokens={input_tokens}, output_tokens={output_tokens}, stop_reason={stop_reason}")
 
             if attempt > 0:
                 logger.info(f"[BEDROCK] Bedrock succeeded after {attempt + 1} attempts for step '{step_name}'")
 
-            return response
+            return result
 
         except ClientError as e:
             attempt_elapsed = time.time() - attempt_start
@@ -516,13 +527,63 @@ def _converse_with_retry(
                 logger.error(f"[BEDROCK] Step '{step_name}' failed after {max_retries} attempts: {e}")
                 raise
 
-    # Should not reach here, but handle gracefully
+    # Reached when throttling exhausted the attempts with raise_on_throttle=False.
     logger.error(f"[BEDROCK] Step '{step_name}' exhausted all retries without success")
     if raise_on_throttle and last_exception:  # pragma: no cover — defensive guard; retryable errors raise inside the loop
         raise BedrockThrottlingError(
             f"Bedrock failed after {max_retries} retries for step '{step_name}': {last_exception}"
         )
-    return {}
+    return None
+
+
+def _converse_with_retry(
+    client,
+    kwargs: dict,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    raise_on_throttle: bool = True,
+    step_name: str = "unknown",
+) -> dict:
+    """
+    Invoke Bedrock converse with exponential backoff retry, returning the raw response.
+
+    The retry POLICY is bedrock_call_with_retry's; this adds the response logging
+    that only a Converse reply has, and keeps the `{}` empty return the callers
+    below are written against.
+
+    Args:
+        client: Bedrock runtime client
+        kwargs: Arguments for client.converse()
+        max_retries: Maximum retry attempts
+        raise_on_throttle: If True, raise BedrockThrottlingError after max retries
+        step_name: Name of the current step for logging
+
+    Returns:
+        Raw Bedrock converse response dict, or {} when retries were exhausted
+        with raise_on_throttle=False.
+
+    Raises:
+        BedrockThrottlingError: If throttled after max retries and raise_on_throttle=True
+        ClientError: For non-retryable AWS errors
+    """
+    response = bedrock_call_with_retry(
+        lambda: client.converse(**kwargs),
+        max_retries=max_retries,
+        raise_on_throttle=raise_on_throttle,
+        step_name=step_name,
+        call_label='client.converse()',
+    )
+    if not isinstance(response, dict):
+        return {}
+
+    usage = response.get('usage', {})
+    stop_reason = response.get('stopReason', 'unknown')
+    input_tokens = usage.get('inputTokens', 0)
+    output_tokens = usage.get('outputTokens', 0)
+    logger.info(
+        f"[BEDROCK] Usage: input_tokens={input_tokens}, output_tokens={output_tokens}, "
+        f"stop_reason={stop_reason}"
+    )
+    return response
 
 
 def _invoke_with_retry(

--- a/voc-datalake/lambda/shared/converse.py
+++ b/voc-datalake/lambda/shared/converse.py
@@ -431,7 +431,11 @@ def bedrock_call_with_retry(
     Args:
         call: Zero-argument callable performing ONE Bedrock request. Called again
             per retry, so it must be safe to re-run (build the request outside).
-        max_retries: Maximum attempts, including the first.
+        max_retries: Maximum attempts, including the first. Every caller passes a
+            literal or takes the default — nothing derives it from configuration or
+            the environment (the research prompt templates carry `max_tokens`, not
+            this), so the 0 case below is a programming error rather than something
+            a settings row can produce.
         raise_on_throttle: If True, raise BedrockThrottlingError once throttling
             has exhausted the attempts. If False, return None instead.
         step_name: Name of the current step, for logging.

--- a/voc-datalake/lambda/shared/converse.py
+++ b/voc-datalake/lambda/shared/converse.py
@@ -5,7 +5,7 @@ Provides a unified interface for LLM interactions with optional tool use.
 
 import random
 import time
-from typing import Callable
+from typing import Callable, TypeVar
 from botocore.exceptions import ClientError, ReadTimeoutError
 from shared.logging import logger
 from shared.aws import get_bedrock_client
@@ -13,6 +13,12 @@ from shared.model_config import (
     get_active_model_id, omits_temperature, uses_adaptive_thinking, DEFAULT_SURFACE,
 )
 
+
+# Whatever the wrapped Bedrock call returns, so bedrock_call_with_retry does not
+# flatten it to `object`: its callers read the response directly (`.get('output')`,
+# `['body'].read()`) now that none of them guards against None, and a return type
+# that hid the shape would invite those guards straight back.
+_CallResult = TypeVar('_CallResult')
 
 # Retry configuration
 DEFAULT_MAX_RETRIES = 5
@@ -398,12 +404,12 @@ def converse(
 
 
 def bedrock_call_with_retry(
-    call: Callable[[], object],
+    call: Callable[[], _CallResult],
     max_retries: int = DEFAULT_MAX_RETRIES,
     raise_on_throttle: bool = True,
     step_name: str = "unknown",
     call_label: str = "the Bedrock call",
-) -> object | None:
+) -> _CallResult | None:
     """Run *call*, retrying only the failures a second attempt can actually fix.
 
     THE POLICY LIVES HERE because botocore cannot express it: **retry a throttle,

--- a/voc-datalake/lambda/shared/converse.py
+++ b/voc-datalake/lambda/shared/converse.py
@@ -6,7 +6,7 @@ Provides a unified interface for LLM interactions with optional tool use.
 import random
 import time
 from typing import Callable
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, ReadTimeoutError
 from shared.logging import logger
 from shared.aws import get_bedrock_client
 from shared.model_config import (
@@ -473,6 +473,32 @@ def _converse_with_retry(
                 # Non-retryable error
                 logger.error(f"[BEDROCK] Non-retryable error for step '{step_name}': {error_code} - {error_message}")
                 raise
+
+        except ReadTimeoutError:
+            # NOT retried, deliberately — and this branch is what keeps the
+            # one-attempt budget in shared/aws.py from being undone here.
+            #
+            # `converse` is non-streaming, so a read timeout means the generation
+            # needed longer than the client was willing to wait. The identical
+            # request will not run faster on a second try, and each retry
+            # re-submits the prompt and re-pays for a full abandoned generation
+            # while spending time this invocation no longer has. Retrying would
+            # simply move the old 3 × 300 = 900 collision up one layer and make it
+            # 5 × 840, i.e. the same bug with a bigger multiplier.
+            #
+            # Raised rather than swallowed so the caller's own failure path runs
+            # (shared/jobs.py records the job `failed`), and logged HERE because
+            # the read timeout is the one attempt outcome the application would
+            # otherwise never name — it is not a ClientError and carries no error
+            # code to triage from.
+            attempt_elapsed = time.time() - attempt_start
+            logger.error(
+                f"[BEDROCK] Read timeout for step '{step_name}' after "
+                f"{attempt_elapsed:.2f}s — not retried: a non-streaming generation "
+                f"that exceeded the read budget will exceed it again. Reduce "
+                f"max_tokens for this step or split it."
+            )
+            raise
 
         except Exception as e:
             attempt_elapsed = time.time() - attempt_start

--- a/voc-datalake/lambda/shared/converse.py
+++ b/voc-datalake/lambda/shared/converse.py
@@ -403,7 +403,7 @@ def bedrock_call_with_retry(
     raise_on_throttle: bool = True,
     step_name: str = "unknown",
     call_label: str = "the Bedrock call",
-):
+) -> object | None:
     """Run *call*, retrying only the failures a second attempt can actually fix.
 
     THE POLICY LIVES HERE because botocore cannot express it: **retry a throttle,
@@ -432,11 +432,18 @@ def bedrock_call_with_retry(
         call_label: What is being called, for logging.
 
     Returns:
-        Whatever *call* returns, or None when retries are exhausted with
-        raise_on_throttle=False.
+        Whatever *call* returns. **None ONLY when raise_on_throttle=False** — with
+        the default this either returns a result or raises, so callers do not need
+        to guard against None. That is a total contract on purpose: three call
+        sites each inventing their own None check is how one of them ends up
+        without it, and the failure there is a TypeError on the next line instead
+        of a diagnosis.
 
     Raises:
-        BedrockThrottlingError: If throttled after max_retries and raise_on_throttle=True
+        BedrockThrottlingError: If throttling exhausted the attempts and
+            raise_on_throttle=True — including the degenerate max_retries=0, where
+            no attempt was made at all. A caller error must fail loudly rather
+            than return an empty result that reads like a Bedrock answer.
         ReadTimeoutError: Immediately, on the first read timeout, unretried
         ClientError: For non-retryable AWS errors
     """
@@ -527,11 +534,17 @@ def bedrock_call_with_retry(
                 logger.error(f"[BEDROCK] Step '{step_name}' failed after {max_retries} attempts: {e}")
                 raise
 
-    # Reached when throttling exhausted the attempts with raise_on_throttle=False.
+    # Reached when the attempts ran out without a result: throttling with
+    # raise_on_throttle=False, or the degenerate max_retries=0 where the loop never
+    # ran and `last_exception` is therefore None.
     logger.error(f"[BEDROCK] Step '{step_name}' exhausted all retries without success")
-    if raise_on_throttle and last_exception:  # pragma: no cover — defensive guard; retryable errors raise inside the loop
+    if raise_on_throttle:
+        # Not conditional on last_exception: with max_retries=0 there is none, and
+        # returning None there would hand a caller who cannot expect it (see the
+        # contract above) something that reads like an empty Bedrock answer.
+        cause = f': {last_exception}' if last_exception else ' (no attempt was made)'
         raise BedrockThrottlingError(
-            f"Bedrock failed after {max_retries} retries for step '{step_name}': {last_exception}"
+            f"Bedrock failed after {max_retries} retries for step '{step_name}'{cause}"
         )
     return None
 

--- a/voc-datalake/lambda/shared/test/test_aws.py
+++ b/voc-datalake/lambda/shared/test/test_aws.py
@@ -79,6 +79,116 @@ class TestClearSecretCache:
         assert mock_client.get_secret_value.call_count == 2
 
 
+class TestBedrockClientBudget:
+    """The read timeout and the retry count MULTIPLY, and that product is the bug.
+
+    At `read_timeout=300` with `max_attempts=3` the budget was 900 s — EXACTLY the
+    ceiling of the 15-minute job Lambdas that generate documents, prototypes,
+    personas and research. A generation needing more than five minutes therefore
+    could not succeed at all: two abandoned attempts, each re-paying for a full
+    generation, then killed mid-third with nothing returned. Measured live on a
+    prototype build.
+
+    Nothing covered this before (see the module docstring's note about dropped
+    client-factory tests) and that is precisely how it survived: each value reads
+    as reasonable on its own line, and the number it collides with lives in a CDK
+    stack. So both halves are pinned — the values that reach botocore, and the
+    arithmetic that made them unsatisfiable.
+    """
+
+    # An AWS service maximum, not a repo choice: no Lambda can be configured
+    # above 15 minutes, so a client budget at or above this can never fit inside
+    # ANY caller. lib/stacks/api-stack.test.ts pins the same constant against the
+    # timeouts actually configured, which is the half this file cannot see.
+    MAX_LAMBDA_TIMEOUT_SECONDS = 900
+
+    @staticmethod
+    def _build_and_capture():
+        """Build the client through a patched boto3 and return the call args.
+
+        The client is cached in a module global that outlives a single test, so it
+        is cleared on both sides: without the reset before, an earlier test's
+        client is returned and nothing is captured; without the reset after, every
+        later test in the session is handed this MagicMock.
+        """
+        import shared.aws as shared_aws
+
+        with patch('shared.aws.boto3') as mock_boto3:
+            shared_aws._bedrock_client = None
+            try:
+                shared_aws.get_bedrock_client()
+            finally:
+                shared_aws._bedrock_client = None
+        return mock_boto3.client.call_args
+
+    def test_the_client_carries_the_declared_timeouts_and_one_attempt(self):
+        """What actually reaches botocore, not what the constants say."""
+        call = self._build_and_capture()
+        config = call.kwargs['config']
+
+        from shared.aws import (
+            BEDROCK_CONNECT_TIMEOUT_SECONDS,
+            BEDROCK_MAX_ATTEMPTS,
+            BEDROCK_READ_TIMEOUT_SECONDS,
+        )
+
+        assert call.args[0] == 'bedrock-runtime'
+        assert config.read_timeout == BEDROCK_READ_TIMEOUT_SECONDS
+        assert config.connect_timeout == BEDROCK_CONNECT_TIMEOUT_SECONDS
+        assert config.retries['max_attempts'] == BEDROCK_MAX_ATTEMPTS
+
+    def test_standard_retry_mode_is_explicit(self):
+        """`max_attempts` counts TOTAL attempts in standard mode.
+
+        Legacy mode's reading of the same key is ambiguous, so the mode is stated
+        rather than inherited: `max_attempts: 1` has to mean one attempt, or the
+        budget below is a lower bound instead of the budget.
+        """
+        config = self._build_and_capture().kwargs['config']
+
+        assert config.retries['mode'] == 'standard'
+
+    def test_a_single_attempt_so_no_caller_gets_a_multiple_of_the_read_timeout(self):
+        """One cached client serves 30 s API handlers and 15 min job Lambdas alike.
+
+        A per-caller budget would need a keyed cache; one attempt is what makes a
+        single shared budget safe for all of them, because the worst case is one
+        read timeout rather than N of them.
+        """
+        from shared.aws import BEDROCK_MAX_ATTEMPTS
+
+        assert BEDROCK_MAX_ATTEMPTS == 1, (
+            'more than one attempt makes the budget a MULTIPLE of the read '
+            'timeout, which is how 300 x 3 came to equal the 900s job ceiling. '
+            'shared/converse.py already retries what is genuinely transient, and '
+            'logs each attempt; botocore retries below it, invisibly.'
+        )
+
+    def test_the_budget_fits_inside_a_lambda_with_room_to_record_the_failure(self):
+        """The regression test: 300 x 3 = 900 fails here, and so does 840 x 2.
+
+        Fitting is not enough — the invocation also has to survive the timeout
+        long enough for shared/jobs.py to write the job `failed`. A budget that
+        merely equals the ceiling turns a slow generation into a silent kill and
+        an eternal `running` row, which is what was observed live.
+        """
+        from shared.aws import BEDROCK_MAX_ATTEMPTS, BEDROCK_READ_TIMEOUT_SECONDS
+
+        budget = BEDROCK_READ_TIMEOUT_SECONDS * BEDROCK_MAX_ATTEMPTS
+
+        assert budget < self.MAX_LAMBDA_TIMEOUT_SECONDS, (
+            f'the Bedrock read budget ({budget}s) is not smaller than the longest '
+            f'possible Lambda timeout ({self.MAX_LAMBDA_TIMEOUT_SECONDS}s), so the '
+            f'last attempt is always killed in flight'
+        )
+        # Enough for a DynamoDB status write plus unwinding, generously: the point
+        # is that the reserve is DELIBERATE, not whatever rounding left behind.
+        assert self.MAX_LAMBDA_TIMEOUT_SECONDS - budget >= 30, (
+            'too little of the invocation is left after the read timeout fires '
+            'for the handler to record the failure'
+        )
+
+
 class TestBedrockModelId:
 
     def test_model_id_points_to_claude_sonnet(self):

--- a/voc-datalake/lambda/shared/test/test_bedrock_retry_policy.py
+++ b/voc-datalake/lambda/shared/test/test_bedrock_retry_policy.py
@@ -223,3 +223,57 @@ class TestTheRetryPolicy:
             bedrock_call_with_retry(call, step_name='t')
 
         assert call.call_count == 1
+
+
+class TestThePolicyCostsTheApiHandlersNothingAtColdStart:
+    """Routing the raw callers through this policy must not widen their bundles.
+
+    `api/product_context.py` and `api/manual_import_processor.py` now import
+    `shared.converse` at module scope, which puts it on the cold-start path of API
+    handlers that previously reached Bedrock through `shared.aws` alone. Those
+    handlers answer browser requests, so a heavyweight import hoisted into
+    `converse` later would be paid on every cold start of theirs.
+
+    Stated as a RELATIVE property rather than against an allowlist: every module
+    that reaches Bedrock already imports `shared.aws` (that is where the client
+    comes from), so "adds nothing `shared.aws` did not already add" is exactly the
+    question — and unlike a curated list it cannot go stale.
+
+    Same subprocess technique as the `imports_cryptography` fixture in
+    lambda/conftest.py, and for the same reason: half this suite has already
+    imported these modules, so an in-process check on `sys.modules` would pass
+    regardless of the import graph.
+    """
+
+    @staticmethod
+    def _third_party_imports(module_name: str) -> set:
+        import json
+        import subprocess
+        import sys
+
+        code = (
+            'import sys, json; before = set(sys.modules);'
+            f' import {module_name};'
+            " added = {m.split('.')[0] for m in set(sys.modules) - before};"
+            ' print(json.dumps(sorted('
+            '     a for a in added'
+            "     if a not in sys.stdlib_module_names and not a.startswith('_')"
+            ' )))'
+        )
+        result = subprocess.run(
+            [sys.executable, '-c', code],
+            capture_output=True, text=True, cwd=str(LAMBDA_ROOT), check=False,
+        )
+        assert result.returncode == 0, f'importing {module_name} failed: {result.stderr}'
+        return set(json.loads(result.stdout.strip().splitlines()[-1]))
+
+    def test_converse_pulls_in_nothing_that_the_client_module_does_not(self):
+        from_aws = self._third_party_imports('shared.aws')
+        from_converse = self._third_party_imports('shared.converse')
+
+        assert from_converse <= from_aws, (
+            f'importing shared.converse pulls in {sorted(from_converse - from_aws)}, '
+            f'which shared.aws does not. Two API handlers now import it at module '
+            f'scope, so anything added here is paid on their cold starts — keep the '
+            f'new import inside the function that needs it.'
+        )

--- a/voc-datalake/lambda/shared/test/test_bedrock_retry_policy.py
+++ b/voc-datalake/lambda/shared/test/test_bedrock_retry_policy.py
@@ -45,7 +45,18 @@ EXEMPT = {
 
 
 def _first_party_modules():
-    """Every non-test .py under lambda/, excluding vendored layer code."""
+    """Every non-test .py under lambda/, excluding vendored layer code.
+
+    Two limits, stated so the guard is not read as more than it is:
+
+    * anything with `/test` in its path is skipped, which would also skip a
+      production module named `testing_*.py`. None exists; if one appears it is
+      unguarded and this line is why.
+    * the caller only feeds modules whose source mentions `get_bedrock_client` or
+      `bedrock-runtime`, so a module handed an already-built client as a PARAMETER
+      escapes the scan. `shared/avatar.py` is the one place that shape exists today
+      and it is exempt on its own merits.
+    """
     for path in sorted(LAMBDA_ROOT.rglob('*.py')):
         rel = path.relative_to(LAMBDA_ROOT).as_posix()
         if rel.startswith(('layers/', 'test')) or '/test' in f'/{rel}':
@@ -167,6 +178,24 @@ class TestTheRetryPolicy:
             bedrock_call_with_retry(call, max_retries=3, step_name='t')
 
         assert call.call_count == 3
+
+    def test_a_zero_attempt_budget_raises_rather_than_returning_nothing(self):
+        """The contract three call sites now rely on: with the default, no None.
+
+        `max_retries=0` is the one way the loop can finish having recorded no
+        exception, and it is a caller mistake. Returning None there would hand a
+        caller that does not check — because the contract says it need not — an
+        empty value that reads exactly like a Bedrock answer, and the failure
+        surfaces as a TypeError one line later rather than as a diagnosis.
+        """
+        from shared.converse import BedrockThrottlingError, bedrock_call_with_retry
+
+        call = MagicMock()
+
+        with pytest.raises(BedrockThrottlingError, match='no attempt was made'):
+            bedrock_call_with_retry(call, max_retries=0, step_name='t')
+
+        call.assert_not_called()
 
     @patch('shared.converse.time.sleep')
     def test_sustained_throttling_returns_none_when_asked_not_to_raise(self, mock_sleep):

--- a/voc-datalake/lambda/shared/test/test_bedrock_retry_policy.py
+++ b/voc-datalake/lambda/shared/test/test_bedrock_retry_policy.py
@@ -243,10 +243,23 @@ class TestThePolicyCostsTheApiHandlersNothingAtColdStart:
     lambda/conftest.py, and for the same reason: half this suite has already
     imported these modules, so an in-process check on `sys.modules` would pass
     regardless of the import graph.
+
+    What it does NOT see, so it is not read as stronger than it is: names are
+    collapsed to their top-level package, so the guard catches a new third-party
+    DEPENDENCY, not a new submodule of one already present — a fresh
+    `boto3.dynamodb.transform`-shaped import inside `converse`, or inside a
+    `shared.*` module it newly pulls in, costs cold-start time invisibly here.
+    Collapsing is deliberate: the comparison is about what has to be installed and
+    loaded at all, and first-party `shared.*` names would otherwise dominate the
+    diff with modules that are in both bundles by construction.
+
+    Requires Python 3.10+ in the subprocess for `sys.stdlib_module_names`. The
+    runtime is 3.14 and the venv 3.13; on anything older the assertion below
+    reports the subprocess's own stderr rather than a wrong answer.
     """
 
     @staticmethod
-    def _third_party_imports(module_name: str) -> set:
+    def _third_party_imports(module_name: str) -> set[str]:
         import json
         import subprocess
         import sys

--- a/voc-datalake/lambda/shared/test/test_bedrock_retry_policy.py
+++ b/voc-datalake/lambda/shared/test/test_bedrock_retry_policy.py
@@ -1,0 +1,196 @@
+"""One retry policy for every Bedrock caller, and the guard that keeps it that way.
+
+The policy is: **retry a throttle, never retry a read timeout.** botocore cannot
+express it — its attempt budget covers both — which is why `shared/aws.py` gives
+the shared client ONE attempt and `shared/converse.py::bedrock_call_with_retry`
+owns the decision instead.
+
+That split has a failure mode this file exists to prevent. A caller that builds its
+own Converse/InvokeModel request (tool config, image block, Anthropic-native body)
+and calls the shared client directly gets NO retry at all, so the first 429 becomes
+a failed job or a user-visible error. Three such callers exist, and nothing about
+the client's signature makes the omission visible at the call site — the code reads
+perfectly fine either way.
+"""
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError, ReadTimeoutError
+
+# lambda/shared/test/ -> voc-datalake/lambda/
+LAMBDA_ROOT = Path(__file__).resolve().parents[2]
+
+RAW_CALL_ATTRS = frozenset({'converse', 'invoke_model'})
+
+# Modules that reach Bedrock without the shared policy, each with the reason it is
+# allowed to. An empty exemption is not an option: the point of the list is that
+# adding a caller forces a decision, in review, about what its first throttle does.
+EXEMPT = {
+    # Owns the policy.
+    'shared/converse.py': 'defines bedrock_call_with_retry',
+    # Degrades to a template prompt on any failure (see its own except branch), so a
+    # throttle costs prompt quality rather than the avatar. Its IMAGE client is a
+    # separate one that keeps botocore retries on purpose, because a 10-wide avatar
+    # fan-out makes throttling the expected failure there. Also deliberately keeps a
+    # narrow import graph (test_avatar asserts importing it pulls in no cryptography),
+    # which importing converse would widen.
+    'shared/avatar.py': 'falls back to a template prompt; image client retries separately',
+    # stdlib+boto3 only so CoreStack stays container-free, so it CANNOT import
+    # shared/. Builds its own client, already at one attempt, and its caller marks
+    # the record failed with a stall guard behind it.
+    'product_doc_extractor/handler.py': 'cannot import shared/ by design',
+}
+
+
+def _first_party_modules():
+    """Every non-test .py under lambda/, excluding vendored layer code."""
+    for path in sorted(LAMBDA_ROOT.rglob('*.py')):
+        rel = path.relative_to(LAMBDA_ROOT).as_posix()
+        if rel.startswith(('layers/', 'test')) or '/test' in f'/{rel}':
+            continue
+        yield rel, path
+
+
+class TestEveryRawBedrockCallCarriesThePolicy:
+    """A source-level guard, because there is no runtime signal to assert on.
+
+    Aimed at the AST rather than a grep: a call is judged by whether a
+    `bedrock_call_with_retry(...)` encloses it, which is exactly the property that
+    makes the retry apply, and which no amount of nearby text can fake.
+    """
+
+    @staticmethod
+    def _unguarded_calls(source: str) -> list[str]:
+        tree = ast.parse(source)
+        guarded: set[int] = set()
+
+        # Mark every node inside a bedrock_call_with_retry(...) call, at any depth:
+        # the real call sites pass a lambda, so the client call is a grandchild.
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.id if isinstance(func, ast.Name) else getattr(func, 'attr', None)
+            if name == 'bedrock_call_with_retry':
+                guarded.update(id(child) for child in ast.walk(node))
+
+        return [
+            f'{node.func.attr}() at line {node.lineno}'
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in RAW_CALL_ATTRS
+            and id(node) not in guarded
+        ]
+
+    def test_no_module_calls_the_shared_client_without_a_retry(self):
+        offenders: dict[str, list[str]] = {}
+
+        for rel, path in _first_party_modules():
+            source = path.read_text(encoding='utf-8')
+            if 'get_bedrock_client' not in source and 'bedrock-runtime' not in source:
+                continue
+            if rel in EXEMPT:
+                continue
+            unguarded = self._unguarded_calls(source)
+            if unguarded:
+                offenders[rel] = unguarded
+
+        assert offenders == {}, (
+            f'these Bedrock calls have no retry: {offenders}. The shared client makes '
+            f'ONE botocore attempt by design (BEDROCK_READ_TIMEOUT_SECONDS in '
+            f'shared/aws.py), so a bare call surfaces the first ThrottlingException to '
+            f'the user or fails the job. Wrap it in bedrock_call_with_retry(), use '
+            f'converse(), or add the module to EXEMPT above with the reason.'
+        )
+
+    def test_the_exemptions_still_exist(self):
+        """An exemption for a moved file silently stops guarding its replacement."""
+        for rel in EXEMPT:
+            assert (LAMBDA_ROOT / rel).is_file(), (
+                f'{rel} is exempt from the Bedrock retry guard but no longer exists — '
+                f'delete the exemption, or point it at the file that replaced it'
+            )
+
+    def test_the_guard_sees_an_unguarded_call(self):
+        """The detector, on a mutant. Without this the case above can pass vacuously."""
+        guarded = 'bedrock_call_with_retry(lambda: client.converse(modelId=m))'
+        bare = 'client.converse(modelId=m)'
+
+        assert self._unguarded_calls(guarded) == []
+        assert self._unguarded_calls(bare) == ['converse() at line 1']
+
+
+class TestTheRetryPolicy:
+    """The two halves of the policy, in both directions."""
+
+    @staticmethod
+    def _throttle():
+        return ClientError(
+            {'Error': {'Code': 'ThrottlingException', 'Message': 'Rate exceeded'}},
+            'Converse',
+        )
+
+    @patch('shared.converse.time.sleep')
+    def test_a_throttle_is_retried_with_backoff(self, mock_sleep):
+        """The half botocore used to provide for the raw callers, now provided here."""
+        from shared.converse import bedrock_call_with_retry
+
+        call = MagicMock(side_effect=[self._throttle(), {'ok': True}])
+        result = bedrock_call_with_retry(call, step_name='t')
+
+        assert result == {'ok': True}
+        assert call.call_count == 2
+        mock_sleep.assert_called_once()
+
+    @patch('shared.converse.time.sleep')
+    def test_a_read_timeout_is_not_retried(self, mock_sleep):
+        from shared.converse import bedrock_call_with_retry
+
+        call = MagicMock(side_effect=ReadTimeoutError(endpoint_url='https://bedrock'))
+
+        with pytest.raises(ReadTimeoutError):
+            bedrock_call_with_retry(call, step_name='t')
+
+        assert call.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch('shared.converse.time.sleep')
+    def test_sustained_throttling_raises_a_named_error(self, mock_sleep):
+        from shared.converse import BedrockThrottlingError, bedrock_call_with_retry
+
+        call = MagicMock(side_effect=self._throttle())
+
+        with pytest.raises(BedrockThrottlingError):
+            bedrock_call_with_retry(call, max_retries=3, step_name='t')
+
+        assert call.call_count == 3
+
+    @patch('shared.converse.time.sleep')
+    def test_sustained_throttling_returns_none_when_asked_not_to_raise(self, mock_sleep):
+        """`None`, not `{}`: the helper is generic, so it cannot invent an empty
+        response shape. `_converse_with_retry` maps it back to `{}` for its own
+        callers, who are written against that."""
+        from shared.converse import bedrock_call_with_retry
+
+        call = MagicMock(side_effect=self._throttle())
+        result = bedrock_call_with_retry(
+            call, max_retries=2, raise_on_throttle=False, step_name='t'
+        )
+
+        assert result is None
+
+    def test_a_non_retryable_error_is_raised_at_once(self):
+        from shared.converse import bedrock_call_with_retry
+
+        denied = ClientError(
+            {'Error': {'Code': 'AccessDeniedException', 'Message': 'no'}}, 'Converse'
+        )
+        call = MagicMock(side_effect=denied)
+
+        with pytest.raises(ClientError):
+            bedrock_call_with_retry(call, step_name='t')
+
+        assert call.call_count == 1

--- a/voc-datalake/lambda/shared/test/test_converse.py
+++ b/voc-datalake/lambda/shared/test/test_converse.py
@@ -1070,3 +1070,69 @@ class TestConverseSurfaceRouting:
         )
 
         mock_resolve.assert_called_once_with('prototype')
+
+
+class TestReadTimeoutIsNotRetried:
+    """A read timeout is a size verdict here, not a transient fault.
+
+    `converse` is non-streaming, so the socket is legitimately idle for the whole
+    generation and a read timeout means "this generation needed longer than the
+    client would wait". The identical request will not run faster on a second
+    attempt, and each retry re-submits the prompt and re-pays for a full abandoned
+    generation while spending time the invocation no longer has.
+
+    This is the guard on the fix for the 900 s collision, not decoration: dropping
+    botocore's own three attempts (shared/aws.py) only helps while THIS loop does
+    not take them over. Delete the branch and one read timeout becomes five doomed
+    generations — the same defect one layer up, with a bigger multiplier.
+    """
+
+    ENDPOINT = 'https://bedrock-runtime.us-east-1.amazonaws.com'
+
+    @patch('shared.converse.time.sleep')
+    @patch('shared.converse.get_bedrock_client')
+    def test_a_read_timeout_raises_after_exactly_one_attempt(self, mock_get_client, mock_sleep):
+        from botocore.exceptions import ReadTimeoutError
+
+        mock_client = MagicMock()
+        mock_client.converse.side_effect = ReadTimeoutError(endpoint_url=self.ENDPOINT)
+        mock_get_client.return_value = mock_client
+
+        from shared.converse import converse
+
+        with pytest.raises(ReadTimeoutError):
+            converse('Test', max_retries=5)
+
+        assert mock_client.converse.call_count == 1, (
+            'a read timeout was retried; five attempts at the read timeout is the '
+            'same unsatisfiable budget the client config was fixed to remove'
+        )
+        # No backoff either: sleeping before a retry that must not happen is the
+        # symptom that the raise was added without removing the retry path.
+        mock_sleep.assert_not_called()
+
+    @patch('shared.converse.time.sleep')
+    @patch('shared.converse.get_bedrock_client')
+    def test_a_connect_timeout_is_still_retried(self, mock_get_client, mock_sleep):
+        """The control, so the branch above is narrow rather than "nothing retries".
+
+        A connect timeout costs 10 s and no generation at all — it is the transient
+        fault a retry is FOR. `ConnectTimeoutError` is a sibling of
+        `ReadTimeoutError` in botocore, not a subclass, so catching one must not
+        quietly catch the other; nothing in the type hierarchy prevents that
+        mistake, hence this test.
+        """
+        from botocore.exceptions import ConnectTimeoutError
+
+        mock_client = MagicMock()
+        mock_client.converse.side_effect = [
+            ConnectTimeoutError(endpoint_url=self.ENDPOINT),
+            {'output': {'message': {'content': [{'text': 'Success'}]}}},
+        ]
+        mock_get_client.return_value = mock_client
+
+        from shared.converse import converse
+        result = converse('Test', max_retries=5)
+
+        assert result == 'Success'
+        assert mock_client.converse.call_count == 2

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -2860,3 +2860,127 @@ describe('document workflow replay routing', () => {
     expect(state.definition).toContain('"Default":"DocStep0"');
   });
 });
+
+describe('the Bedrock generation budget fits the job Lambdas', () => {
+  // The bug this pins was arithmetic split across two files: shared/aws.py built
+  // the ONE cached Bedrock client with read_timeout=300 and max_attempts=3, and
+  // the job functions below are configured for 15 minutes. 3 x 300 = 900, so a
+  // generation needing more than five minutes could not succeed at all — two
+  // abandoned attempts, each re-paying for a full generation, then killed
+  // mid-third. Measured live on a prototype build, where the application log read
+  // "Attempt 1/5" for the whole 900 s because botocore retried BELOW
+  // shared/converse.py's own loop.
+  //
+  // Neither file could catch it alone, which is the reason this test exists here:
+  // the Python side pins the values and their product (lambda/shared/test/
+  // test_aws.py), and this side pins the product against the timeouts actually
+  // synthesized. Same shape as the delegation-timeout suite above.
+  //
+  // Matched on LOGICAL ID, not FunctionName: uniqueName() builds names from the
+  // Aws.ACCOUNT_ID/Aws.REGION pseudo-parameters, so FunctionName synthesizes to
+  // an Fn::Join rather than a comparable string.
+  const JOB_CONSTRUCT_IDS = [
+    'PersonaGeneratorJob',
+    'DocumentGeneratorJob',
+    'DocumentMergerJob',
+    'PersonaImporterJob',
+  ];
+
+  // The two that run a FULL-LENGTH generation, and the pair the read budget is
+  // sized against: `build_prototype` asks for 32000 tokens on this generator, and
+  // persona generation is the other 15-minute caller. `voc-research-step` in
+  // ProcessingStack is the third, pinned at the same 900 s by its own suite.
+  const LONG_GENERATION_JOB_IDS = ['DocumentGeneratorJob', 'PersonaGeneratorJob'];
+
+  const JobFunctionSchema = z.object({ Timeout: z.number() });
+
+  /** Each named function's logical id and timeout, validated rather than assumed. */
+  const jobFunctions = (constructIds: string[] = JOB_CONSTRUCT_IDS) => {
+    const functions = Object.entries(apiTemplate().findResources('AWS::Lambda::Function'));
+    return constructIds.map((constructId) => {
+      const matches = functions.filter(([logicalId]) => logicalId.startsWith(constructId));
+      // Count FIRST: a renamed construct must read as "not found", not as a
+      // vacuous pass over an empty list.
+      expect(matches, `expected exactly one ${constructId}`).toHaveLength(1);
+      return {
+        constructId,
+        logicalId: matches[0][0],
+        timeout: JobFunctionSchema.parse(matches[0][1].Properties).Timeout,
+      };
+    });
+  };
+
+  /** read_timeout x max_attempts, read from the Python that configures the client. */
+  const bedrockBudgetSeconds = () => {
+    const source = readRepoFile('lambda', 'shared', 'aws.py');
+    const readTimeout = source.match(/^BEDROCK_READ_TIMEOUT_SECONDS:\s*Final\s*=\s*(\d+)/m)?.[1];
+    const maxAttempts = source.match(/^BEDROCK_MAX_ATTEMPTS:\s*Final\s*=\s*(\d+)/m)?.[1];
+    // Aimed at the NAMED constants: a rename or an inlined literal must fail
+    // loudly here rather than quietly stop matching and pass.
+    expect(readTimeout, 'could not read BEDROCK_READ_TIMEOUT_SECONDS from shared/aws.py').toBeDefined();
+    expect(maxAttempts, 'could not read BEDROCK_MAX_ATTEMPTS from shared/aws.py').toBeDefined();
+    return Number(readTimeout) * Number(maxAttempts);
+  };
+
+  // Enough of the invocation to write the job `failed` and unwind, generously.
+  // The point is that the reserve is DELIBERATE rather than whatever rounding
+  // happened to leave behind.
+  const FAILURE_RECORDING_RESERVE_SECONDS = 30;
+
+  it('fires before the long-generation jobs are killed, with time to record the failure', () => {
+    const budget = bedrockBudgetSeconds();
+
+    for (const fn of jobFunctions(LONG_GENERATION_JOB_IDS)) {
+      // Strictly less than, not "fits": a budget that merely EQUALS the ceiling
+      // is the original bug exactly. The invocation has to outlive its own read
+      // timeout far enough for shared/jobs.py to write the job `failed`, or a slow
+      // generation is a silent kill and a job row stuck on `running` forever.
+      expect(budget, `${fn.constructId} runs ${fn.timeout}s; the Bedrock read budget is ${budget}s`)
+        .toBeLessThan(fn.timeout - FAILURE_RECORDING_RESERVE_SECONDS);
+    }
+  });
+
+  it('never multiplies inside a caller too short for the read timeout to bind', () => {
+    // Deliberately NOT asserting `budget < timeout` for every Bedrock caller, and
+    // the asymmetry is the point — the same shape the delegation suite above
+    // records. ONE cached client serves the 30 s API handlers, the 5-10 minute
+    // importer/merger jobs and the 15-minute generators; a per-caller read timeout
+    // would need a keyed client cache and the caller's remaining time plumbed
+    // through converse(), which nothing passes today.
+    //
+    // What makes one shared budget SAFE for the short callers is a single attempt:
+    // their own timeout binds first, and with no retry behind it nothing is
+    // wasted, which is the whole harm being removed here. The residue — a Lambda
+    // killed at its own ceiling leaves its job row `running` — is a different and
+    // separately documented defect (it covers OOM and every other kill too, so a
+    // read-timeout-shaped fix would only be a partial one).
+    const source = readRepoFile('lambda', 'shared', 'aws.py');
+    const maxAttempts = source.match(/^BEDROCK_MAX_ATTEMPTS:\s*Final\s*=\s*(\d+)/m)?.[1];
+
+    expect(Number(maxAttempts), 'shared/aws.py must make exactly one Bedrock attempt: more than '
+      + 'one makes the budget a MULTIPLE of the read timeout, which is how 300 x 3 came to equal '
+      + 'the 900s job ceiling').toBe(1);
+  });
+
+  it('does not retry the whole generation behind the caller', () => {
+    // These four are invoked with InvocationType='Event', and AWS re-drives a
+    // failed async invocation twice more by default — the second multiplier that
+    // turned one 15-minute kill into ~45 minutes of Opus generations. A missing
+    // EventInvokeConfig is indistinguishable from the default at a glance, which
+    // is why the resource is asserted to EXIST rather than just to be zero.
+    const configs = Object.values(apiTemplate().findResources('AWS::Lambda::EventInvokeConfig'))
+      .map((resource) => z.object({
+        Properties: z.object({
+          FunctionName: RefSchema,
+          MaximumRetryAttempts: z.number(),
+        }),
+      }).parse(resource).Properties);
+
+    for (const fn of jobFunctions()) {
+      const config = configs.find((c) => c.FunctionName.Ref === fn.logicalId);
+      expect(config, `${fn.constructId} has no EventInvokeConfig, so AWS retries it twice`)
+        .toBeDefined();
+      expect(config?.MaximumRetryAttempts, `${fn.constructId} async retries`).toBe(0);
+    }
+  });
+});

--- a/voc-datalake/lib/stacks/api-stack.test.ts
+++ b/voc-datalake/lib/stacks/api-stack.test.ts
@@ -36,6 +36,10 @@ import { z } from 'zod';
 
 import { VocApiStack } from './api-stack';
 import { ManifestSchema } from '../plugin-loader';
+import {
+  BEDROCK_FAILURE_RECORDING_RESERVE_SECONDS,
+  pythonIntConstant,
+} from '../test-support/cross-language-invariants';
 
 /** The only routes that may be served without credentials.
  *
@@ -2911,21 +2915,11 @@ describe('the Bedrock generation budget fits the job Lambdas', () => {
   };
 
   /** read_timeout x max_attempts, read from the Python that configures the client. */
-  const bedrockBudgetSeconds = () => {
-    const source = readRepoFile('lambda', 'shared', 'aws.py');
-    const readTimeout = source.match(/^BEDROCK_READ_TIMEOUT_SECONDS:\s*Final\s*=\s*(\d+)/m)?.[1];
-    const maxAttempts = source.match(/^BEDROCK_MAX_ATTEMPTS:\s*Final\s*=\s*(\d+)/m)?.[1];
-    // Aimed at the NAMED constants: a rename or an inlined literal must fail
-    // loudly here rather than quietly stop matching and pass.
-    expect(readTimeout, 'could not read BEDROCK_READ_TIMEOUT_SECONDS from shared/aws.py').toBeDefined();
-    expect(maxAttempts, 'could not read BEDROCK_MAX_ATTEMPTS from shared/aws.py').toBeDefined();
-    return Number(readTimeout) * Number(maxAttempts);
-  };
-
-  // Enough of the invocation to write the job `failed` and unwind, generously.
-  // The point is that the reserve is DELIBERATE rather than whatever rounding
-  // happened to leave behind.
-  const FAILURE_RECORDING_RESERVE_SECONDS = 30;
+  const bedrockMaxAttempts = () =>
+    pythonIntConstant('BEDROCK_MAX_ATTEMPTS', 'lambda', 'shared', 'aws.py');
+  const bedrockBudgetSeconds = () =>
+    pythonIntConstant('BEDROCK_READ_TIMEOUT_SECONDS', 'lambda', 'shared', 'aws.py') *
+    bedrockMaxAttempts();
 
   it('fires before the long-generation jobs are killed, with time to record the failure', () => {
     const budget = bedrockBudgetSeconds();
@@ -2936,28 +2930,53 @@ describe('the Bedrock generation budget fits the job Lambdas', () => {
       // timeout far enough for shared/jobs.py to write the job `failed`, or a slow
       // generation is a silent kill and a job row stuck on `running` forever.
       expect(budget, `${fn.constructId} runs ${fn.timeout}s; the Bedrock read budget is ${budget}s`)
-        .toBeLessThan(fn.timeout - FAILURE_RECORDING_RESERVE_SECONDS);
+        .toBeLessThan(fn.timeout - BEDROCK_FAILURE_RECORDING_RESERVE_SECONDS);
     }
   });
 
-  it('never multiplies inside a caller too short for the read timeout to bind', () => {
-    // Deliberately NOT asserting `budget < timeout` for every Bedrock caller, and
-    // the asymmetry is the point — the same shape the delegation suite above
-    // records. ONE cached client serves the 30 s API handlers, the 5-10 minute
-    // importer/merger jobs and the 15-minute generators; a per-caller read timeout
-    // would need a keyed client cache and the caller's remaining time plumbed
-    // through converse(), which nothing passes today.
+  it('classifies every job Lambda as one the read timeout binds inside, or one it does not', () => {
+    // ONE cached client serves the 30 s API handlers, the 5-10 minute
+    // importer/merger jobs and the 15-minute generators, so "the budget is below
+    // every caller's timeout" is not achievable: a per-caller read timeout needs a
+    // keyed client cache plus the caller's remaining time plumbed through
+    // converse(), which nothing passes today.
     //
-    // What makes one shared budget SAFE for the short callers is a single attempt:
-    // their own timeout binds first, and with no retry behind it nothing is
-    // wasted, which is the whole harm being removed here. The residue — a Lambda
-    // killed at its own ceiling leaves its job row `running` — is a different and
-    // separately documented defect (it covers OOM and every other kill too, so a
-    // read-timeout-shaped fix would only be a partial one).
-    const source = readRepoFile('lambda', 'shared', 'aws.py');
-    const maxAttempts = source.match(/^BEDROCK_MAX_ATTEMPTS:\s*Final\s*=\s*(\d+)/m)?.[1];
+    // Rather than leave that asymmetry as prose, it is enumerated. A job Lambda is
+    // in exactly one band, and a new one — or a timeout change that moves an
+    // existing one across the line — fails here and has to be classified in review
+    // instead of quietly inheriting whichever behaviour it happens to get.
+    //
+    // Band 2 is not a regression introduced by the budget: at the previous 300 x 3
+    // the merger's first read timeout did not surface either, because botocore had
+    // already started attempt 2 when the function was killed. What band 2 costs is
+    // the DIAGNOSIS — the row stays `running` rather than going `failed` — and that
+    // is the separately documented job-timeout defect, whose fix (a remaining-time
+    // guard) covers OOM and every other kill too, so a read-timeout-shaped fix here
+    // would only be a partial one.
+    const budget = bedrockBudgetSeconds();
+    const bands = { bindsInside: [] as string[], killedAtItsOwnCeiling: [] as string[] };
 
-    expect(Number(maxAttempts), 'shared/aws.py must make exactly one Bedrock attempt: more than '
+    for (const fn of jobFunctions()) {
+      const band = budget < fn.timeout - BEDROCK_FAILURE_RECORDING_RESERVE_SECONDS
+        ? 'bindsInside'
+        : 'killedAtItsOwnCeiling';
+      bands[band].push(fn.constructId);
+    }
+
+    expect(bands).toEqual({
+      // 15-minute generations: the read timeout fires first and the job records `failed`.
+      bindsInside: ['PersonaGeneratorJob', 'DocumentGeneratorJob'],
+      // 10- and 5-minute jobs: their own timeout is reached first. Safe because the
+      // budget is ONE attempt, so nothing is spent on a retry that cannot help.
+      killedAtItsOwnCeiling: ['DocumentMergerJob', 'PersonaImporterJob'],
+    });
+  });
+
+  it('never multiplies inside a caller too short for the read timeout to bind', () => {
+    // The property that makes one shared budget safe for band 2 above: a single
+    // attempt, so no caller is ever handed a MULTIPLE of the read timeout. This is
+    // the assertion that fails if someone restores botocore's retries.
+    expect(bedrockMaxAttempts(), 'shared/aws.py must make exactly one Bedrock attempt: more than '
       + 'one makes the budget a MULTIPLE of the read timeout, which is how 300 x 3 came to equal '
       + 'the 900s job ceiling').toBe(1);
   });

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -726,6 +726,27 @@ export class VocApiStack extends VocStack {
     // Persona avatar image model — see model-allowlist.ts for its EOL deadline.
     const avatarImageModelResource = imageModelArn();
 
+    // Every job Lambda below is invoked with InvocationType='Event' (see
+    // shared/aws.py::invoke_lambda_async), and AWS re-drives a FAILED async
+    // invocation twice more by default, silently. That default is what turned one
+    // prototype click into ~45 minutes: the function was killed at its own 15-min
+    // ceiling, then re-run twice from scratch, each attempt re-writing the same
+    // job row's progress so the UI looked like one job making no headway. Measured
+    // live — a second START with the SAME request id is the signature.
+    //
+    // Zero, because an LLM generation is neither cheap nor idempotent and a retry
+    // here buys nothing: the work restarts from the beginning with the same inputs
+    // that just failed, and shared/jobs.py already records the job `failed` for
+    // the UI to render, so the user can retry deliberately and see why. A hidden
+    // retry only multiplies cost and delays the diagnosis.
+    //
+    // NOT a substitute for a failure destination — routing exhausted async
+    // invocations somewhere durable is tracked separately (#253). This only stops
+    // the multiplier. And it does not affect the Step Functions path for PRD/PR-FAQ:
+    // an EventInvokeConfig governs async invocations only, so createDocumentStateMachine's
+    // own explicit, VISIBLE retries below are untouched.
+    const JOB_ASYNC_RETRY_ATTEMPTS = 0;
+
     // Persona Generator Job Lambda
     const personaGeneratorRole = this.createLambdaRole('PersonaGeneratorRole');
     feedbackTable.grantReadData(personaGeneratorRole);
@@ -748,6 +769,7 @@ export class VocApiStack extends VocStack {
       role: personaGeneratorRole,
       timeout: cdk.Duration.minutes(15),
       memorySize: 1024,
+      retryAttempts: JOB_ASYNC_RETRY_ATTEMPTS,
       environment: {
         PROJECTS_TABLE: projectsTable.tableName,
         FEEDBACK_TABLE: feedbackTable.tableName,
@@ -792,6 +814,7 @@ export class VocApiStack extends VocStack {
       role: documentGeneratorRole,
       timeout: cdk.Duration.minutes(15),
       memorySize: 1024,
+      retryAttempts: JOB_ASYNC_RETRY_ATTEMPTS,
       environment: {
         PROJECTS_TABLE: projectsTable.tableName,
         FEEDBACK_TABLE: feedbackTable.tableName,
@@ -830,6 +853,7 @@ export class VocApiStack extends VocStack {
       role: documentMergerRole,
       timeout: cdk.Duration.minutes(10),
       memorySize: 1024,
+      retryAttempts: JOB_ASYNC_RETRY_ATTEMPTS,
       environment: {
         PROJECTS_TABLE: projectsTable.tableName,
         FEEDBACK_TABLE: feedbackTable.tableName,
@@ -864,6 +888,7 @@ export class VocApiStack extends VocStack {
       role: personaImporterRole,
       timeout: cdk.Duration.minutes(5),
       memorySize: 512,
+      retryAttempts: JOB_ASYNC_RETRY_ATTEMPTS,
       environment: {
         PROJECTS_TABLE: projectsTable.tableName,
         AGGREGATES_TABLE: aggregatesTable.tableName,

--- a/voc-datalake/lib/stacks/api-stack.ts
+++ b/voc-datalake/lib/stacks/api-stack.ts
@@ -745,6 +745,15 @@ export class VocApiStack extends VocStack {
     // the multiplier. And it does not affect the Step Functions path for PRD/PR-FAQ:
     // an EventInvokeConfig governs async invocations only, so createDocumentStateMachine's
     // own explicit, VISIBLE retries below are untouched.
+    //
+    // Scoped to these four on purpose. The other async targets in this app keep the
+    // AWS default, because for them a re-drive is a benefit rather than a repeated
+    // bill: `voc-manual-import-processor` re-does bounded, content-keyed work that
+    // the processor's idempotency records already de-duplicate, and the scraper and
+    // integration invocations are watermark-driven, so repeating one fetches from
+    // where it left off. What sets these four apart is that ONE invocation is ONE
+    // large generation: a re-drive re-pays for it in full and cannot succeed for a
+    // reason the first attempt failed on.
     const JOB_ASYNC_RETRY_ATTEMPTS = 0;
 
     // Persona Generator Job Lambda

--- a/voc-datalake/lib/stacks/core-stack.test.ts
+++ b/voc-datalake/lib/stacks/core-stack.test.ts
@@ -8,6 +8,8 @@
  * Pre-#105 environments deploy with `-c omitUserPoolUsernameConfiguration=true`
  * to keep their pool untouched; greenfield keeps case-insensitive sign-in.
  */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, it, expect } from 'vitest';
 import * as cdk from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
@@ -1124,6 +1126,33 @@ describe('VocCoreStack product doc extractor', () => {
     // would start marking SUCCESSFUL extractions as failed.
     expect(fn.Timeout).toBe(120);
     expect(fn.MemorySize).toBeGreaterThanOrEqual(512);
+  });
+
+  it('gives its Bedrock client a budget that fits inside that timeout', () => {
+    // This handler builds its OWN Bedrock client — it is stdlib+boto3 only, so it
+    // cannot import shared/aws.py — and botocore's defaults are wrong here in the
+    // same way the shared client's old ones were: a 60 s read timeout with the
+    // default retry budget can outlast this function's 120 s ceiling, so the last
+    // attempt is always killed in flight. That is a guaranteed-doomed retry, not
+    // a diagnosis, and it is exactly the collision that cost 45 minutes on the
+    // prototype path (see lib/stacks/api-stack.test.ts for the job-Lambda half).
+    //
+    // Read from the handler source because the two numbers that collide live in
+    // different languages and different files; nothing else can see both.
+    const source = readFileSync(
+      join(__dirname, '..', '..', 'lambda', 'product_doc_extractor', 'handler.py'),
+      'utf-8',
+    );
+    const readTimeout = source.match(/^BEDROCK_READ_TIMEOUT_SECONDS\s*=\s*(\d+)/m)?.[1];
+    const maxAttempts = source.match(/^BEDROCK_MAX_ATTEMPTS\s*=\s*(\d+)/m)?.[1];
+    expect(readTimeout, 'could not read BEDROCK_READ_TIMEOUT_SECONDS from the handler').toBeDefined();
+    expect(maxAttempts, 'could not read BEDROCK_MAX_ATTEMPTS from the handler').toBeDefined();
+
+    const budget = Number(readTimeout) * Number(maxAttempts);
+    const fn = extractorFunction();
+
+    expect(budget, `the extractor waits up to ${budget}s on Bedrock but runs for ${fn.Timeout}s`)
+      .toBeLessThan(fn.Timeout);
   });
 
   it('ships without a bundled layer, so CoreStack stays container-free', () => {

--- a/voc-datalake/lib/stacks/core-stack.test.ts
+++ b/voc-datalake/lib/stacks/core-stack.test.ts
@@ -16,6 +16,10 @@ import { Match, Template } from 'aws-cdk-lib/assertions';
 import { z } from 'zod';
 import { VocCoreStack } from './core-stack';
 import { ALLOWED_MODEL_IDS, MAX_IMAGE_BYTES, MAX_IMAGE_DIMENSION_PX } from '../utils/model-allowlist';
+import {
+  BEDROCK_FAILURE_RECORDING_RESERVE_SECONDS,
+  pythonIntConstant,
+} from '../test-support/cross-language-invariants';
 // The same fixed synth environment and committed feature flags the whole-app
 // harness uses, imported rather than re-declared: a second copy of either drifts
 // silently. Importing costs nothing at module load — synth-app.ts only shells out
@@ -1139,20 +1143,17 @@ describe('VocCoreStack product doc extractor', () => {
     //
     // Read from the handler source because the two numbers that collide live in
     // different languages and different files; nothing else can see both.
-    const source = readFileSync(
-      join(__dirname, '..', '..', 'lambda', 'product_doc_extractor', 'handler.py'),
-      'utf-8',
-    );
-    const readTimeout = source.match(/^BEDROCK_READ_TIMEOUT_SECONDS\s*=\s*(\d+)/m)?.[1];
-    const maxAttempts = source.match(/^BEDROCK_MAX_ATTEMPTS\s*=\s*(\d+)/m)?.[1];
-    expect(readTimeout, 'could not read BEDROCK_READ_TIMEOUT_SECONDS from the handler').toBeDefined();
-    expect(maxAttempts, 'could not read BEDROCK_MAX_ATTEMPTS from the handler').toBeDefined();
-
-    const budget = Number(readTimeout) * Number(maxAttempts);
+    const budget =
+      pythonIntConstant('BEDROCK_READ_TIMEOUT_SECONDS', 'lambda', 'product_doc_extractor', 'handler.py') *
+      pythonIntConstant('BEDROCK_MAX_ATTEMPTS', 'lambda', 'product_doc_extractor', 'handler.py');
     const fn = extractorFunction();
 
+    // The same reserve the shared client's guard requires, for the same reason:
+    // "fits" is not enough, the invocation also has to outlive its own read timeout
+    // long enough to record the failure it hit (`_mark_failed` here). A budget that
+    // merely lands under the ceiling turns a slow description into a silent kill.
     expect(budget, `the extractor waits up to ${budget}s on Bedrock but runs for ${fn.Timeout}s`)
-      .toBeLessThan(fn.Timeout);
+      .toBeLessThan(fn.Timeout - BEDROCK_FAILURE_RECORDING_RESERVE_SECONDS);
   });
 
   it('ships without a bundled layer, so CoreStack stays container-free', () => {

--- a/voc-datalake/lib/test-support/baseline.json
+++ b/voc-datalake/lib/test-support/baseline.json
@@ -2,7 +2,7 @@
   "description": "Fingerprint of the no-prefix synth. Regenerate with npx ts-node scripts/generate-baseline.ts ONLY for a change intended to alter the default templates — see the script header.",
   "stacks": {
     "VocApiStack": {
-      "templateSha256": "61f06dc8ae37e9ae15ea8794db803f2357d1b08dc49c91224e9d01f85b49494a",
+      "templateSha256": "1beac3e41a2ba0dcb4cbd68a5138efc83a787aebc3235e7d744b074ec0a9f1cc",
       "names": {
         "physicalNames": [
           "AWS::ApiGateway::Authorizer Name = voc-cognito-authorizer",

--- a/voc-datalake/lib/test-support/cross-language-invariants.ts
+++ b/voc-datalake/lib/test-support/cross-language-invariants.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Read a named integer constant out of a Python source file in this repo.
+ *
+ * Several invariants in this app span a Python constant and a synthesized
+ * CloudFormation value — a Bedrock read timeout against the Lambda timeout it has
+ * to fit inside, a delegation timeout against the adapter's own — and no single
+ * file can keep those honest. The CDK suites therefore read the Python side, and
+ * this is that read, in one place: the regex is subtle enough (anchored, optional
+ * `Final` annotation, digits only) that three hand-rolled copies would drift.
+ *
+ * THROWS rather than returning undefined when the constant is absent. A rename or
+ * an inlined literal must fail loudly: a regex that quietly stops matching turns
+ * every assertion built on it into a vacuous pass, which is worse than no guard at
+ * all because it still reads like one.
+ */
+export function pythonIntConstant(name: string, ...pathSegments: string[]): number {
+  const path = join(__dirname, '..', '..', ...pathSegments);
+  const source = readFileSync(path, 'utf-8');
+  // Matches `NAME = 840`, `NAME: Final = 840` and `NAME: Final[int] = 840`, at the
+  // start of a line so a mention inside a comment or an f-string cannot match.
+  const pattern = new RegExp(`^${name}(?::\\s*Final(?:\\[int\\])?)?\\s*=\\s*(\\d+)`, 'm');
+  const matched = source.match(pattern)?.[1];
+  if (matched === undefined) {
+    throw new Error(
+      `could not read ${name} from ${pathSegments.join('/')} — it was renamed, ` +
+        'inlined, or is no longer an integer literal. Any assertion comparing it to a ' +
+        'synthesized value is now vacuous; fix the name here rather than deleting it.',
+    );
+  }
+  return Number(matched);
+}
+
+/**
+ * How much of an invocation must remain after a Bedrock read timeout fires.
+ *
+ * A budget that merely lands under the caller's ceiling is not enough: the point
+ * of the read timeout firing first is that the handler gets to RECORD what
+ * happened — `shared/jobs.py` writing the job `failed`, or the extractor marking
+ * its record failed — instead of being killed mid-flight and leaving a row stuck
+ * on `running`. Without a reserve, a read timeout one second under the ceiling
+ * passes an assertion while delivering none of the benefit.
+ *
+ * Generous on purpose: the work to be done is a single DynamoDB write, so the
+ * number is not calibrated to it. It exists so the headroom is a DECISION rather
+ * than whatever rounding happened to leave behind, and so raising a read timeout
+ * towards its ceiling fails loudly.
+ *
+ * Shared by the api-stack and core-stack suites because both assert the same
+ * property against different functions, and two copies would drift apart in
+ * exactly the direction that weakens them.
+ */
+export const BEDROCK_FAILURE_RECORDING_RESERVE_SECONDS = 30;


### PR DESCRIPTION
A generation needing more than five minutes could not succeed on any Bedrock surface, and a failed prototype build cost roughly 45 minutes. Two independent retry layers were multiplying on top of one 15-minute function, and neither was visible in the logs.

Measured on a live deployment: one `build_prototype` job watched from start to kill, with the immediately preceding successful build of the same project as the control.

## The client budget

`shared/aws.py::get_bedrock_client` built the **one cached** Bedrock client with `read_timeout=300` and `max_attempts=3`. **3 × 300 = 900**, exactly the timeout of the job Lambdas that build prototypes, documents, personas and research. So the first read timed out at 5 minutes, botocore retried twice more on its own, and Lambda killed the function part-way through the third with nothing returned. Each abandoned attempt re-submitted the prompt and re-paid for a full generation.

| | |
|---|---|
| Application retry counter, entire lifetime | `Attempt 1/5` — never advanced |
| Invocation outcome | `Duration: 900000.00 ms` |
| Control: same step, same project, minutes earlier | **154,884 ms**, `stop_reason=end_turn` |

Those retries happen **below** `shared/converse.py`'s own loop, which is why the log read "Attempt 1/5" for the whole 900 s: the run looked like one slow call rather than three abandoned generations. The control proves it is size-dependent, not an outage.

`converse` is non-streaming, so the socket is legitimately idle until the generation completes — a read timeout measures "big", not "broken", and the larger the requested output the more certain it fires. `max_tokens=32000` on the prototype surface therefore invited output that a 300 s read timeout forbade: the configuration contradicted itself.

**Now `BEDROCK_READ_TIMEOUT_SECONDS = 840` with `BEDROCK_MAX_ATTEMPTS = 1`.** `mode: 'standard'` is stated explicitly because that mode counts *total* attempts, where legacy mode's reading of the same key is ambiguous — `shared/mcp_delegate.py` already uses that pair.

**`ReadTimeoutError` is now non-retryable in `_converse_with_retry`.** This is load-bearing rather than tidiness: the loop's `except Exception` would otherwise inherit botocore's job and make it 5 × 840 instead of 3 × 300 — the same defect one layer up with a bigger multiplier. `ConnectTimeoutError` is a sibling class, not a subclass, and stays retryable: it costs 10 s and no generation.

## The async re-drive, which is where the 45 minutes came from

The four job Lambdas are invoked with `InvocationType='Event'`, where AWS re-runs a failed invocation **twice more by default** — invisibly, because each re-run wrote progress to the same job row and looked like the first attempt making none. The log shows a second `START` with the same request id after the first died.

They now carry `retryAttempts: 0`. An LLM generation is neither cheap nor idempotent, and `shared/jobs.py` already records the job `failed` for the UI to render, so a hidden retry buys nothing. Step Functions is unaffected: an `EventInvokeConfig` governs async invocations only, so the PRD/PR-FAQ path's explicit, visible `llmRetry` still applies.

## The same defect in a second place

`product_doc_extractor` builds its own Bedrock client and had the same collision at a smaller scale: botocore's default 60 s read timeout with default retries against a 120 s function, so its last attempt was always killed in flight. Now 80 s × 1, which also lets a slow image description finish where it previously gave up. That handler is stdlib+boto3 only and cannot import `shared/`, so its constants are duplicated by design, like `_is_conditional_check_failure`.

Found by grepping every `bedrock-runtime` client rather than only the reported one. `shared/avatar.py`'s image client was checked and left alone: 120 × 3 = 360 s fits inside its caller, and throttling is its expected failure, so its retries are wanted.

## Tests

The collision spans a Python constant and a CDK timeout, and neither file can see both — so it is pinned from both sides.

- **`lambda/shared/test/test_aws.py`** — what actually reaches botocore, the explicit standard mode, one attempt, and the budget against the 900 s Lambda maximum with a reserve for recording the failure. Nothing covered `get_bedrock_client` before (that file's docstring records dropping client-factory tests), which is how values that read as reasonable line by line survived.
- **`lambda/shared/test/test_converse.py`** — the read timeout raising after exactly one attempt with no backoff, plus a connect-timeout control so the branch is narrow rather than "nothing retries".
- **`lib/stacks/api-stack.test.ts`** — reads the Python constants and compares them to the synthesized job-Lambda timeouts, and asserts the `EventInvokeConfig` **exists** with `MaximumRetryAttempts: 0`, since a missing one is indistinguishable from the default at a glance. Same shape as the delegation-timeout suite above it.
- **`lib/stacks/core-stack.test.ts`** — the same for the extractor.
- **`lambda/product_doc_extractor/test/test_handler.py`** — that the client actually *uses* those constants. The rest of that suite injects fakes into `_clients`, so `_bedrock()` never ran and a dropped `config=` would have left the CDK guard passing while the deployed client went back to botocore's defaults.

Four mutations were run to confirm each case fails for its stated reason: restoring 300 × 3, raising the read timeout to 900, dropping one `retryAttempts`, and disabling the read-timeout branch.

## Baseline

`lib/test-support/baseline.json` is regenerated because `retryAttempts` adds four `AWS::Lambda::EventInvokeConfig` resources. The template was dumped before and after and diffed: the delta is exactly those four plus Lambda asset hashes, with the readable name inventory byte-identical — no table, bucket or user pool is renamed. (`canonicalTemplate` normalises asset hashes, which is why only VocApiStack's digest moves.)

## Two things this deliberately does NOT claim

1. **The budget is not below every caller's timeout, and cannot be.** One cached client serves 30 s API handlers and 15-minute jobs alike; a per-caller budget needs a keyed client cache plus the caller's remaining time plumbed through `converse()`, which nothing passes today. What is asserted instead is the property that makes one shared budget safe for the short callers: **one attempt**, so nobody is handed a multiple of the read timeout. A caller shorter than 840 s still dies at its own ceiling — that residue is the separately documented job-timeout defect, whose fix covers OOM and every other kill too, so a read-timeout-shaped version would only be a partial one.
2. **No live prototype build over 300 s has been run.** Unit and synth level only. The arithmetic now permits it (the control emitted 15,833 output tokens in 155 s, so 32000 tokens sits far inside 840 s) but permitted is not observed.

Also unchanged: routing an exhausted async invocation somewhere durable (a failure destination / DLQ) is #253. `retryAttempts: 0` stops the multiplier; it does not add a destination.

## Verification

Run on this base (`f7e07593`):

| Leg | Result |
|---|---|
| `test:backend` | **4,339 passed** |
| `test:cdk` | **339 / 340** — the one failure is pre-existing and unrelated: `api-stack.test.ts`'s repo-markdown scan walks a local untracked `.tmp/*.md` scratch file. Moving that file aside gives 81/81 in the file |
| `typecheck:cdk` (`tsc --noEmit`) | clean |
| `lint:python` (ruff) | no new findings — the touched files report the same 18 pre-existing ones before and after |

No frontend or stream code is touched.
